### PR TITLE
Prevent duplicate "slide" for tile in Romania, condense code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 32
-        versionCode 81
-        versionName "1.2.3"
+        versionCode 83
+        versionName "1.2.5"
 
         // API 14 = Ice Cream (4.0)
         // API 16 = Jelly Bean (4.1) - required for Firebase

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -12,8 +12,6 @@ import android.widget.TextView;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
 
-import java.util.ArrayList;
-
 import static org.alphatilesapps.alphatiles.Start.*;
 
 public class Romania extends GameActivity {
@@ -193,36 +191,40 @@ public class Romania extends GameActivity {
             case 2:
                 // CASE 2: check Group One, if count is zero, then check Group Two
                 // Group One = words that START with the active tile
-                groupCount = Start.wordList.returnGroupOneCount(activeTileString);
+                groupCount = Start.wordList.numberOfWordsForActiveTile(activeTileString, 1);
                 if (groupCount > 0) {
-                    groupOfWordsForActiveTile = Start.wordList.returnGroupOneWords(activeTileString, groupCount);
+                    groupOfWordsForActiveTile = Start.wordList.wordsForActiveTile(activeTileString, groupCount, 1);
                     failedToMatchInitialTile = false;
                 } else {
                     // Group Two = words that contain the active tile non-initially (but excluding initially)
                     failedToMatchInitialTile = true;
-                    groupCount = Start.wordList.returnGroupTwoCount(activeTileString);
+                    groupCount = Start.wordList.numberOfWordsForActiveTile(activeTileString, 2);
 
                     if (groupCount > 0) {
-                        groupOfWordsForActiveTile = Start.wordList.returnGroupTwoWords(activeTileString, groupCount); // Group Two = words that contain the active tile non-initially (but excluding initially)
+                        groupOfWordsForActiveTile = Start.wordList.wordsForActiveTile(activeTileString, groupCount, 2); // Group Two = words that contain the active tile non-initially (but excluding initially)
+                    } else {
+                        skipThisTile = true;
                     }
                 }
                 break;
             case 3:
                 // CASE 3: check Group Three
                 // Group Three = words containing the active tile anywhere (initial and/or non-initial)
-                groupCount = Start.wordList.returnGroupThreeCount(activeTileString);
+                groupCount = Start.wordList.numberOfWordsForActiveTile(activeTileString, 3);
                 if (groupCount > 0) {
-                    groupOfWordsForActiveTile = Start.wordList.returnGroupThreeWords(activeTileString, groupCount); // Group Three = words containing the active tile anywhere (initial and/or non-initial)
+                    groupOfWordsForActiveTile = Start.wordList.wordsForActiveTile(activeTileString, groupCount, 3); // Group Three = words containing the active tile anywhere (initial and/or non-initial)
+                } else {
+                    skipThisTile = true;
                 }
                 break;
             default:
                 // CASE 1: check Group One
                 // Group One = words that START with the active tile
-                groupCount = Start.wordList.returnGroupOneCount(activeTileString);
+                groupCount = Start.wordList.numberOfWordsForActiveTile(activeTileString, 1);
                 if (groupCount > 0) {
-                    groupOfWordsForActiveTile = Start.wordList.returnGroupOneWords(activeTileString, groupCount);
+                    groupOfWordsForActiveTile = Start.wordList.wordsForActiveTile(activeTileString, groupCount, 1);
                     failedToMatchInitialTile = false;
-                } else { //there are no words at begin with the active tile
+                } else { // There are no words at begin with the active tile
                     failedToMatchInitialTile = true;
                     skipThisTile = true;
                 }
@@ -240,11 +242,11 @@ public class Romania extends GameActivity {
 
         if (!skipThisTile) { // If we DO have words in the group for this tile given the scan setting, then...
 
-            //display a word (should normally be the first word) from the group of words for the active tile
+            // Display a word (should normally be the first word) from the group of words for the active tile
             wordInLWC = groupOfWordsForActiveTile[indexWithinGroup][0];
             wordInLOP = groupOfWordsForActiveTile[indexWithinGroup][1];
 
-            //Group 3 has all words containing the tile anywhere. This checks whether the current word is active-tile-initial or not
+            // Group 3 has all words containing the tile anywhere. This checks whether the current word is active-tile-initial or not
             if (scanSetting == 3) {
                 parsedWordArrayFinal = Start.tileList.parseWordIntoTiles(wordInLOP); // KP
                 failedToMatchInitialTile = !activeTileString.equals(parsedWordArrayFinal.get(0));
@@ -305,7 +307,7 @@ public class Romania extends GameActivity {
             failedToMatchInitialTile = !activeTileString.equals(parsedWordArrayFinal.get(0));
         }
 
-        //display the next word in groupOfWordsForActiveTile[][]
+        // Display the next word in groupOfWordsForActiveTile[][]
         if (!skipThisTile) {
 
             TextView activeWord = (TextView) findViewById(R.id.activeWordTextView);
@@ -417,7 +419,7 @@ public class Romania extends GameActivity {
             activeTile = Start.tileList.returnNextAlphabetTile(oldTile); // KP
         }
         if (scanSetting == 1) {
-            while (returnGroupOneCountRomania(activeTile) == 0) { // JP: prevents user from having to click
+            while (Start.wordList.numberOfWordsForActiveTile(activeTile, 1) == 0) { // JP: prevents user from having to click
                 // the arrow multiple times to skip irrelevant tiles that are never word-initial
                 oldTile = activeTile;
                 if (differentiateTypes) {
@@ -427,7 +429,7 @@ public class Romania extends GameActivity {
                 }
             }
         } else if (scanSetting == 2) {
-            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || returnGroupTwoCountRomania(activeTile) == 0) {
+            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || Start.wordList.numberOfWordsForActiveTile(activeTile, 2) == 0) {
                 oldTile = activeTile;
                 if (differentiateTypes) {
                     activeTile = Start.tileListWithMultipleTypes.returnNextAlphabetTileDifferentiateTypes(oldTile);
@@ -437,7 +439,7 @@ public class Romania extends GameActivity {
             }
         } else { // scanSetting 3
             while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) ||
-                    returnGroupThreeCountRomania(activeTile) == 0) {
+                    Start.wordList.numberOfWordsForActiveTile(activeTile, 3) == 0) {
                 oldTile = activeTile;
                 if (differentiateTypes) {
                     activeTile = Start.tileListWithMultipleTypes.returnNextAlphabetTileDifferentiateTypes(oldTile);
@@ -464,7 +466,7 @@ public class Romania extends GameActivity {
             activeTile = Start.tileList.returnPreviousAlphabetTile(oldTile); // KP
         }
         if (scanSetting == 1) {
-            while (returnGroupOneCountRomania(activeTile) == 0) {
+            while (Start.wordList.numberOfWordsForActiveTile(activeTile, 1) == 0) {
                 // JP: prevents user from having to click
                 // the arrow multiple times to skip irrelevant tiles that are never word-initial
                 oldTile = activeTile;
@@ -475,7 +477,7 @@ public class Romania extends GameActivity {
                 }
             }
         } else if (scanSetting == 2) {
-            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || returnGroupTwoCountRomania(activeTile) == 0) {
+            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || Start.wordList.numberOfWordsForActiveTile(activeTile, 2) == 0) {
                 oldTile = activeTile;
                 if (differentiateTypes) {
                     activeTile = Start.tileListWithMultipleTypes.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
@@ -484,8 +486,7 @@ public class Romania extends GameActivity {
                 }
             }
         } else { // scanSetting 3
-            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) ||
-                    returnGroupThreeCountRomania(activeTile) == 0) {
+            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || Start.wordList.numberOfWordsForActiveTile(activeTile, 3) == 0) {
                 oldTile = activeTile;
                 if (differentiateTypes) {
                     activeTile = Start.tileListWithMultipleTypes.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
@@ -501,171 +502,6 @@ public class Romania extends GameActivity {
         editor.putString("lastActiveTileGame001_player" + playerString, activeTile);
         editor.apply();
         setUpBasedOnGameTile(activeTile);
-    }
-
-    // JP copied this function into here because of
-    // "non-static method cannot be accessed in static context" issue
-    public int returnGroupOneCountRomania(String someGameTile) {
-        // Group One = words that START with the active tile
-
-        ArrayList<String> parsedWordArrayFinal;
-        String wordInitialTile;
-        String wordInitialTileType;
-        String someGameTileType;
-        String someGameTileWithoutSuffix;
-
-        someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-        if (someGameTileType.equals("B")) {
-            someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-        } else if (someGameTileType.equals("C")) {
-            someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
-        } else {
-            someGameTileWithoutSuffix = someGameTile;
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileType;
-        }
-
-        int tilesCount = 0;
-
-        for (int i = 0; i < wordList.size(); i++) {
-            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordList.get(i).localWord);
-
-            wordInitialTile = parsedWordArrayFinal.get(0);
-
-            if (wordInitialTile != null) {
-
-                if (differentiateTypes) {// Checking if both tile and type match
-                    if (MULTIFUNCTIONS.contains(someGameTileWithoutSuffix)) {
-                        wordInitialTileType = Start.tileList.getInstanceTypeForMixedTile(0, wordList.get(i).nationalWord);
-                    } else {// Not dealing with a multifunction symbol
-                        wordInitialTileType = tileHashMap.find(wordInitialTile).tileType;
-                    }
-
-                    if (wordInitialTile.equals(someGameTileWithoutSuffix) && someGameTileType.equals(wordInitialTileType)) {
-                        tilesCount++;
-                    }
-
-                } else {// Not differentiating types, only matching tile to tile
-                    if (parsedWordArrayFinal.get(0).equals(someGameTile)) {
-                        tilesCount++;
-                    }
-                }
-
-            }
-        }
-
-        return tilesCount;
-
-    }
-
-    public int returnGroupTwoCountRomania(String someGameTile) {
-        // Group Two = words that contain the active tile non-initially (but excluding initially)
-
-        ArrayList<String> parsedWordArrayFinal;
-        String tileInFocus;
-        String tileInFocusType;
-        String someGameTileType;
-        String someGameTileWithoutSuffix;
-
-        someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-        if (someGameTileType.equals("B")) {
-            someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-        } else if (someGameTileType.equals("C")) {
-            someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
-        } else {
-            someGameTileWithoutSuffix = someGameTile;
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileType;
-        }
-
-        int tilesCount = 0;
-
-        for (int i = 0; i < wordList.size(); i++) {
-            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordList.get(i).localWord);
-
-            for (int k = 1; k < parsedWordArrayFinal.size(); k++) {
-                tileInFocus = parsedWordArrayFinal.get(k);
-
-                if (tileInFocus != null) {
-
-                    if (differentiateTypes) {// Checking if both tile and type match
-                        if (MULTIFUNCTIONS.contains(someGameTileWithoutSuffix)) {
-                            tileInFocusType = Start.tileList.getInstanceTypeForMixedTile(k, wordList.get(i).nationalWord);
-                        } else {// Not dealing with a multifunction symbol
-                            tileInFocusType = tileHashMap.find(tileInFocus).tileType;
-                        }
-
-                        if (tileInFocus.equals(someGameTileWithoutSuffix) && someGameTileType.equals(tileInFocusType)) {
-                            tilesCount++;
-                        }
-
-                    } else {// Not differentiating types, only matching tile to tile
-                        if (parsedWordArrayFinal.get(k).equals(someGameTile)) {
-                            tilesCount++;
-                        }
-                    }
-                }
-            }
-        }
-
-        return tilesCount;
-
-    }
-
-    public int returnGroupThreeCountRomania(String someGameTile) {
-        // Group Three = words containing the active tile anywhere (initial and/or non-initial)
-
-        ArrayList<String> parsedWordArrayFinal;
-        String tileInFocus;
-        String tileInFocusType;
-        String someGameTileType;
-        String someGameTileWithoutSuffix;
-
-        someGameTileType = Character.toString(someGameTile.charAt(someGameTile.length() - 1));
-        if (someGameTileType.equals("B")) {
-            someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeB;
-        } else if (someGameTileType.equals("C")) {
-            someGameTileWithoutSuffix = someGameTile.substring(0, someGameTile.length() - 1);
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileTypeC;
-        } else {
-            someGameTileWithoutSuffix = someGameTile;
-            someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileType;
-        }
-
-        int tilesCount = 0;
-
-        for (int i = 0; i < wordList.size(); i++) {
-            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordList.get(i).localWord);
-
-            for (int k = 0; k < parsedWordArrayFinal.size(); k++) {
-                tileInFocus = parsedWordArrayFinal.get(k);
-
-                if (tileInFocus != null) {
-
-                    if (differentiateTypes) {// Checking if both tile and type match
-                        if (MULTIFUNCTIONS.contains(someGameTileWithoutSuffix)) {
-                            tileInFocusType = Start.tileList.getInstanceTypeForMixedTile(k, wordList.get(i).nationalWord);
-                        } else {// Not dealing with a multifunction symbol
-                            tileInFocusType = tileHashMap.find(tileInFocus).tileType;
-                        }
-
-                        if (tileInFocus.equals(someGameTileWithoutSuffix) && someGameTileType.equals(tileInFocusType)) {
-                            tilesCount++;
-                        }
-                    } else {// Not differentiating types, only matching tile to tile
-                        if (parsedWordArrayFinal.get(k).equals(someGameTile)) {
-                            tilesCount++;
-                        }
-                    }
-                }
-            }
-        }
-
-        return tilesCount;
-
     }
 
     public void repeatGame(View View) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -652,46 +652,47 @@ public class Start extends AppCompatActivity {
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileType;
             }
 
-            int tilesCount = 0;
+            int wordCount = 0;
 
             for (int i = 0; i < size(); i++) {
+                boolean wordFound = false;
                 parsedWordArrayFinal = tileList.parseWordIntoTiles(get(i).localWord);
-
                 wordInitialTile = parsedWordArrayFinal.get(0);
 
                 if (wordInitialTile != null) {
 
-                    if (differentiateTypes) {//checking if both tile and type match
+                    if (differentiateTypes) {// checking if both tile and type match
                         if (MULTIFUNCTIONS.contains(someGameTileWithoutSuffix)) {
                             wordInitialTileType = Start.tileList.getInstanceTypeForMixedTile(0, get(i).nationalWord);
-                        } else {//not dealing with a multifunction symbol
+                        } else {// not dealing with a multifunction symbol
                             wordInitialTileType = tileHashMap.find(wordInitialTile).tileType;
                         }
 
                         if (wordInitialTile.equals(someGameTileWithoutSuffix) && someGameTileType.equals(wordInitialTileType)) {
-                            tilesCount++;
+                            wordFound = true;
                         }
 
-                    } else {//Not differentiating types, only matching tile to tile
+                    } else {// Not differentiating types, only matching tile to tile
                         if (parsedWordArrayFinal.get(0).equals(someGameTile)) {
-                            tilesCount++;
+                            wordFound = true;
                         }
                     }
 
                 }
+                if (wordFound) {
+                    wordCount++;
+                }
             }
-
-            return tilesCount;
-
+            return wordCount;
         }
 
-        public String[][] returnGroupOneWords(String someGameTile, int tilesCount) {
+        public String[][] returnGroupOneWords(String someGameTile, int wordCount) {
             // Group One = words that START with the active tile
 
             ArrayList<String> parsedWordArrayFinal;
             int hitsCounter = 0;
 
-            String[][] wordsWithNonInitialTiles = new String[tilesCount][2];
+            String[][] wordsWithNonInitialTiles = new String[wordCount][2];
 
             String wordInitialTile;
             String wordInitialTileType;
@@ -767,9 +768,10 @@ public class Start extends AppCompatActivity {
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileType;
             }
 
-            int tilesCount = 0;
+            int wordCount = 0;
 
             for (int i = 0; i < size(); i++) {
+                boolean wordFound = false;
                 parsedWordArrayFinal = tileList.parseWordIntoTiles(get(i).localWord);
 
                 for (int k = 1; k < parsedWordArrayFinal.size(); k++) {
@@ -785,29 +787,31 @@ public class Start extends AppCompatActivity {
                             }
 
                             if (tileInFocus.equals(someGameTileWithoutSuffix) && someGameTileType.equals(tileInFocusType)) {
-                                tilesCount++;
+                                wordFound = true;
                             }
 
                         } else {//Not differentiating types, only matching tile to tile
                             if (parsedWordArrayFinal.get(k).equals(someGameTile)) {
-                                tilesCount++;
+                                wordFound = true;
                             }
                         }
                     }
                 }
+                if (wordFound) {
+                    wordCount++;
+                }
             }
-
-            return tilesCount;
-
+            return wordCount;
         }
 
-        public String[][] returnGroupTwoWords(String someGameTile, int tilesCount) {
+
+        public String[][] returnGroupTwoWords(String someGameTile, int wordCount) {
             // Group Two = words that contain the active tile non-initially (but excluding initially)
 
             ArrayList<String> parsedWordArrayFinal;
             int hitsCounter = 0;
 
-            String[][] wordsWithNonInitialTiles = new String[tilesCount][2];
+            String[][] wordsWithNonInitialTiles = new String[wordCount][2];
 
             String tileInFocus;
             String tileInFocusType;
@@ -884,9 +888,10 @@ public class Start extends AppCompatActivity {
                 someGameTileType = tileHashMap.find(someGameTileWithoutSuffix).tileType;
             }
 
-            int tilesCount = 0;
+            int wordCount = 0;
 
             for (int i = 0; i < size(); i++) {
+                boolean wordFound = false;
                 parsedWordArrayFinal = tileList.parseWordIntoTiles(get(i).localWord);
 
                 for (int k = 0; k < parsedWordArrayFinal.size(); k++) {
@@ -902,29 +907,31 @@ public class Start extends AppCompatActivity {
                             }
 
                             if (tileInFocus.equals(someGameTileWithoutSuffix) && someGameTileType.equals(tileInFocusType)) {
-                                tilesCount++;
+                                wordFound = true;
                             }
 
                         } else {//Not differentiating types, only matching tile to tile
                             if (parsedWordArrayFinal.get(k).equals(someGameTile)) {
-                                tilesCount++;
+                                wordFound = true;
                             }
                         }
                     }
                 }
+                if (wordFound) {
+                    wordCount++;
+                }
             }
-
-            return tilesCount;
-
+            return wordCount;
         }
 
-        public String[][] returnGroupThreeWords(String someGameTile, int tilesCount) {
+
+        public String[][] returnGroupThreeWords(String someGameTile, int wordCount) {
             // Group Three = words containing the active tile anywhere (initial and/or non-initial)
 
             ArrayList<String> parsedWordArrayFinal;
             int hitsCounter = 0;
 
-            String[][] wordsContainingSomeGameTile = new String[tilesCount][2];
+            String[][] wordsContainingSomeGameTile = new String[wordCount][2];
 
             String tileInFocus;
             String tileInFocusType;
@@ -975,17 +982,16 @@ public class Start extends AppCompatActivity {
                     }
                 }
             }
-
             return wordsContainingSomeGameTile;
-
-
         }
+
 
         public String stripInstructionCharacters(String localWord) {
             // The period instructs the parseWord method to force a tile break
             String newString = localWord.replaceAll("[.]", "");
             return newString;
         }
+
 
         public int returnPositionInWordList(String someLWCWord) {
 
@@ -1000,6 +1006,7 @@ public class Start extends AppCompatActivity {
             return wordPosition;
 
         }
+
 
         public ArrayList<String[]> returnFourWords(String wordInLOP, String wordInLWC, String refTile, int challengeLevel, String refType, String choiceType) {
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -36,7 +36,7 @@ public class Start extends AppCompatActivity {
 
     public static TileListWithMultipleTypes tileListWithMultipleTypes;
 
-    public static TileListWithMultipleTypes tileListWithMultiTypesNoSAD;
+    public static TileListWithMultipleTypes tileListWithMultipleTypesNoSAD;
 
     public static WordList wordList;     // KP  // from aa_wordlist.txt
 
@@ -57,9 +57,9 @@ public class Start extends AppCompatActivity {
 
     public static TileHashMap tileHashMapNoSAD;
 
-    public static TileHashMapWithMultipleTypes tileHashMapWithMultipleTypes;
+    public static TileTypeHashMapWithMultipleTypes tileTypeHashMapWithMultipleTypes;
 
-    public static TileHashMapWithMultipleTypes tileHashMapWithMultiTypesNoSAD;
+    public static TileTypeHashMapWithMultipleTypes tileTypeHashMapWithMultipleTypesNoSAD;
 
     public static WordHashMap wordHashMap;
 
@@ -291,25 +291,29 @@ public class Start extends AppCompatActivity {
         if (differentiateTypes) {
 
             tileListWithMultipleTypes = new TileListWithMultipleTypes();
-            tileListWithMultiTypesNoSAD = new TileListWithMultipleTypes();
-            tileHashMapWithMultipleTypes = new TileHashMapWithMultipleTypes();
-            tileHashMapWithMultiTypesNoSAD = new TileHashMapWithMultipleTypes();
+            tileListWithMultipleTypesNoSAD = new TileListWithMultipleTypes();
+            tileTypeHashMapWithMultipleTypes = new TileTypeHashMapWithMultipleTypes();
+            tileTypeHashMapWithMultipleTypesNoSAD = new TileTypeHashMapWithMultipleTypes();
 
             for (Tile tile : tileList) {
                 tileListWithMultipleTypes.add(tile.baseTile);
-                tileHashMapWithMultipleTypes.put(tile.baseTile, tile.tileType);
+                tileTypeHashMapWithMultipleTypes.put(tile.baseTile, tile.tileType);
                 if (!tile.tileType.equals("SAD")) {
-                    tileListWithMultiTypesNoSAD.add(tile.baseTile);
-                    tileHashMapWithMultiTypesNoSAD.put(tile.baseTile, tile.tileType);
+                    tileListWithMultipleTypesNoSAD.add(tile.baseTile);
+                    tileTypeHashMapWithMultipleTypesNoSAD.put(tile.baseTile, tile.tileType);
                 }
                 // SAD should never have a 2nd or 3rd type other than "none"
                 if (!tile.tileTypeB.equals("none")) {
                     tileListWithMultipleTypes.add(tile.baseTile + "B");
-                    tileHashMapWithMultipleTypes.put(tile.baseTile + "B", tile.tileTypeB);
+                    tileTypeHashMapWithMultipleTypes.put(tile.baseTile + "B", tile.tileTypeB);
+                    tileListWithMultipleTypesNoSAD.add(tile.baseTile + "B");
+                    tileTypeHashMapWithMultipleTypesNoSAD.put(tile.baseTile + "B", tile.tileTypeB);
                 }
                 if (!tile.tileTypeC.equals("none")) {
                     tileListWithMultipleTypes.add(tile.baseTile + "C");
-                    tileHashMapWithMultipleTypes.put(tile.baseTile + "C", tile.tileTypeC);
+                    tileTypeHashMapWithMultipleTypes.put(tile.baseTile + "C", tile.tileTypeC);
+                    tileListWithMultipleTypesNoSAD.add(tile.baseTile + "C");
+                    tileTypeHashMapWithMultipleTypesNoSAD.put(tile.baseTile + "C", tile.tileTypeC);
                 }
             }
         }
@@ -1641,7 +1645,7 @@ public class Start extends AppCompatActivity {
 
     }
 
-    public class TileHashMapWithMultipleTypes extends HashMap<String, String> {
+    public class TileTypeHashMapWithMultipleTypes extends HashMap<String, String> {
         public String text;
         public String type;
     }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
@@ -171,7 +171,7 @@ public class Sudan extends GameActivity {
         } else {
             int total = 0;
             if (differentiateTypes) {
-                total = tileListWithMultiTypesNoSAD.size() - TILE_BUTTONS.length;
+                total = tileListWithMultipleTypesNoSAD.size() - TILE_BUTTONS.length;
             } else {
                 total = tileListNoSAD.size() - TILE_BUTTONS.length; // 1 page is accounted for in numPages init
             }
@@ -187,12 +187,12 @@ public class Sudan extends GameActivity {
     public void splitTileListAcrossPages() {
 
         if (differentiateTypes) {
-            int numTiles = tileListWithMultiTypesNoSAD.size();
+            int numTiles = tileListWithMultipleTypesNoSAD.size();
             int cont = 0;
             for (int i = 0; i < numPages + 1; i++) {
                 for (int j = 0; j < TILE_BUTTONS.length; j++) {
                     if (cont < numTiles) {
-                        pagesList.get(i).add(tileListWithMultiTypesNoSAD.get(cont));
+                        pagesList.get(i).add(tileListWithMultipleTypesNoSAD.get(cont));
                     }
                     cont++;
                 }
@@ -340,7 +340,7 @@ public class Sudan extends GameActivity {
             String type;
             if (differentiateTypes) {
                 // JP: what I need is a way to access the type of a tile in the tileListWithMultipleTypes
-                type = tileHashMapWithMultiTypesNoSAD.get(pagesList.get(page).get(k));
+                type = tileTypeHashMapWithMultipleTypesNoSAD.get(pagesList.get(page).get(k));
             } else {
                 type = tileHashMapNoSAD.find(pagesList.get(page).get(k)).tileType;
             }
@@ -453,7 +453,7 @@ public class Sudan extends GameActivity {
             if (!differentiateTypes) {// Not differentiating the uses of multifunction tiles
                 tileText = tileListNoSAD.get(justClickedKey - 1).baseTile;
             } else { // differentiateMultipleTypes ==2. We ARE differentiating the uses of multifunction tiles
-                tileText = tileListWithMultiTypesNoSAD.get(justClickedKey - 1);
+                tileText = tileListWithMultipleTypesNoSAD.get(justClickedKey - 1);
             }
 
             gameSounds.play(tileAudioIDs.get(tileText), 1.0f, 1.0f, 2, 0, 1.0f);


### PR DESCRIPTION
Previously, if a tile occurred twice in a word, that word would occur twice in the slides for that tile in Romania. 
In the loop through each word's tiles, I now have it break if the tile has been matched, so that the word is not added twice.

While I was doing this, I noticed duplicate code and wondered if it would be easier to return word count and word group in one method for each, where we pass the scan setting to the method. There would be less code to maintain. I implemented this change.  I also removed the duplicate methods from the Romania class. We can call the non-static methods from Start.wordList (a static object).