### PR TITLE
Match the correct button to audio in Sudan.java

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
@@ -297,36 +297,28 @@ public class Sudan extends GameActivity {
         setAllTilesUnclickable();
         setOptionsRowUnclickable();
 
-        String viewText = "";
-        int justClickedKey = Integer.parseInt((String) view.getTag()) + (currentPageNumber * 35);
+        String viewText = pagesList.get(currentPageNumber).get(Integer.parseInt((String) view.getTag())-1);
+        int audioId = 0;
+        int duration = 0;
         if (syllableGame.equals("S")) {
-            viewText = Start.syllableList.get(justClickedKey - 1).syllable;
-
-
-            gameSounds.play(syllableAudioIDs.get(viewText), 1.0f, 1.0f, 2, 0, 1.0f);
-            soundSequencer.postDelayed(new Runnable() {
-                public void run() {
-                    if (repeatLocked) {
-                        setAllTilesClickable();
-                    }
-                    setOptionsRowClickable();
-                }
-
-            }, 925);
+            audioId = syllableAudioIDs.get(viewText);
+            duration = syllableDurations.get(viewText);
 
         } else {
-            viewText = cumulativeStageBasedTileList.get(justClickedKey - 1);
-            gameSounds.play(tileAudioIDs.get(viewText), 1.0f, 1.0f, 2, 0, 1.0f);
-            soundSequencer.postDelayed(new Runnable() {
-                public void run() {
-                    if (repeatLocked) {
-                        setAllTilesClickable();
-                    }
-                    setOptionsRowClickable();
-                }
-
-            }, 925);
+            audioId = tileAudioIDs.get(viewText);
+            duration = tileDurations.get(viewText);
         }
+
+        gameSounds.play(audioId, 1.0f, 1.0f, 2, 0, 1.0f);
+        soundSequencer.postDelayed(new Runnable() {
+            public void run() {
+                if (repeatLocked) {
+                    setAllTilesClickable();
+                }
+                setOptionsRowClickable();
+            }
+
+        }, duration);
     }
 
     public void clickPicHearAudio(View view) {


### PR DESCRIPTION
In this PR, rather than accessing whole tile and syllable lists to find the right audio for each button, I access the pages of tiles/syllables assigned to actual buttons . These pages are set up to exclude SAD (space and dash) tiles. This fixes a bug where tiles were being accessed out of order due to SAD tiles at the beginning of the cumulative stage-based tile list (which are not found on the page).

Edit: I also added in the correct durations for the tile and syllable audio, and I condensed the code a bit to remove some duplicated lines for the Syllable and Tile modes.