### PR TITLE
Bugfix: Store memory image and text on same chosen word (v.1.3.7)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 93
-        versionName "1.3.6"
+        versionCode 94
+        versionName "1.3.7"
 
         // API 14 = Ice Cream (4.0)
         // API 16 = Jelly Bean (4.1) - required for Firebase

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -179,13 +179,24 @@ public class Mexico extends GameActivity {
         // KP, Oct 2020
         int cardsToSetUp = visibleTiles / 2;   // this is half the number of cards
 
-        for (int i = 0; i < visibleTiles; i++) {
+        for (int i = 0; i < cardsToSetUp; i++) {
             chooseWord();
             String[] content = new String[]
                     {
                             wordInLWC,
                             wordInLOP,
-                            i < cardsToSetUp ? "TEXT" : "IMAGE",
+                            "TEXT",
+                            "UNSELECTED",
+                            String.valueOf(wordHashMap.get(wordInLWC).duration),    // audio clip duration in seconds
+                            wordHashMap.get(wordInLWC).adjustment,    // font adjustment
+
+                    };
+            memoryCollection.add(content);
+            content = new String[]
+                    {
+                            wordInLWC,
+                            wordInLOP,
+                            "IMAGE",
                             "UNSELECTED",
                             String.valueOf(wordHashMap.get(wordInLWC).duration),    // audio clip duration in seconds
                             wordHashMap.get(wordInLWC).adjustment,    // font adjustment


### PR DESCRIPTION
When changing some logic for word choices, I mistakenly removed code that ensured the same word was used for image and text card pairs in Memory - which makes the game unplayable! This PR fixes that.