### PR TITLE
Adds app version info and number to loading screen

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
@@ -13,6 +13,7 @@ import android.media.SoundPool;
 import android.os.Bundle;
 import android.os.Handler;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import static org.alphatilesapps.alphatiles.Start.hasSyllableAudio;
 import static org.alphatilesapps.alphatiles.Start.wordAudioIDs;
@@ -30,6 +31,8 @@ import static org.alphatilesapps.alphatiles.Start.correctSoundID;
 import static org.alphatilesapps.alphatiles.Start.incorrectSoundID;
 import static org.alphatilesapps.alphatiles.Start.correctFinalSoundID;
 import static org.alphatilesapps.alphatiles.Start.correctSoundDuration;
+
+import org.w3c.dom.Text;
 
 import java.util.HashMap;
 import java.util.Timer;
@@ -55,6 +58,11 @@ public class LoadingScreen extends AppCompatActivity {
 
         progressBar = findViewById(R.id.progressBar);
         context = this;
+
+        String verName = BuildConfig.VERSION_NAME;
+        TextView versionNumberView = (TextView) findViewById(R.id.versionNumber);
+        versionNumberView.setText(getString(R.string.ver_info, verName));
+
 
         int num_of_words = wordList.size();
 

--- a/app/src/main/res/layout/activity_loading_screen.xml
+++ b/app/src/main/res/layout/activity_loading_screen.xml
@@ -71,4 +71,18 @@
         app:layout_constraintTop_toTopOf="@+id/guideline2"
         app:srcCompat="@drawable/zz_splash" />
 
+    <TextView
+        android:id="@+id/versionNumber"
+        android:text="@string/alphaTilesVersionInfo"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center_horizontal|center_vertical"
+        android:textAlignment="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guideline4"
+        tools:layout_editor_absoluteX="173dp"
+        tools:layout_editor_absoluteY="797dp" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56163492/200265624-e2d5996f-81a8-4474-af64-9b0e8be718aa.png)

This PR allows users to see which version of Alpha Tiles they have installed with just a glance when the app starts up.