### PR TITLE
Add an optional setting to delay the disappearance of memory cards

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -18,6 +18,7 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Scanner;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import static android.graphics.Color.BLACK;
@@ -37,6 +38,8 @@ public class Mexico extends GameActivity {
         // # 4 [state: "SELECTED" or "UNSELECTED" or "PAIRED"]
         // # 5 duration in ms
         // # 6 font adjustment for longer words
+
+    String delaySetting = Start.settingsList.find("View memory cards for _ milliseconds");
 
     ArrayList<String[]> wordListArray; // KP
 
@@ -423,6 +426,14 @@ public class Mexico extends GameActivity {
 
         } else {
             // The two cards do NOT match
+            if(delaySetting.compareTo("") != 0) {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(Long.valueOf(delaySetting));
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
             TextView cardA = findViewById(TILE_BUTTONS[cardHitA]); // RR
             TextView cardB = findViewById(TILE_BUTTONS[cardHitB]); // RR
             cardA.setText("");


### PR DESCRIPTION
A user has requested the ability to see memory cards for a little longer, to help beginning readers. This PR adds the option to specify a delay to the memory game so that incorrectly selected cards are visible a little bit longer. The setting ("View memory cards for _ millesonds") should be given by a whole number of milliseconds in the aa_settings.txt file of a language pack. 