### PR TITLE
RTL United States game

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -228,15 +228,8 @@ public class UnitedStates extends GameActivity {
 
         for (int b = 0; b < visibleTiles; b += 2) {
 
-            int bLRRL;
-            if (scriptDirection.compareTo("RTL") == 0) {
-                bLRRL = visibleTiles - 2 - b;
-            } else {
-                bLRRL = b;
-            }
-
-            Button tileButtonA = (Button) findViewById(TILE_BUTTONS[bLRRL]);
-            Button tileButtonB = (Button) findViewById(TILE_BUTTONS[bLRRL + 1]);
+            Button tileButtonA = (Button) findViewById(TILE_BUTTONS[b]);
+            Button tileButtonB = (Button) findViewById(TILE_BUTTONS[b + 1]);
 
             String tileColorStr = COLORS.get((b % 5) / 2);
             int tileColor = Color.parseColor(tileColorStr);
@@ -316,24 +309,9 @@ public class UnitedStates extends GameActivity {
 
         StringBuilder displayedWord = new StringBuilder(); // KP
 
-        // KP
-        if (scriptDirection.compareTo("RTL") == 0) {
-            for (int j = selections.length - 1; j >= 0; j--) {
-
-                if (!selections[j].equals("")) {
-
-                    displayedWord.append(selections[j]);
-
-                }
-            }
-        } else {
-            for (int j = 0; j < selections.length; j++) {
-
-                if (!selections[j].equals("")) {
-
-                    displayedWord.append(selections[j]);
-
-                }
+        for (int j = 0; j < selections.length; j++) {
+            if (!selections[j].equals("")) {
+                displayedWord.append(selections[j]);
             }
         }
 


### PR DESCRIPTION
I took out some code from United States.java that was causing a bug in the RTL product flavors.

The emulator on the main branch before the change:
As you can see, the tiles are left to right, should be right to left. 

![Screenshot (57)](https://user-images.githubusercontent.com/56163492/220563571-af930a6e-cf4b-460f-9394-29a578af11af.png)

Fixed here:
![Screenshot (61)](https://user-images.githubusercontent.com/56163492/220564640-ab601243-d301-4f55-92a9-e1dd9d14f13a.png)

![Screenshot (59)](https://user-images.githubusercontent.com/56163492/220564720-4369fe35-e763-43cf-86d8-7daaa4bd0491.png)

