### PR TITLE
Adding default delay setting to memory game

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -39,8 +39,6 @@ public class Mexico extends GameActivity {
         // # 5 duration in ms
         // # 6 font adjustment for longer words
 
-    String delaySetting = Start.settingsList.find("View memory cards for _ milliseconds");
-
     ArrayList<String[]> wordListArray; // KP
 
     int justClickedCard;
@@ -417,8 +415,13 @@ public class Mexico extends GameActivity {
 
         } else {
             // The two cards do NOT match
+            long delay = 0;
+            String delaySetting = Start.settingsList.find("View memory cards for _ milliseconds");
+            if(delaySetting.compareTo("")!=0) {
+                delay = Long.valueOf(delaySetting);
+            }
             handler = new Handler();
-            handler.postDelayed(flipCardsBackOver, Long.valueOf(delaySetting));
+            handler.postDelayed(flipCardsBackOver, delay);
 
         }
 


### PR DESCRIPTION
This adds a default delay setting of 0 milliseconds to the memory game, so that if a language pack doesn't have a delay setting in aa_settings.txt, the app will build like before, with no delay.