### PR TITLE
Prevent issue with 0-width characters like saltillo

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -866,7 +866,12 @@ public class Start extends AppCompatActivity {
             String activeTileType;
             String activeTileWithoutSuffix;
 
-            activeTileTypeSuffix = Character.toString(activeTile.charAt(activeTile.length() - 1));
+            if (activeTile.length() > 0){
+                activeTileTypeSuffix = Character.toString(activeTile.charAt(activeTile.length() - 1));
+            } else {
+                activeTileTypeSuffix = ""; // Prevents issues with recognizing "zero-width" characters such as saltillo
+            }
+
             if (activeTileTypeSuffix.equals("B")) {
                 activeTileWithoutSuffix = activeTile.substring(0, activeTile.length() - 1);
                 activeTileType = tileHashMap.find(activeTileWithoutSuffix).tileTypeB;
@@ -936,7 +941,11 @@ public class Start extends AppCompatActivity {
             String activeTileType;
             String activeTileWithoutSuffix;
 
-            activeTileTypeSuffix = Character.toString(activeTile.charAt(activeTile.length() - 1));
+            if (activeTile.length() > 0) {
+                activeTileTypeSuffix = Character.toString(activeTile.charAt(activeTile.length() - 1));
+            } else { // Prevent mysterious issues with "zero-width" characters like saltillo
+                activeTileTypeSuffix = "";
+            }
             if (activeTileTypeSuffix.equals("B")) {
                 activeTileWithoutSuffix = activeTile.substring(0, activeTile.length() - 1);
                 activeTileType = tileHashMap.find(activeTileWithoutSuffix).tileTypeB;


### PR DESCRIPTION
Sometimes, the saltillo character (U+A78C) is perceived in Java to have a char length of 0. So, this PR adds to the logic that checks the last char of a tile to make sure the tile it is checking is not 0-length, and if it is, to handle it appropriately.