### PR TITLE
Refactor s1.compareTo(s2) == 0 to s1.equals(s2), etc

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/About.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/About.java
@@ -71,13 +71,13 @@ public class About extends AppCompatActivity {
         TextView verInfo = findViewById(R.id.appVersionInEnglish);
         verInfo.setText(getString(R.string.ver_info, verName));
 
-        if (scriptDirection.compareTo("RTL") == 0) {
+        if (scriptDirection.equals("RTL")) {
             forceRTLIfSupported();
         } else {
             forceLTRIfSupported();
         }
 
-        if (hideSILlogoSetting.compareTo("") != 0) {
+        if (!hideSILlogoSetting.equals("")) {
             hideSILlogo = Boolean.parseBoolean(hideSILlogoSetting);
 
             if (hideSILlogo) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -113,7 +113,7 @@ public class Brazil extends GameActivity {
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
 
-        if (scriptDirection.compareTo("RTL") == 0) { // LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -296,9 +296,9 @@ public class Brazil extends GameActivity {
             wordInLOP = Start.wordList.get(randomNum).localWord; // KP
 
             // If this word isn't one of the 3 previously tested words, we're good // LM
-            if (wordInLWC.compareTo(lastWord) != 0
-                    && wordInLWC.compareTo(secondToLastWord) != 0
-                    && wordInLWC.compareTo(thirdToLastWord) != 0) {
+            if (!wordInLWC.equals(lastWord)
+                    && !wordInLWC.equals(secondToLastWord)
+                    && !wordInLWC.equals(thirdToLastWord)) {
                 freshWord = true;
                 thirdToLastWord = secondToLastWord;
                 secondToLastWord = lastWord;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/China.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/China.java
@@ -97,7 +97,7 @@ public class China extends GameActivity {
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
         setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
             ImageView playNextWordImage = (ImageView) findViewById(R.id.playNextWord);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
@@ -83,7 +83,7 @@ public class ChoosePlayer extends AppCompatActivity {
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
-        if (scriptDirection.compareTo("RTL") == 0) { // LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView avatar01Image = (ImageView) findViewById(R.id.avatar01);
             ImageView avatar02Image = (ImageView) findViewById(R.id.avatar02);
             ImageView avatar03Image = (ImageView) findViewById(R.id.avatar03);
@@ -145,12 +145,12 @@ public class ChoosePlayer extends AppCompatActivity {
 
             TextView name = findViewById(AVATAR_NAMES[n]);
             name.setText(playerName);
-            if (singleColorHex.compareTo("") != 0) {
+            if (!singleColorHex.equals("")) {
                 name.setBackgroundColor(Color.parseColor(singleColorHex));
             }
         }
 
-        if (scriptDirection.compareTo("RTL") == 0) {
+        if (scriptDirection.equals("RTL")) {
             forceRTLIfSupported();
         } else {
             forceLTRIfSupported();
@@ -179,7 +179,7 @@ public class ChoosePlayer extends AppCompatActivity {
 
         String daysUntilExpirationSetting = settingsList.find("Days until expiration");
 
-        if (daysUntilExpirationSetting.compareTo("") != 0) {
+        if (!daysUntilExpirationSetting.equals("")) {
             int daysUntilExpiration = Integer.valueOf(daysUntilExpirationSetting);
             String installDate = prefs.getString("InstallDate", null);
             if (installDate == null) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -111,7 +111,7 @@ public class Colombia extends GameActivity {
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
-        if (scriptDirection.compareTo("RTL") == 0) { // LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
             ImageView deleteImage = (ImageView) findViewById(R.id.deleteImage);
@@ -202,9 +202,9 @@ public class Colombia extends GameActivity {
             wordInLOP = Start.wordList.get(randomNum).localWord; // KP
 
             // If this word isn't one of the 3 previously tested words, we're good // LM
-            if (wordInLWC.compareTo(lastWord) != 0
-                    && wordInLWC.compareTo(secondToLastWord) != 0
-                    && wordInLWC.compareTo(thirdToLastWord) != 0) {
+            if (!wordInLWC.equals(lastWord)
+                    && !wordInLWC.equals(secondToLastWord)
+                    && !wordInLWC.equals(thirdToLastWord)) {
                 freshWord = true;
                 thirdToLastWord = secondToLastWord;
                 secondToLastWord = lastWord;
@@ -387,13 +387,13 @@ public class Colombia extends GameActivity {
                     if (keysInUse > TILE_BUTTONS.length) {
                         TextView key34 = findViewById(TILE_BUTTONS[TILE_BUTTONS.length - 2]);
                         key34.setBackgroundResource(R.drawable.zz_backward_green);
-                        if (scriptDirection.compareTo("RTL") == 0) { //LTR is default
+                        if (scriptDirection.equals("RTL")) {
                             key34.setRotationY(180);
                         }
                         key34.setText("");
                         TextView key35 = findViewById(TILE_BUTTONS[TILE_BUTTONS.length - 1]);
                         key35.setBackgroundResource(R.drawable.zz_forward_green);
-                        if (scriptDirection.compareTo("RTL") == 0) { //LTR is default
+                        if (scriptDirection.equals("RTL")) {
                             key35.setRotationY(180);
                         }
                         key35.setText("");

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
@@ -51,7 +51,7 @@ public class Earth extends AppCompatActivity {
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView goForwardImage = (ImageView) findViewById(R.id.goForward);
             ImageView goBackImage = (ImageView) findViewById(R.id.goBack);
             ImageView activePlayerImage = (ImageView) findViewById(R.id.activePlayerImage);
@@ -90,7 +90,7 @@ public class Earth extends AppCompatActivity {
 
         updateDoors();
 
-        if (scriptDirection.compareTo("RTL") == 0) {
+        if (scriptDirection.equals("RTL")) {
             forceRTLIfSupported();
         } else {
             forceLTRIfSupported();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
@@ -99,7 +99,7 @@ public class Ecuador extends GameActivity {
         setContentView(R.layout.ecuador);
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);     // forces portrait mode only
 
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -441,9 +441,9 @@ public class Ecuador extends GameActivity {
             wordInLWC = wordListArray.get(rightWordIndex)[0];
 
             //If this word isn't one of the 3 previously tested words, we're good // LM
-            if (wordInLWC.compareTo(lastWord) != 0
-                    && wordInLWC.compareTo(secondToLastWord) != 0
-                    && wordInLWC.compareTo(thirdToLastWord) != 0) {
+            if (!wordInLWC.equals(lastWord)
+                    && !wordInLWC.equals(secondToLastWord)
+                    && !wordInLWC.equals(thirdToLastWord)) {
                 freshWord = true;
                 thirdToLastWord = secondToLastWord;
                 secondToLastWord = lastWord;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -120,7 +120,7 @@ public abstract class GameActivity extends AppCompatActivity {
 
         className = getClass().getName();
 
-        if (scriptDirection.compareTo("RTL") == 0) {
+        if (scriptDirection.equals("RTL")) {
             forceRTLIfSupported();
         } else {
             forceLTRIfSupported();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -117,7 +117,7 @@ public class Georgia extends GameActivity {
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);     // forces portrait mode only
 
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -234,9 +234,9 @@ public class Georgia extends GameActivity {
             wordInLOP = Start.wordList.get(randomNum).localWord; // KP
 
             //If this word isn't one of the 3 previously tested words, we're good // LM
-            if (wordInLWC.compareTo(lastWord) != 0
-                    && wordInLWC.compareTo(secondToLastWord) != 0
-                    && wordInLWC.compareTo(thirdToLastWord) != 0) {
+            if (!wordInLWC.equals(lastWord)
+                    && !wordInLWC.equals(secondToLastWord)
+                    && !wordInLWC.equals(thirdToLastWord)) {
                 // this next section was moved by JP to help make sure that whatever word is chosen
                 // actually begins with a C or V
                 if (syllableGame.equals("S")) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -112,7 +112,7 @@ public class Italy extends GameActivity {
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);     // forces portrait mode only
 
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
             ImageView playNextWordImage = (ImageView) findViewById(R.id.playNextWord);
@@ -283,7 +283,7 @@ public class Italy extends GameActivity {
 
         TextView tileJustSelected = findViewById(TILE_BUTTONS[indexOfTileJustSelected - 1]);
 
-        if (((String) tileJustSelected.getText()).compareTo(wordInLOP) == 0) {
+        if (((String) tileJustSelected.getText()).equals(wordInLOP)) {
             respondToCorrectSelection(indexOfTileJustSelected);
         } else {
             respondToIncorrectSelection();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
@@ -145,7 +145,7 @@ public class Japan extends GameActivity {
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);     // forces landscape mode only
 
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -224,9 +224,9 @@ public class Japan extends GameActivity {
 
             if (parsedWordIntoTiles.size() <= MAX_TILES) { //JP: choose word w/ <= 12 tiles
                 //If this word isn't one of the 3 previously tested words, we're good // LM
-                if (wordInLWC.compareTo(lastWord) != 0
-                        && wordInLWC.compareTo(secondToLastWord) != 0
-                        && wordInLWC.compareTo(thirdToLastWord) != 0) {
+                if (!wordInLWC.equals(lastWord)
+                        && !wordInLWC.equals(secondToLastWord)
+                        && !wordInLWC.equals(thirdToLastWord)) {
                     freshWord = true;
                     thirdToLastWord = secondToLastWord;
                     secondToLastWord = lastWord;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
@@ -207,8 +207,8 @@ public class LoadingScreen extends AppCompatActivity {
             tileDurations.put(tile.baseTile, duration);
             tile.tileDuration1 = duration;
 
-            if (tile.tileTypeB.compareTo("none") != 0) {
-                if (tile.audioForTileB.compareTo("X") != 0) {
+            if (!tile.tileTypeB.equals("none")) {
+                if (!tile.audioForTileB.equals("X")) {
                     resId = res.getIdentifier(tile.audioForTileB, "raw", context.getPackageName());
                     duration = getAssetDuration(resId) + 100;
                     tileAudioIDs.put(tile.baseTile + "B", gameSounds.load(context, resId, 2));

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -93,7 +93,7 @@ public class Mexico extends GameActivity {
         setContentView(R.layout.mexico);
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);     // forces portrait mode only
 
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -375,7 +375,7 @@ public class Mexico extends GameActivity {
             // The two cards do NOT match
             long delay = 0;
             String delaySetting = Start.settingsList.find("View memory cards for _ milliseconds");
-            if (delaySetting.compareTo("") != 0) {
+            if (!delaySetting.equals("")) {
                 delay = Long.valueOf(delaySetting);
             }
             handler = new Handler();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -90,7 +90,7 @@ public class Myanmar extends GameActivity {
         setContentView(R.layout.myanmar);
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);     // forces portrait mode only
 
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
@@ -78,7 +78,7 @@ public class Peru extends GameActivity {
         setContentView(R.layout.peru);
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -162,9 +162,9 @@ public class Peru extends GameActivity {
             wordInLOP = Start.wordList.get(randomNum).localWord; // KP
 
             //If this word isn't one of the 3 previously tested words, we're good // LM
-            if (wordInLWC.compareTo(lastWord) != 0
-                    && wordInLWC.compareTo(secondToLastWord) != 0
-                    && wordInLWC.compareTo(thirdToLastWord) != 0) {
+            if (!wordInLWC.equals(lastWord)
+                    && !wordInLWC.equals(secondToLastWord)
+                    && !wordInLWC.equals(thirdToLastWord)) {
                 freshWord = true;
                 thirdToLastWord = secondToLastWord;
                 secondToLastWord = lastWord;
@@ -219,7 +219,7 @@ public class Peru extends GameActivity {
                             nextWord.setText(incorrectChoice1);
                             isDuplicateAnswerChoice = false;
                             for (int j = 0; j < incorrectChoice1.length() - 2; j++) {
-                                if (incorrectChoice1.substring(j, j + 3).compareTo("للہ") == 0) {
+                                if (incorrectChoice1.substring(j, j + 3).equals("للہ")) {
                                     isDuplicateAnswerChoice = true;
                                 }
                             }
@@ -256,15 +256,15 @@ public class Peru extends GameActivity {
 
                             isDuplicateAnswerChoice = false; // LM // resets to true and keeps looping if a duplicate has been made:
                             for (int answerChoice = 0; answerChoice < i; answerChoice++) {
-                                if (incorrectChoice2.compareTo(((TextView) findViewById(TILE_BUTTONS[answerChoice])).getText().toString()) == 0) {
+                                if (incorrectChoice2.equals(((TextView) findViewById(TILE_BUTTONS[answerChoice])).getText().toString())) {
                                     isDuplicateAnswerChoice = true;
                                 }
                             }
-                            if (incorrectChoice2.compareTo(Start.wordList.stripInstructionCharacters(wordInLOP)) == 0) {
+                            if (incorrectChoice2.equals(Start.wordList.stripInstructionCharacters(wordInLOP))) {
                                 isDuplicateAnswerChoice = true;
                             }
                             for (int j = 0; j < incorrectChoice2.length() - 2; j++) {
-                                if (incorrectChoice2.substring(j, j + 3).compareTo("للہ") == 0) {
+                                if (incorrectChoice2.substring(j, j + 3).equals("للہ")) {
                                     isDuplicateAnswerChoice = true;
                                 }
                             }
@@ -291,12 +291,12 @@ public class Peru extends GameActivity {
 
                             isDuplicateAnswerChoice = false; // LM // resets to true and keeps looping if a duplicate has been made:
                             for (int answerChoice = 0; answerChoice < i; answerChoice++) {
-                                if (incorrectChoice3.compareTo(((TextView) findViewById(TILE_BUTTONS[answerChoice])).getText().toString()) == 0) {
+                                if (incorrectChoice3.equals(((TextView) findViewById(TILE_BUTTONS[answerChoice])).getText().toString())) {
                                     isDuplicateAnswerChoice = true;
                                 }
                             }
                             for (int j = 0; j < incorrectChoice3.length() - 2; j++) {
-                                if (incorrectChoice3.substring(j, j + 3).compareTo("للہ") == 0) {
+                                if (incorrectChoice3.substring(j, j + 3).equals("للہ")) {
                                     isDuplicateAnswerChoice = true;
                                 }
                             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
@@ -50,7 +50,7 @@ public class Resources extends AppCompatActivity {
         buildResourcesArray();
         loadResources();
 
-        if (scriptDirection.compareTo("RTL") == 0) {
+        if (scriptDirection.equals("RTL")) {
             forceRTLIfSupported();
         } else {
             forceLTRIfSupported();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -94,7 +94,7 @@ public class Romania extends GameActivity {
         // Display or show the three filter options based on value in aa_settings.txt
         Boolean showFilterOptions;
         String hasFilterSetting = settingsList.find("Show filter options for Game 001");
-        if (hasFilterSetting.compareTo("") != 0) {
+        if (!hasFilterSetting.equals("")) {
             showFilterOptions = Boolean.parseBoolean(hasFilterSetting);
         } else {
             showFilterOptions = false;
@@ -132,7 +132,7 @@ public class Romania extends GameActivity {
         pointsEarned.setText(String.valueOf(points));
 
         String differentiateTypesSetting = Start.settingsList.find("Differentiates types of multitype symbols");
-        if (differentiateTypesSetting.compareTo("") != 0) {
+        if (!differentiateTypesSetting.equals("")) {
             differentiateTypes = Boolean.parseBoolean(differentiateTypesSetting);
 
             if (differentiateTypes) {
@@ -148,7 +148,7 @@ public class Romania extends GameActivity {
         String startingAlphabetTile = prefs.getString("lastActiveTileGame001_player" + playerString, firstAlphabetTile);
 
         scriptDirection = Start.langInfoList.find("Script direction (LTR or RTL)");
-        if (scriptDirection.compareTo("RTL") == 0) {
+        if (scriptDirection.equals("RTL")) {
             forceRTL = true;
         } else {
             forceRTL = false;
@@ -515,10 +515,10 @@ public class Romania extends GameActivity {
         String someGameTileWithoutSuffix;
 
         someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-        if (someGameTileType.compareTo("B") == 0) {
+        if (someGameTileType.equals("B")) {
             someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
             someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-        } else if (someGameTileType.compareTo("C") == 0) {
+        } else if (someGameTileType.equals("C")) {
             someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
             someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
         } else {
@@ -569,10 +569,10 @@ public class Romania extends GameActivity {
         String someGameTileWithoutSuffix;
 
         someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-        if (someGameTileType.compareTo("B") == 0) {
+        if (someGameTileType.equals("B")) {
             someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
             someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-        } else if (someGameTileType.compareTo("C") == 0) {
+        } else if (someGameTileType.equals("C")) {
             someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
             someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
         } else {
@@ -624,10 +624,10 @@ public class Romania extends GameActivity {
         String someGameTileWithoutSuffix;
 
         someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-        if (someGameTileType.compareTo("B") == 0) {
+        if (someGameTileType.equals("B")) {
             someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
             someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-        } else if (someGameTileType.compareTo("C") == 0) {
+        } else if (someGameTileType.equals("C")) {
             someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
             someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
         } else {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
@@ -53,7 +53,7 @@ public class SetPlayerName extends AppCompatActivity {
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
-        if (scriptDirection.compareTo("RTL") == 0) { // LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView deleteImage = (ImageView) findViewById(R.id.deleteImage);
             ImageView avatarImage = (ImageView) findViewById(R.id.avatar);
 
@@ -97,7 +97,7 @@ public class SetPlayerName extends AppCompatActivity {
             name.setSelection(name.getText().length());
         }
 
-        if (scriptDirection.compareTo("RTL") == 0) {
+        if (scriptDirection.equals("RTL")) {
             forceRTLIfSupported();
         } else {
             forceLTRIfSupported();
@@ -179,12 +179,12 @@ public class SetPlayerName extends AppCompatActivity {
         if (keysInUse > KEYS.length) {
             TextView key34 = findViewById(KEYS[KEYS.length - 2]);
             key34.setBackgroundResource(R.drawable.zz_backward_green);
-            if (scriptDirection.compareTo("RTL") == 0) { //LM: LTR is default
+            if (scriptDirection.equals("RTL")) {
                 key34.setRotationY(180);
             }
             key34.setText("");
             TextView key35 = findViewById(KEYS[KEYS.length - 1]);
-            if (scriptDirection.compareTo("RTL") == 0) { //LM: LTR is default
+            if (scriptDirection.equals("RTL")) {
                 key35.setRotationY(180);
             }
             key35.setBackgroundResource(R.drawable.zz_forward_green);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -113,21 +113,21 @@ public class Start extends AppCompatActivity {
         buildColorsArray();
 
         String hasAudioSetting = settingsList.find("Has tile audio");
-        if (hasAudioSetting.compareTo("") != 0) {
+        if (!hasAudioSetting.equals("")) {
             hasTileAudio = Boolean.parseBoolean(hasAudioSetting);
         } else {
             hasTileAudio = false;
         }
 
         String differentiateTypesSetting = settingsList.find("Differentiates types of multitype symbols");
-        if (differentiateTypesSetting.compareTo("") != 0) {
+        if (!differentiateTypesSetting.equals("")) {
             differentiateTypes = Boolean.parseBoolean(differentiateTypesSetting);
         } else {
             differentiateTypes = false;
         }
 
         String after12checkedTrackersSetting = settingsList.find("After 12 checked trackers");
-        if (after12checkedTrackersSetting.compareTo("") != 0) {
+        if (!after12checkedTrackersSetting.equals("")) {
             after12checkedTrackers = Integer.valueOf(after12checkedTrackersSetting);
         } else {
             after12checkedTrackers = 3;
@@ -135,7 +135,7 @@ public class Start extends AppCompatActivity {
 
         //to make syllable audio optional
         String hasSyllableAudioSetting = settingsList.find("Has syllable audio");
-        if (hasSyllableAudioSetting.compareTo("") != 0) {
+        if (!hasSyllableAudioSetting.equals("")) {
             hasSyllableAudio = Boolean.parseBoolean(hasSyllableAudioSetting);
         } else {
             hasSyllableAudio = false;
@@ -304,11 +304,11 @@ public class Start extends AppCompatActivity {
                     tileHashMapWithMultiTypesNoSAD.put(tile.baseTile, tile.tileType);
                 }
                 // SAD should never have a 2nd or 3rd type other than "none"
-                if (tile.tileTypeB.compareTo("none") != 0) {
+                if (!tile.tileTypeB.equals("none")) {
                     tileListWithMultipleTypes.add(tile.baseTile + "B");
                     tileHashMapWithMultipleTypes.put(tile.baseTile + "B", tile.tileTypeB);
                 }
-                if (tile.tileTypeC.compareTo("none") != 0) {
+                if (!tile.tileTypeC.equals("none")) {
                     tileListWithMultipleTypes.add(tile.baseTile + "C");
                     tileHashMapWithMultipleTypes.put(tile.baseTile + "C", tile.tileTypeC);
                 }
@@ -641,10 +641,10 @@ public class Start extends AppCompatActivity {
             String someGameTileWithoutSuffix;
 
             someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-            if (someGameTileType.compareTo("B") == 0) {
+            if (someGameTileType.equals("B")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-            } else if (someGameTileType.compareTo("C") == 0) {
+            } else if (someGameTileType.equals("C")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
             } else {
@@ -700,10 +700,10 @@ public class Start extends AppCompatActivity {
 
 
             someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-            if (someGameTileType.compareTo("B") == 0) {
+            if (someGameTileType.equals("B")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-            } else if (someGameTileType.compareTo("C") == 0) {
+            } else if (someGameTileType.equals("C")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
             } else {
@@ -756,10 +756,10 @@ public class Start extends AppCompatActivity {
             String someGameTileWithoutSuffix;
 
             someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-            if (someGameTileType.compareTo("B") == 0) {
+            if (someGameTileType.equals("B")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-            } else if (someGameTileType.compareTo("C") == 0) {
+            } else if (someGameTileType.equals("C")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
             } else {
@@ -816,10 +816,10 @@ public class Start extends AppCompatActivity {
 
 
             someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-            if (someGameTileType.compareTo("B") == 0) {
+            if (someGameTileType.equals("B")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-            } else if (someGameTileType.compareTo("C") == 0) {
+            } else if (someGameTileType.equals("C")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
             } else {
@@ -873,10 +873,10 @@ public class Start extends AppCompatActivity {
             String someGameTileWithoutSuffix;
 
             someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-            if (someGameTileType.compareTo("B") == 0) {
+            if (someGameTileType.equals("B")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-            } else if (someGameTileType.compareTo("C") == 0) {
+            } else if (someGameTileType.equals("C")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
             } else {
@@ -933,10 +933,10 @@ public class Start extends AppCompatActivity {
 
 
             someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-            if (someGameTileType.compareTo("B") == 0) {
+            if (someGameTileType.equals("B")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-            } else if (someGameTileType.compareTo("C") == 0) {
+            } else if (someGameTileType.equals("C")) {
                 someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
             } else {
@@ -1760,7 +1760,7 @@ public class Start extends AppCompatActivity {
 
         public Tile find(String key) {
             for (String k : keySet()) {
-                if (k.compareTo(key) == 0) {
+                if (k.equals(key)) {
                     return (get(k));
                 }
             }
@@ -1773,7 +1773,7 @@ public class Start extends AppCompatActivity {
 
         public Syllable find(String key) {
             for (String k : keySet()) {
-                if (k.compareTo(key) == 0) {
+                if (k.equals(key)) {
                     return (get(k));
                 }
             }
@@ -1786,7 +1786,7 @@ public class Start extends AppCompatActivity {
 
         public Word find(String key) {
             for (String k : keySet()) {
-                if (k.compareTo(key) == 0) {
+                if (k.equals(key)) {
                     return (get(k));
                 }
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
@@ -105,7 +105,7 @@ public class Sudan extends GameActivity {
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
-        if (scriptDirection.compareTo("RTL") == 0) { // LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -258,7 +258,7 @@ public class Sudan extends GameActivity {
             int tileColor = Color.parseColor(typeColor);
             tileView.setBackgroundColor(tileColor);
 
-            if (t.tileTypeB.compareTo("none") != 0) {
+            if (!t.tileTypeB.equals("none")) {
                 tileView = findViewById(TILE_BUTTONS[visibleTiles]);
                 tileView.setText(t.baseTile);
                 visibleTiles++;
@@ -283,7 +283,7 @@ public class Sudan extends GameActivity {
                 tileView.setBackgroundColor(tileColorB);
             }
 
-            if (t.tileTypeC.compareTo("none") != 0) {
+            if (!t.tileTypeC.equals("none")) {
 
                 tileView = findViewById(TILE_BUTTONS[visibleTiles]);
                 tileView.setText(t.baseTile);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -141,7 +141,7 @@ public class Thailand extends GameActivity {
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);     // forces portrait mode only
 
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        if (scriptDirection.compareTo("RTL") == 0) { //LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -220,9 +220,9 @@ public class Thailand extends GameActivity {
                         refTile = parsedWordArrayFinal.get(0);
                         refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     }
-                    if (refTile.compareTo(refTileLast) != 0
-                            && refTile.compareTo(refTileSecondToLast) != 0
-                            && refTile.compareTo(refTileThirdToLast) != 0) {
+                    if (!refTile.equals(refTileLast)
+                            && !refTile.equals(refTileSecondToLast)
+                            && !refTile.equals(refTileThirdToLast)) {
                         freshTile = true;
                         refTileThirdToLast = refTileSecondToLast;
                         refTileSecondToLast = refTileLast;
@@ -245,9 +245,9 @@ public class Thailand extends GameActivity {
                         refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     }
                     // SAD should never be first tile linguistically, so no need to programatically filter out
-                    if (refTile.compareTo(refTileLast) != 0
-                            && refTile.compareTo(refTileSecondToLast) != 0
-                            && refTile.compareTo(refTileThirdToLast) != 0) {
+                    if (!refTile.equals(refTileLast)
+                            && !refTile.equals(refTileSecondToLast)
+                            && !refTile.equals(refTileThirdToLast)) {
                         freshTile = true;
                         refTileThirdToLast = refTileSecondToLast;
                         refTileSecondToLast = refTileLast;
@@ -269,9 +269,9 @@ public class Thailand extends GameActivity {
                         refTile = parsedWordArrayFinal.get(0);
                         refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     }
-                    if (refTile.compareTo(refTileLast) != 0
-                            && refTile.compareTo(refTileSecondToLast) != 0
-                            && refTile.compareTo(refTileThirdToLast) != 0) {
+                    if (!refTile.equals(refTileLast)
+                            && !refTile.equals(refTileSecondToLast)
+                            && !refTile.equals(refTileThirdToLast)) {
                         freshTile = true;
                         refTileThirdToLast = refTileSecondToLast;
                         refTileSecondToLast = refTileLast;
@@ -286,9 +286,9 @@ public class Thailand extends GameActivity {
             while (!freshTile) {
                 int randomNum2 = rand.nextInt(sortableSyllArray.size());
                 refTile = sortableSyllArray.get(randomNum2).syllable;
-                if (refTile.compareTo(refTileLast) != 0
-                        && refTile.compareTo(refTileSecondToLast) != 0
-                        && refTile.compareTo(refTileThirdToLast) != 0) {
+                if (!refTile.equals(refTileLast)
+                        && !refTile.equals(refTileSecondToLast)
+                        && !refTile.equals(refTileThirdToLast)) {
                     freshTile = true;
                     refTileThirdToLast = refTileSecondToLast;
                     refTileSecondToLast = refTileLast;
@@ -302,9 +302,9 @@ public class Thailand extends GameActivity {
                 chooseWord();
                 parsedWordArrayFinal = syllableList.parseWordIntoSyllables(wordInLOP);
                 refTile = parsedWordArrayFinal.get(0);
-                if (refTile.compareTo(refTileLast) != 0
-                        && refTile.compareTo(refTileSecondToLast) != 0
-                        && refTile.compareTo(refTileThirdToLast) != 0) {
+                if (!refTile.equals(refTileLast)
+                        && !refTile.equals(refTileSecondToLast)
+                        && !refTile.equals(refTileThirdToLast)) {
                     freshTile = true;
                     refTileThirdToLast = refTileSecondToLast;
                     refTileSecondToLast = refTileLast;
@@ -330,9 +330,9 @@ public class Thailand extends GameActivity {
                         refTile = sortableTilesArray.get(randomNum2).baseTile;
                         refTileType = sortableTilesArray.get(randomNum2).tileType;
                     }
-                    if (refTile.compareTo(refTileLast) != 0
-                            && refTile.compareTo(refTileSecondToLast) != 0
-                            && refTile.compareTo(refTileThirdToLast) != 0) {
+                    if (!refTile.equals(refTileLast)
+                            && !refTile.equals(refTileSecondToLast)
+                            && !refTile.equals(refTileThirdToLast)) {
                         freshTile = true;
                         refTileThirdToLast = refTileSecondToLast;
                         refTileSecondToLast = refTileLast;
@@ -354,9 +354,9 @@ public class Thailand extends GameActivity {
                         refTile = sortableTilesArray.get(randomNum2).upperTile;
                         refTileType = sortableTilesArray.get(randomNum2).tileType;
                     }
-                    if (refTile.compareTo(refTileLast) != 0
-                            && refTile.compareTo(refTileSecondToLast) != 0
-                            && refTile.compareTo(refTileThirdToLast) != 0) {
+                    if (!refTile.equals(refTileLast)
+                            && !refTile.equals(refTileSecondToLast)
+                            && !refTile.equals(refTileThirdToLast)) {
                         freshTile = true;
                         refTileThirdToLast = refTileSecondToLast;
                         refTileSecondToLast = refTileLast;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -141,7 +141,7 @@ public class UnitedStates extends GameActivity {
 
         updateTrackers();
 
-        if (scriptDirection.compareTo("RTL") == 0) { // LM: flips images for RTL layouts. LTR is default
+        if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
@@ -188,9 +188,9 @@ public class UnitedStates extends GameActivity {
                 wordInLOP = Start.wordList.get(randomNum).localWord; // KP
 
                 //If this word isn't one of the 3 previously tested words, we're good // LM
-                if (wordInLWC.compareTo(lastWord) != 0
-                        && wordInLWC.compareTo(secondToLastWord) != 0
-                        && wordInLWC.compareTo(thirdToLastWord) != 0) {
+                if (!wordInLWC.equals(lastWord)
+                        && !wordInLWC.equals(secondToLastWord)
+                        && !wordInLWC.equals(thirdToLastWord)) {
                     freshWord = true;
                     thirdToLastWord = secondToLastWord;
                     secondToLastWord = lastWord;


### PR DESCRIPTION
I used to be in the habit of writing this:

if(thisString.comparesTo(thatString) == 0)

for string comparison. But this is more readable and does the same thing:

if(thisString.equals(thatString)

So, this PR replaces instances of the String .compareTo method with the String .equals method.