### PR TITLE
Keep other cards unclickable while evaluating two selected memory cards

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -287,18 +287,9 @@ public class Mexico extends GameActivity {
 
     public void respondToCardSelection() {
 
-        setAllTilesUnclickable();
-        setOptionsRowUnclickable();
-
         int t = justClickedCard - 1; //  justClickedCard uses 1 to 12/16/20 (dep. on challengeLevel), t uses the array ID: between [0] and [11] / [15] / [19]
 
         if (memoryCollection.get(t)[3].equals("PAIRED")) {
-            setAllTilesUnclickable();
-            setOptionsRowClickable();
-            return;
-        }
-
-        if (activeSelections == 2) {
             setAllTilesClickable();
             setOptionsRowClickable();
             return;
@@ -335,22 +326,22 @@ public class Mexico extends GameActivity {
 //        card.getBackground().setAlpha(255);
 
         if (activeSelections == 2) {
+            setOptionsRowUnclickable();
+            setAllTilesUnclickable();
 
             handler = new Handler();
-            handler.postDelayed(quickViewDelay, 800);
+            handler.postDelayed(quickViewDelay, Long.valueOf(800));
             // Will run respondToTwoActiveCards() after delay...
             // https://www.youtube.com/watch?v=3pgGVBmSVq0
             // https://codinginflow.com/tutorials/android/handler-postdelayed-runnable
         }
-
-        setAllTilesClickable();
-        setOptionsRowClickable();
 
     }
 
     
 
     public void respondToTwoActiveCards() {
+
 
         // Two cards have been selected (which may or may not match)
         activeSelections = 0;       // (a reset)
@@ -426,31 +417,10 @@ public class Mexico extends GameActivity {
 
         } else {
             // The two cards do NOT match
-            if(delaySetting.compareTo("") != 0) {
-                try {
-                    TimeUnit.MILLISECONDS.sleep(Long.valueOf(delaySetting));
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                }
-            }
+            handler = new Handler();
+            handler.postDelayed(flipCardsBackOver, Long.valueOf(delaySetting));
 
-            TextView cardA = findViewById(TILE_BUTTONS[cardHitA]); // RR
-            TextView cardB = findViewById(TILE_BUTTONS[cardHitB]); // RR
-            cardA.setText("");
-            cardB.setText("");
-            cardA.setBackgroundResource(R.drawable.zz_alphatileslogo2);
-            cardB.setBackgroundResource(R.drawable.zz_alphatileslogo2);
-            memoryCollection.get(cardHitA)[3] = "UNSELECTED"; // KP
-            memoryCollection.get(cardHitB)[3] = "UNSELECTED"; // KP
         }
-
-    }
-
-    public void onBtnClick(View view) {
-
-        priorClickedCard = justClickedCard;
-        justClickedCard = Integer.parseInt((String)view.getTag());
-        respondToCardSelection();
 
     }
 
@@ -460,6 +430,34 @@ public class Mexico extends GameActivity {
             respondToTwoActiveCards();
         }
     };
+
+    private Runnable flipCardsBackOver = new Runnable() {
+        @Override
+        public void run() {
+            resetAfterIncorrectGuess();
+        }
+    };
+
+    public void resetAfterIncorrectGuess(){
+        TextView cardA = findViewById(TILE_BUTTONS[cardHitA]); // RR
+        TextView cardB = findViewById(TILE_BUTTONS[cardHitB]); // RR
+        cardA.setText("");
+        cardB.setText("");
+        cardA.setBackgroundResource(R.drawable.zz_alphatileslogo2);
+        cardB.setBackgroundResource(R.drawable.zz_alphatileslogo2);
+        memoryCollection.get(cardHitA)[3] = "UNSELECTED"; // KP
+        memoryCollection.get(cardHitB)[3] = "UNSELECTED"; // KP
+        setAllTilesClickable();
+        setOptionsRowClickable();
+    }
+
+    public void onBtnClick(View view) {
+
+        priorClickedCard = justClickedCard;
+        justClickedCard = Integer.parseInt((String)view.getTag());
+        respondToCardSelection();
+
+    }
 
     public void clickPicHearAudio(View view)
     {


### PR DESCRIPTION
This pull request fixes the timing of setting cards clickable and unclickable while viewing two selected cards. After selecting two mismatching cards, there may be a delay (given in aa_settings.txt), and during this delay, the rest of the cards will remain unclickable and turned over even after the selected cards are turned back over.