### PR TITLE
Allow overlap in wordsearch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 87
-        versionName "1.3.0"
+        versionCode 88
+        versionName "1.3.1"
 
         // API 14 = Ice Cream (4.0)
         // API 16 = Jelly Bean (4.1) - required for Firebase


### PR DESCRIPTION
Previously, we generated some words that overlap in the grid but would not allow a user to click tiles that were part of found words. So, overlapping words could not be found, and there was no way to finish the round, or to advance to another round without exiting and reentering the game. These code changes allow players to click tiles contained in words already found in the wordsearch grid. 