### PR TITLE
In-app pixel width testing & audio duration calculation

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
@@ -13,6 +13,7 @@ import android.media.SoundPool;
 import android.os.Bundle;
 import android.os.Handler;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import static org.alphatilesapps.alphatiles.Start.hasSyllableAudio;
 import static org.alphatilesapps.alphatiles.Start.wordAudioIDs;
@@ -45,6 +46,7 @@ public class LoadingScreen extends AppCompatActivity {
     private Handler mHandler = new Handler();
     Context context;
     ProgressBar progressBar;
+    int maxWordWidthInPixels = 39;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -230,6 +232,23 @@ public class LoadingScreen extends AppCompatActivity {
         mmr.setDataSource(afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
         return Integer.parseInt(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
     }
+
+    private float getPixelWidthAdjustment(String word){
+        TextView wordView = new TextView(this);
+        wordView.setText(word);
+        wordView.setTextSize(11);
+        wordView.measure(0,0);import static org.alphatilesapps.alphatiles.Start.wordList;
+        int wordWidthInPixels = wordView.getMeasuredWidth();
+        if (wordWidthInPixels <= maxWordWidthInPixels){
+            return 1;
+        }
+        else{
+            return Math.round((maxWordWidthInPixels *100.0) /(wordWidthInPixels*100.0));
+        }
+
+    }
+
+
 }
 
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -7,8 +7,6 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.DisplayMetrics;
-import android.util.TypedValue;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -17,14 +15,13 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Scanner;
 import java.util.logging.Logger;
 
-import static android.graphics.Color.BLACK;
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
+import org.alphatilesapps.alphatiles.Start.WordList;
 
-import android.content.Intent;
+import static android.graphics.Color.BLACK;
+
+import androidx.constraintlayout.widget.ConstraintSet;
 
 import static org.alphatilesapps.alphatiles.Start.*;
 
@@ -38,7 +35,7 @@ public class Mexico extends GameActivity {
         // # 5 duration in ms
         // # 6 font adjustment for longer words
 
-    ArrayList<String[]> wordListArray; // KP
+    WordList wordListExcludingTheLongestWords; // KP
 
     int justClickedCard;
     int priorClickedCard;
@@ -128,7 +125,7 @@ public class Mexico extends GameActivity {
         challengeLevel = getIntent().getIntExtra("challengeLevel", -1); // KP
         syllableGame = getIntent().getStringExtra("syllableGame");
 
-        wordListArray = new ArrayList(); // KP
+        wordListExcludingTheLongestWords = new WordList(); // KP
 
         String gameUniqueID = country.toLowerCase().substring(0,2) + challengeLevel + syllableGame;
 
@@ -203,7 +200,7 @@ public class Mexico extends GameActivity {
 
         setCardTextToEmpty();
         buildWordsArray();
-        Collections.shuffle(wordListArray); // KP
+        Collections.shuffle(wordListExcludingTheLongestWords); // KP
         chooseMemoryWords();
         Collections.shuffle(memoryCollection); // KP
         pairsCompleted = 0;
@@ -240,18 +237,11 @@ public class Mexico extends GameActivity {
         // KP, Oct 2020
         // AH, Nov 2020, revised to allow for spaces in words
 
-        Scanner scanner = new Scanner(getResources().openRawResource(R.raw.aa_wordlist));
-        if (scanner.hasNextLine()) {
-            scanner.nextLine();
-        }     // skip the header row
-
-        while (scanner.hasNextLine()) {
-            String thisLine = scanner.nextLine();
-            String[] thisLineArray = thisLine.split("\t");
-            double activeAdjustment = Double.parseDouble(thisLineArray[4]);
-            if (activeAdjustment >= lowestAdjustment) {
+        for(int i = 0; i<wordList.size(); i++) {
+            double adjustment = Double.valueOf(wordList.get(i).adjustment);
+            if (adjustment >= lowestAdjustment) {
 //                LOGGER.info("Remember: thisLineArray[4] = " + thisLineArray[4]);
-                wordListArray.add(thisLineArray);
+                wordListExcludingTheLongestWords.add(wordList.get(i));
             }
         }
     }
@@ -267,12 +257,12 @@ public class Mexico extends GameActivity {
             int index = i < cardsToSetUp ? i : i - cardsToSetUp;
             String[] content = new String[]
                     {
-                            wordListArray.get(index)[0],
-                            wordListArray.get(index)[1],
+                            wordListExcludingTheLongestWords.get(index).nationalWord,
+                            wordListExcludingTheLongestWords.get(index).localWord,
                             i < cardsToSetUp ? "TEXT" : "IMAGE",
                             "UNSELECTED",
-                            wordListArray.get(index)[2],    // audio clip duration in seconds
-                            wordListArray.get(index)[4],    // font adjustment
+                            String.valueOf(wordListExcludingTheLongestWords.get(index).duration),    // audio clip duration in seconds
+                            wordListExcludingTheLongestWords.get(index).adjustment,    // font adjustment
 
 
                     };

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -2,9 +2,11 @@ package org.alphatilesapps.alphatiles;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.AssetFileDescriptor;
 import android.graphics.drawable.Drawable;
 import android.media.AudioAttributes;
 import android.media.AudioManager;
+import android.media.MediaMetadataRetriever;
 import android.media.SoundPool;
 import android.os.Build;
 import android.os.Bundle;
@@ -217,7 +219,7 @@ public class Start extends AppCompatActivity
 
         buildWordsArray();
         totalAudio = totalAudio + wordList.size();
-        populateWordDurations(); /* JP separated from the loop where we populate wordAudioIDs for
+        /*populateWordDurations(); /* JP separated from the loop where we populate wordAudioIDs for
         the purpose of making sure durations hashmap will be done even if loading the audio isn't;
         makes null checking simpler
         */
@@ -280,12 +282,14 @@ public class Start extends AppCompatActivity
 
 
 
-    public void populateWordDurations(){
-        wordDurations = new HashMap();
-        for (Word word: wordList)
-        {
-            wordDurations.put(word.nationalWord, word.duration + 100);
-        }
+
+
+    private int getAssetDuration(int assetID)
+    {
+        MediaMetadataRetriever mmr = new MediaMetadataRetriever();
+        AssetFileDescriptor afd = context.getResources().openRawResourceFd(assetID);
+        mmr.setDataSource(afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
+        return Integer.parseInt(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
     }
 
     public void buildTilesArray() {
@@ -313,12 +317,12 @@ public class Start extends AppCompatActivity
                 tileList.audioForTileBTitle = thisLineArray[8];
                 tileList.tileTypeCTitle = thisLineArray[9];
                 tileList.audioForTileCTitle = thisLineArray[10];
-                tileList.tileDuration1 = thisLineArray[11];
-                tileList.tileDuration2 = thisLineArray[12];
-                tileList.tileDuration3 = thisLineArray[13];
+                tileList.tileDuration1 = "";
+                tileList.tileDuration2 = "";
+                tileList.tileDuration3 = "";
                 header = false;
             } else {
-                Tile tile = new Tile(thisLineArray[0], thisLineArray[1], thisLineArray[2], thisLineArray[3], thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], Integer.parseInt(thisLineArray[11]), Integer.parseInt(thisLineArray[12]), Integer.parseInt(thisLineArray[13]));
+                Tile tile = new Tile(thisLineArray[0], thisLineArray[1], thisLineArray[2], thisLineArray[3], thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0);
                 if (!tile.hasNull()) {
                     tileList.add(tile);
                     if (!tile.tileType.equals("SAD")){
@@ -406,10 +410,10 @@ public class Start extends AppCompatActivity
                 wordList.localTitle = thisLineArray[1];
                 wordList.durationTitle = thisLineArray[2];
                 wordList.mixedDefsTitle = thisLineArray[3];
-                wordList.adjustment = thisLineArray[4];
+                wordList.adjustment = ""; //set during LoadingScreen activity
                 header = false;
             } else {
-                Word word = new Word(thisLineArray[0], thisLineArray[1], Integer.parseInt(thisLineArray[2]), thisLineArray[3], thisLineArray[4]);
+                Word word = new Word(thisLineArray[0], thisLineArray[1], Integer.parseInt(thisLineArray[2]), thisLineArray[3], "");
                 if (!word.hasNull()) {
                     wordList.add(word);
                 }
@@ -672,7 +676,7 @@ public class Start extends AppCompatActivity
         }
     }
 
-    public class WordList extends ArrayList<Word> {
+    public static class WordList extends ArrayList<Word> {
         public String nationalTitle;	// e.g. languages like English or Spanish (LWCs = Languages of Wider Communication)
         public String localTitle;	// e.g. LOPS (language of play) like Me'phaa, Kayan or Romani Gabor
         public String durationTitle;	// the length of the clip in ms, relevant only if set to use SoundPool


### PR DESCRIPTION
Thus far, developers have separately run scripts on a draft language pack to gather information about the widths of words and the durations of audio as a step in building each new Alpha Tiles app. This branch adds methods to the Start and LoadingScreen activities, as well as the Mexico activity (involving pixel width values) that mean that no pixel width testing or audio duration calcuation will need to be done before putting an app together.