### PR TITLE
Wordsearch bugfix: reset background of double-clicked tile to white

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 89
-        versionName "1.3.2"
+        versionCode 90
+        versionName "1.3.3"
 
         // API 14 = Ice Cream (4.0)
         // API 16 = Jelly Bean (4.1) - required for Firebase

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -477,6 +477,10 @@ public class Myanmar extends GameActivity {
             secondClickIndex = justClickedTile - 1;
             secondClickPreviousBackgroundColor = tileColor;
             secondClickPreviousTextColor = textColor;
+            if (tileColor == Color.parseColor("#FFEB3B")) { // For a second click to a yellow tile, reset to white with black text
+                secondClickPreviousBackgroundColor = Color.parseColor("#FFFFFF");
+                secondClickPreviousTextColor = Color.parseColor("#000000");
+            }
             evaluateTwoClicks();
         }
         setAllTilesClickable();


### PR DESCRIPTION
PR #75 (Allow overlap in wordsearch) introduced a small bug into the wordsearch game.

Bug: After clicking the same tile twice, the tile's background stays yellow, indicating that it is selected, even though the tile is deselected and the player can try other pairs of tiles.

Expected behavior: After clicking the same tile twice, the tile's background should reset to white to indicate that it is deselected.

This PR produces the expected behavior by checking to see if the second tile clicked is yellow (therefore already selected) and resetting its background color to white. 