### PR TITLE
change copyright to SIL International

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 AlphaTiles
+Copyright (c) 2020 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This was supposed to be copyright SIL International all along.  Looks like an oversight that should be fixed.