### PR TITLE
Word search SW-NE direction fix

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -39,8 +39,6 @@ public class Mexico extends GameActivity {
         // # 5 duration in ms
         // # 6 font adjustment for longer words
 
-    String delaySetting = Start.settingsList.find("View memory cards for _ milliseconds");
-
     ArrayList<String[]> wordListArray; // KP
 
     int justClickedCard;
@@ -417,8 +415,13 @@ public class Mexico extends GameActivity {
 
         } else {
             // The two cards do NOT match
+            long delay = 0;
+            String delaySetting = Start.settingsList.find("View memory cards for _ milliseconds");
+            if(delaySetting.compareTo("")!=0) {
+                delay = Long.valueOf(delaySetting);
+            }
             handler = new Handler();
-            handler.postDelayed(flipCardsBackOver, Long.valueOf(delaySetting));
+            handler.postDelayed(flipCardsBackOver, delay);
 
         }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -630,8 +630,14 @@ public class Myanmar extends GameActivity {
 
             for (int t = 0; t < selectionLength; t++) {
 
-                tileX = (lowerClick % 7) + (t * incrementF[0]);
-                tileY = (lowerClick / 7) + (t * incrementF[1]);
+                if(selectionDirection == 19){ // Direction 19 is special, because the forward direction starts from the higher index
+                    tileX = (higherClick % 7) + (t * incrementF[0]);
+                    tileY = (higherClick / 7) + (t * incrementF[1]);
+                }
+                else {
+                    tileX = (lowerClick % 7) + (t * incrementF[0]);
+                    tileY = (lowerClick / 7) + (t * incrementF[1]);
+                }
 
                 LOGGER.info("Remember: builtWord1 tile(X, Y) = (" + tileX + ", " + tileY + ") = " + tilesBoard[tileX][tileY]);
 
@@ -650,7 +656,7 @@ public class Myanmar extends GameActivity {
                 incrementB[0] = 0;
                 incrementB[1] = -1;
             }
-            if (selectionDirection == 19) {
+            if (selectionDirection == 19) { // this is the 1 word direction
                 incrementB[0] = -1;
                 incrementB[1] = 1;
             }
@@ -663,8 +669,15 @@ public class Myanmar extends GameActivity {
 
             for (int t = 0; t < selectionLength; t++) {
 
-                tileX = (higherClick % 7) + (t * incrementB[0]);
-                tileY = (higherClick / 7) + (t * incrementB[1]);
+                if (selectionDirection == 19){ // Direction 19 is special, because the backward direction starts from the lower index
+                    tileX = (lowerClick % 7) + (t * incrementB[0]);
+                    tileY = (lowerClick / 7) + (t * incrementB[1]);
+                }
+                else {
+                    tileX = (higherClick % 7) + (t * incrementB[0]);
+                    tileY = (higherClick / 7) + (t * incrementB[1]);
+                }
+
 
                 LOGGER.info("Remember: builtWord2 tile(X, Y) = (" + tileX + ", " + tileY + ") = " + tilesBoard[tileX][tileY]);
 
@@ -702,8 +715,14 @@ public class Myanmar extends GameActivity {
 
             for (int t = 0; t < selectionLength; t++) {
 
-                tileX = (lowerClick % 7) + (t * incrementF[0]);
-                tileY = (lowerClick / 7) + (t * incrementF[1]);
+                if (selectionDirection == 19){
+                    tileX = (higherClick % 7) + (t * incrementF[0]);
+                    tileY = (higherClick / 7) + (t * incrementF[1]);
+                }
+                else{
+                    tileX = (lowerClick % 7) + (t * incrementF[0]);
+                    tileY = (lowerClick / 7) + (t * incrementF[1]);
+                }
 
                 LOGGER.info("Remember: builtWord1 tile(X, Y) = (" + tileX + ", " + tileY + ")");
 
@@ -760,7 +779,7 @@ public class Myanmar extends GameActivity {
 
             playCorrectSoundThenActiveWordClip(wordsCompleted == completionGoal);
 
-        } else {
+        } else { // word not found
 
             TextView tileA = findViewById(TILE_BUTTONS[firstClickIndex]);
             tileA.setBackgroundColor(Color.parseColor("#FFFFFF")); // white


### PR DESCRIPTION
The SW-NE direction is special, because going in the forward direction, you start from the higher-numbered index, and going in the reverse direction, you start from the lower-numbered index. This is opposite from the other three kinds of directions (N-S, E-W, and NW-SE). This PR adds a bit of code to account for this and fixes crashes that were happening in challenge levels 2 and 3 of the Word Search (Myanmar) game.

I based this branch off of the default memory game setting branch, so you will see that code as well (open in PR #63 )