### PR TITLE
Bugfix: Back arrow to reverse scroll in Romania

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -409,23 +409,23 @@ public class Romania extends GameActivity {
     public void goToPreviousTile(View View) {
         directionIsForward = false;
         String oldTile = activeTile;
-        activeTile = cumulativeStageBasedTileList.returnNextAlphabetTileDifferentiateTypes(oldTile);
+        activeTile = cumulativeStageBasedTileList.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
         if (scanSetting == 1) {
             while (Start.wordList.numberOfWordsForActiveTile(activeTile, 1) == 0) {
                 // JP: prevents user from having to click
                 // the arrow multiple times to skip irrelevant tiles that are never word-initial
                 oldTile = activeTile;
-                activeTile = cumulativeStageBasedTileList.returnNextAlphabetTileDifferentiateTypes(oldTile);
+                activeTile = cumulativeStageBasedTileList.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
             }
         } else if (scanSetting == 2) {
             while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || Start.wordList.numberOfWordsForActiveTile(activeTile, 2) == 0) {
                 oldTile = activeTile;
-                activeTile = cumulativeStageBasedTileList.returnNextAlphabetTileDifferentiateTypes(oldTile);
+                activeTile = cumulativeStageBasedTileList.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
             }
         } else { // scanSetting 3
             while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || Start.wordList.numberOfWordsForActiveTile(activeTile, 3) == 0) {
                 oldTile = activeTile;
-                activeTile = cumulativeStageBasedTileList.returnNextAlphabetTileDifferentiateTypes(oldTile);
+                activeTile = cumulativeStageBasedTileList.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
             }
         }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -1905,13 +1905,13 @@ public class Start extends AppCompatActivity {
         public String returnPreviousAlphabetTileDifferentiateTypes(String oldTile) {
 
             String previousTile = "";
-            for (int i = tileListWithMultipleTypes.size() - 1; i >= 0; i--) {
+            for (int i = size() - 1; i >= 0; i--) {
 
-                if (tileListWithMultipleTypes.get(i).equals(oldTile)) {
+                if (get(i).equals(oldTile)) {
                     if (i > 0) {
-                        previousTile = tileListWithMultipleTypes.get(i - 1);
+                        previousTile = get(i - 1);
                     } else// if (i == 0) {
-                        previousTile = tileListWithMultipleTypes.get(tileListWithMultipleTypes.size() - 1);
+                        previousTile = get(size() - 1);
                 }
             }
 


### PR DESCRIPTION
The returnNextAlphabetTileDifferentiateTypes method was misplaced in several spots in the goToPreviousTile() function of the Romania activity. This PR fixes that by replacing it with the returnPreviousAlphabetTileDifferentiateTypes method. 

It also necessarily corrects the method to be called on any instance of TileListWIthMultipleTypes, (here the cumulativeStageBasedTileList) instead of on the specific static tileListWithMultipleTypes object of the Start class.