### PR TITLE
Fix bugs in four games and change when points are incremented in two games.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 97
-        versionName "1.4.0"
+        versionCode 98
+        versionName "1.4.1"
 
         // API 14 = Ice Cream (4.0)
         // API 16 = Jelly Bean (4.1) - required for Firebase

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -118,6 +118,9 @@ public class Colombia extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
+        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
+        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+
         if (getAudioInstructionsResID() == 0) {
             centerGamesHomeImage();
         }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
@@ -105,6 +105,7 @@ public class Ecuador extends GameActivity {
             centerGamesHomeImage();
         }
 
+        visibleTiles = TILE_BUTTONS.length;
         updatePointsAndTrackers(0);
         playAgain();
     }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -134,14 +134,14 @@ public class Mexico extends GameActivity {
 
     public void repeatGame(View View) {
 
-//        if (mediaPlayerIsPlaying) {
-//            return;
-//        }
-//        // Closing and restarting the activity for each round is not ideal, but it seemed to be helping with memory issues...
-//        Intent intent = getIntent();
-//        intent.setClass(this, Mexico.class);    // so we retain the Extras
-//        startActivity(intent);
-//        finish();
+        if (mediaPlayerIsPlaying) {
+            return;
+        }
+        // Closing and restarting the activity for each round is not ideal, but it seemed to be helping with memory issues...
+        Intent intent = getIntent();
+        intent.setClass(this, Mexico.class);    // so we retain the Extras
+        startActivity(intent);
+        finish();
         playAgain();
 
     }
@@ -299,9 +299,12 @@ public class Mexico extends GameActivity {
             cardA.setTextColor(tileColor); // theme color
             cardB.setTextColor(tileColor); // theme color
 
-            updatePointsAndTrackers(1);
-
             wordInLWC = memoryCollection.get(cardHitA)[0];
+
+            if (pairsCompleted == (visibleTiles / 2)) {
+                updatePointsAndTrackers((visibleTiles / 2));
+            }
+
             playCorrectSoundThenActiveWordClip(pairsCompleted == (visibleTiles / 2));
 
         } else {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -626,10 +626,11 @@ public class Myanmar extends GameActivity {
 
             }
 
-            updatePointsAndTrackers(2);
-
             // Play word and "correct" sounds and then clear the image from word bank
             wordInLWC = sevenWordsInLopLwc[indexOfFoundWord][0];
+            if (wordsCompleted == completionGoal) {
+                updatePointsAndTrackers(wordsCompleted);
+            }
             playCorrectSoundThenActiveWordClip(wordsCompleted == completionGoal);
             handler = new Handler();
             handler.postDelayed(clearImageFromImageBank(indexOfFoundWord), Long.valueOf(wordDurations.get(wordInLWC) + correctSoundDuration));

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -564,7 +564,7 @@ public class Thailand extends GameActivity {
                 switch (refType) {
                     case "TILE_LOWER":
                     case "TILE_AUDIO":
-                        parsedChosenWordArrayFinal = tileList.parseWordIntoTiles(chosenItemText);
+                        parsedChosenWordArrayFinal = tileList.parseWordIntoTiles(fourChoices.get(t)[1]);
                         if (parsedChosenWordArrayFinal.get(0).equals(refItemText)) {
                             goodMatch = true;
                         }
@@ -578,7 +578,7 @@ public class Thailand extends GameActivity {
                         }
                         break;
                     case "TILE_UPPER":
-                        parsedChosenWordArrayFinal = tileList.parseWordIntoTiles(chosenItemText);
+                        parsedChosenWordArrayFinal = tileList.parseWordIntoTiles(fourChoices.get(t)[1]);
                         if (refItemText != null && refItemText.equals(tileListNoSAD.get(tileListNoSAD
                                 .returnPositionInAlphabet(parsedChosenWordArrayFinal.get(0))).upperTile)) {
                             goodMatch = true;


### PR DESCRIPTION
Thailand.java: fix the words-into-tile parsing issue where a word stored as |g.uun| would be interpreted to begin with tile |gu| in some contexts because the parser was analyzing a period-stripped form.

Ecuador.java: insert line so that visibleTiles is represented correctly.

Mexico.java: un-uncomment lines that reloads game after each round. This is a temporary solution, need to investigate underlying issue where you can play one round of Memory without issues then in the second round the cards lock up after the first click or first match.

Colombia.java: add missing line to add game number and internal code to title bar.

Mexico.java and Myanmar.java: wait to increment points and wait to advance tracker until the full round is complete (all matches made in Memory, all words found in Word Search).