### PR TITLE
Parsing of complex tiles such as those in Thai and Lao scripts

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/About.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/About.java
@@ -18,12 +18,16 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
 
+import static org.alphatilesapps.alphatiles.Start.langInfoList;
+import static org.alphatilesapps.alphatiles.Start.localAppName;
+import static org.alphatilesapps.alphatiles.Start.settingsList;
+
 public class About extends AppCompatActivity {
 
     Context context;
-    String scriptDirection = Start.langInfoList.find("Script direction (LTR or RTL)");
-    String hideSILlogoSetting = Start.settingsList.find("Hide SIL logo");
-    String hidePrivacyPolicySetting = Start.settingsList.find("Hide privacy policy");
+    String scriptDirection = langInfoList.find("Script direction (LTR or RTL)");
+    String hideSILlogoSetting = settingsList.find("Hide SIL logo");
+    String hidePrivacyPolicySetting = settingsList.find("Hide privacy policy");
     Boolean hideSILlogo;
     Boolean hidePrivacyPolicy;
 
@@ -35,25 +39,25 @@ public class About extends AppCompatActivity {
 
         setContentView(R.layout.about);
 
-        setTitle(Start.localAppName);
+        setTitle(localAppName);
 
         TextView localName = findViewById(R.id.gameNameInLOP);
-        localName.setText(Start.localAppName);
+        localName.setText(localAppName);
         TextView lgNamesPlusCountry = findViewById(R.id.langNamesPlusCountry);
-        if (Start.langInfoList.find("Lang Name (In Local Lang)").equals(Start.langInfoList.find("Lang Name (In English)"))) {
+        if (langInfoList.find("Lang Name (In Local Lang)").equals(langInfoList.find("Lang Name (In English)"))) {
             lgNamesPlusCountry.setText(context.getString(R.string.names_plus_countryB,
-                    Start.langInfoList.find("Lang Name (In Local Lang)"),
-                    Start.langInfoList.find("Lang Name (In English)"),
-                    Start.langInfoList.find("Country"))); // RR, KP
+                    langInfoList.find("Lang Name (In Local Lang)"),
+                    langInfoList.find("Lang Name (In English)"),
+                    langInfoList.find("Country"))); // RR, KP
         } else {
             lgNamesPlusCountry.setText(context.getString(R.string.names_plus_countryA,
-                    Start.langInfoList.find("Lang Name (In Local Lang)"),
-                    Start.langInfoList.find("Lang Name (In English)"),
-                    Start.langInfoList.find("Country"))); // RR, KP
+                    langInfoList.find("Lang Name (In Local Lang)"),
+                    langInfoList.find("Lang Name (In English)"),
+                    langInfoList.find("Country"))); // RR, KP
         }
 
         TextView photoAudioCredits = findViewById(R.id.photoAudioCredits);
-        photoAudioCredits.setText(Start.langInfoList.find("Audio and image credits"));
+        photoAudioCredits.setText(langInfoList.find("Audio and image credits"));
         photoAudioCredits.setMovementMethod(new ScrollingMovementMethod());
 
         TextView photoAudioCredits2 = findViewById(R.id.photoAudioCredits2);
@@ -73,7 +77,7 @@ public class About extends AppCompatActivity {
 
         TextView email = findViewById(R.id.email);
         email.setAutoLinkMask(Linkify.EMAIL_ADDRESSES);
-        String contactEmail = Start.langInfoList.find("Email");
+        String contactEmail = langInfoList.find("Email");
     if (contactEmail.equals("none") || contactEmail.equals(null)|| contactEmail.equals("")) {
             email.setText("");
         } else {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -66,7 +66,7 @@ public class Brazil extends GameActivity {
         Resources res = context.getResources();
         int audioInstructionsResID;
         try {
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
         } catch (NullPointerException e) {
             audioInstructionsResID = -1;
         }
@@ -123,9 +123,9 @@ public class Brazil extends GameActivity {
         if (challengeLevel < 4 && !syllableGame.equals("S")) {
 
             if (VOWELS.isEmpty()) {  // Makes sure VOWELS is populated only once when the app is running
-                for (int d = 0; d < Start.tileList.size(); d++) {
-                    if (Start.tileList.get(d).tileType.equals("V")) {
-                        VOWELS.add(Start.tileList.get(d).baseTile);
+                for (int d = 0; d < tileList.size(); d++) {
+                    if (tileList.get(d).tileType.contains("V")) {
+                        VOWELS.add(tileList.get(d).baseTile);
                     }
                 }
             }
@@ -142,9 +142,9 @@ public class Brazil extends GameActivity {
         } else {
 
             if (CONSONANTS.isEmpty()) {  // Makes sure CONSONANTS is populated only once when the app is running
-                for (int d = 0; d < Start.tileList.size(); d++) {
-                    if (Start.tileList.get(d).tileType.equals("C")) {
-                        CONSONANTS.add(Start.tileList.get(d).baseTile);
+                for (int d = 0; d < tileList.size(); d++) {
+                    if (tileList.get(d).tileType.equals("C")) {
+                        CONSONANTS.add(tileList.get(d).baseTile);
                     }
                 }
             }
@@ -153,19 +153,19 @@ public class Brazil extends GameActivity {
 
         }
 
-        if (MULTIFUNCTIONS.isEmpty()) {  // Makes sure MULTIFUNCTIONS is populated only once when the app is running
-            for (int d = 0; d < Start.tileList.size(); d++) {
-                if (!Start.tileList.get(d).tileTypeB.equals("none")) {
-                    MULTIFUNCTIONS.add(Start.tileList.get(d).baseTile);
+        if (MULTI_TYPE_TILES.isEmpty()) {  // Makes sure MULTIFUNCTIONS is populated only once when the app is running
+            for (int d = 0; d < tileList.size(); d++) {
+                if (!tileList.get(d).tileTypeB.equals("none")) {
+                    MULTI_TYPE_TILES.add(tileList.get(d).baseTile);
                 }
             }
         }
 
-        Collections.shuffle(MULTIFUNCTIONS);
+        Collections.shuffle(MULTI_TYPE_TILES);
 
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
 
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
         if (syllableGame.equals("S")) {
             visibleTiles = 4;
         } else {
@@ -197,7 +197,7 @@ public class Brazil extends GameActivity {
         if (syllableGame.equals("S")) {
             sortableSyllArray = (Start.SyllableList) syllableList.clone(); // JP
         } else {
-            sortableTilesArray = (Start.TileList) Start.tileList.clone(); // KP
+            sortableTilesArray = (Start.TileList) tileList.clone(); // KP
         }
 
         if (getAudioInstructionsResID() == 0) {
@@ -261,7 +261,7 @@ public class Brazil extends GameActivity {
         if (syllableGame.equals("S")) {
             parsedWordArrayFinal = syllableList.parseWordIntoSyllables(wordInLOP);
         } else {
-            parsedWordArrayFinal = Start.tileList.parseWordIntoTiles(wordInLOP);
+            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP);
         }
 
 
@@ -278,12 +278,12 @@ public class Brazil extends GameActivity {
 
                         nextTile = parsedWordArrayFinal.get(i);
                         // Include if a simple consonant
-                        if (CONSONANTS.contains(nextTile) && !MULTIFUNCTIONS.contains(nextTile)) {
+                        if (CONSONANTS.contains(nextTile) && !MULTI_TYPE_TILES.contains(nextTile)) {
                             proceed = true;
                         }
                         // Include if a multi-function symbol that is a consonant in this instance
-                        if (MULTIFUNCTIONS.contains(nextTile)) {
-                            String instanceType = Start.tileList.getInstanceTypeForMixedTile(i, wordInLWC);
+                        if (MULTI_TYPE_TILES.contains(nextTile)) {
+                            String instanceType = tileList.getInstanceTypeForMixedTile(i, parsedWordArrayFinal, wordInLOP);
                             if (instanceType.equals("C")) {
                                 proceed = true;
                             }
@@ -296,13 +296,13 @@ public class Brazil extends GameActivity {
 
                         nextTile = parsedWordArrayFinal.get(i);
                         // Include if a simple tone marker
-                        if (TONES.contains(nextTile) && !MULTIFUNCTIONS.contains(nextTile)) {
+                        if (TONES.contains(nextTile) && !MULTI_TYPE_TILES.contains(nextTile)) {
                             proceed = true;
                         }
                         // Include if a multi-function symbol that is a tone marker in this instance
-                        if (MULTIFUNCTIONS.contains(nextTile)) {
-                            String instanceType = Start.tileList.getInstanceTypeForMixedTile(i, wordInLWC);
-                            if (instanceType.equals("T")) {
+                        if (MULTI_TYPE_TILES.contains(nextTile)) {
+                            String instanceType = tileList.getInstanceTypeForMixedTile(i, parsedWordArrayFinal, wordInLOP);
+                            if (instanceType.equals("T") || instanceType.equals("AD")) {
                                 proceed = true;
                             }
                         }
@@ -314,13 +314,13 @@ public class Brazil extends GameActivity {
 
                         nextTile = parsedWordArrayFinal.get(i);
                         // Include if a simple vowel
-                        if (VOWELS.contains(nextTile) && !MULTIFUNCTIONS.contains(nextTile)) {
+                        if (VOWELS.contains(nextTile) && !MULTI_TYPE_TILES.contains(nextTile)) {
                             proceed = true;
                         }
                         // Include if a multi-function symbol that is a vowel in this instance
-                        if (MULTIFUNCTIONS.contains(nextTile)) {
-                            String instanceType = Start.tileList.getInstanceTypeForMixedTile(i, wordInLWC);
-                            if (instanceType.equals("V")) {
+                        if (MULTI_TYPE_TILES.contains(nextTile)) {
+                            String instanceType = tileList.getInstanceTypeForMixedTile(i, parsedWordArrayFinal, wordInLOP);
+                            if (instanceType.contains("V")) {
                                 proceed = true;
                             }
                         }
@@ -349,7 +349,7 @@ public class Brazil extends GameActivity {
             for (int i = 0; i < parsedWordArrayFinal.size(); i++) {
                 possibleIndices.add(i);
             }
-            while (repeat) { // JP: changed from 200 chances to keeping track
+            while (repeat && possibleIndices.size()>0) { // JP: changed from 200 chances to keeping track of
 
                 // JP: index is no longer corresponding to the index we remove from the word
                 index = rand.nextInt(possibleIndices.size());
@@ -362,14 +362,14 @@ public class Brazil extends GameActivity {
                     index_to_remove = possibleIndices.get(index);
                     possibleIndices.remove(possibleIndices.get(index));
                 }
-                if (MULTIFUNCTIONS.contains(correctTile)) {
-                    instanceType = Start.tileList.getInstanceTypeForMixedTile(index, wordInLWC);
+                if (MULTI_TYPE_TILES.contains(correctTile)) {
+                    instanceType = tileList.getInstanceTypeForMixedTile(index, parsedWordArrayFinal, wordInLOP);
                 } else {
-                    instanceType = Start.tileList.get(Start.tileList.returnPositionInAlphabet(correctTile)).tileType;
+                    instanceType = tileList.get(tileList.returnPositionInAlphabet(correctTile)).tileType;
                 }
 
                 if (challengeLevel < 4) {
-                    if (instanceType.equals("V")) {
+                    if (instanceType.contains("V")) {
                         repeat = false;
                     }
                 }
@@ -381,7 +381,7 @@ public class Brazil extends GameActivity {
                 }
 
                 if (challengeLevel == 7) {
-                    if (instanceType.equals("T")) {
+                    if (instanceType.equals("T") || instanceType.equals("AD")) {
                         repeat = false;
                     }
                 }
@@ -396,15 +396,11 @@ public class Brazil extends GameActivity {
             }
         }
 
+        ArrayList<String> parsedWordArrayFinalBeforeInsertingBlank = parsedWordArrayFinal;
         parsedWordArrayFinal.set(index_to_remove, "__");
+        String word = combineTilesToMakeWord(parsedWordArrayFinal, parsedWordArrayFinalBeforeInsertingBlank, index_to_remove, wordInLOP);
         TextView constructedWord = findViewById(R.id.activeWordTextView);
-        StringBuilder word = new StringBuilder();
-        for (String s : parsedWordArrayFinal) {
-            if (s != null) {
-                word.append(s);
-            }
-        }
-        constructedWord.setText(word.toString());
+        constructedWord.setText(word);
 
     }
 
@@ -588,8 +584,8 @@ public class Brazil extends GameActivity {
             // when Earth.challengeLevel == 2 || == 5
             correctTileRepresented = true;
             int correspondingRow = 0;
-            for (int d = 0; d < Start.tileList.size(); d++) {
-                if (Start.tileList.get(d).baseTile.equals(correctTile)) {
+            for (int d = 0; d < tileList.size(); d++) {
+                if (tileList.get(d).baseTile.equals(correctTile)) {
                     correspondingRow = d;
                     break;
                 }
@@ -612,9 +608,9 @@ public class Brazil extends GameActivity {
                 randomNum = rand.nextInt(visibleTiles); //
                 String nextTile;
                 if (randomNum == 0) {
-                    nextTile = Start.tileList.get(correspondingRow).baseTile;
+                    nextTile = tileList.get(correspondingRow).baseTile;
                 } else {
-                    nextTile = Start.tileList.get(correspondingRow).altTiles[randomNum - 1];
+                    nextTile = tileList.get(correspondingRow).altTiles[randomNum - 1];
                 }
                 if (!usedTiles.contains(nextTile)) {
                     gameTile.setText(nextTile);
@@ -668,13 +664,8 @@ public class Brazil extends GameActivity {
             }
 
             TextView constructedWord = findViewById(R.id.activeWordTextView);
-            StringBuilder word = new StringBuilder();
-            for (String s : parsedWordArrayFinal) {
-                if (s != null) {
-                    word.append(s);
-                }
-            }
-            constructedWord.setText(word.toString());
+            String word = combineTilesToMakeWord(parsedWordArrayFinal, parsedWordArrayFinal, -1, wordInLOP);
+            constructedWord.setText(word);
 
             for (int t = 0; t < visibleTiles; t++) {
                 TextView gameTile = findViewById(TILE_BUTTONS[t]);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
@@ -33,8 +33,8 @@ import static org.alphatilesapps.alphatiles.Start.*;
 
 public class ChoosePlayer extends AppCompatActivity {
     Context context;
-    String scriptDirection = Start.langInfoList.find("Script direction (LTR or RTL)");
-    String singleColorHex = Start.settingsList.find("Single hex color on avatar screen");
+    String scriptDirection = langInfoList.find("Script direction (LTR or RTL)");
+    String singleColorHex = settingsList.find("Single hex color on avatar screen");
 
     public static ArrayList<Integer> avatarIdList;
     public static ArrayList<Drawable> avatarJpgList;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
@@ -26,7 +26,7 @@ import static org.alphatilesapps.alphatiles.Start.*;
 
 public class Earth extends AppCompatActivity {
     Context context;
-    String scriptDirection = Start.langInfoList.find("Script direction (LTR or RTL)");
+    String scriptDirection = langInfoList.find("Script direction (LTR or RTL)");
 
     int playerNumber = -1;
     String playerString;
@@ -57,7 +57,7 @@ public class Earth extends AppCompatActivity {
             activePlayerImage.setRotationY(180);
         }
 
-        setTitle(Start.localAppName);
+        setTitle(localAppName);
 
         SharedPreferences prefs = getSharedPreferences(ChoosePlayer.SHARED_PREFS, MODE_PRIVATE);
         globalPoints = getIntent().getIntExtra("globalPoints", 0);
@@ -73,7 +73,7 @@ public class Earth extends AppCompatActivity {
         String playerName;
         String localWordForName = langInfoList.find("NAME in local language");
         if (localWordForName.equals("custom")) {
-            defaultName = Start.nameList.get(playerNumber - 1);
+            defaultName = nameList.get(playerNumber - 1);
         } else {
             defaultName = localWordForName + " " + playerNumber;
         }
@@ -123,12 +123,12 @@ public class Earth extends AppCompatActivity {
                     int doorIndex = Integer.parseInt((String) earthCL.getChildAt(j).getTag()) - 1;
                     String doorText = String.valueOf((pageNumber * doorsPerPage) + doorIndex + 1);
                     ((TextView) child).setText(doorText);
-                    if (((pageNumber * doorsPerPage) + doorIndex) >= Start.gameList.size()) {
+                    if (((pageNumber * doorsPerPage) + doorIndex) >= gameList.size()) {
                         ((TextView) child).setVisibility(View.INVISIBLE);
                     } else {
                         String project = "org.alphatilesapps.alphatiles.";
-                        String country = Start.gameList.get((pageNumber * doorsPerPage) + doorIndex).gameCountry;
-                        String challengeLevel = Start.gameList.get((pageNumber * doorsPerPage) + doorIndex).gameLevel;
+                        String country = gameList.get((pageNumber * doorsPerPage) + doorIndex).gameCountry;
+                        String challengeLevel = gameList.get((pageNumber * doorsPerPage) + doorIndex).gameLevel;
                         String syllableGame = gameList.get((pageNumber * doorsPerPage) + doorIndex).gameMode;
                         String stage;
                         if (gameList.get((pageNumber * doorsPerPage) + doorIndex).stage.equals("-")) {
@@ -150,7 +150,7 @@ public class Earth extends AppCompatActivity {
                         } else if (trackerCount < 12) {
                             ((TextView) child).setTextColor(Color.parseColor("#FFFFFF")); // white;
                         } else { // >= 12
-                            String textColor = Start.gameList.get((pageNumber * doorsPerPage) + doorIndex).gameColor;
+                            String textColor = gameList.get((pageNumber * doorsPerPage) + doorIndex).gameColor;
                             ((TextView) child).setTextColor(Color.parseColor(COLORS.get(Integer.parseInt(textColor))));
                         }
 
@@ -176,7 +176,7 @@ public class Earth extends AppCompatActivity {
                         Drawable wrappedDrawable = DrawableCompat.wrap(unwrappedDrawable);
                         if (changeColor) {
                             DrawableCompat.setTint(wrappedDrawable, Color.parseColor(COLORS.get(
-                                    Integer.parseInt(Start.gameList.get((pageNumber * doorsPerPage)
+                                    Integer.parseInt(gameList.get((pageNumber * doorsPerPage)
                                             + doorIndex).gameColor))));
                         }
                         ((TextView) child).setBackground(wrappedDrawable);
@@ -198,7 +198,7 @@ public class Earth extends AppCompatActivity {
         }
 
         ImageView forwardArrow = findViewById(R.id.goForward);
-        if (((pageNumber + 1) * doorsPerPage) < Start.gameList.size()) {
+        if (((pageNumber + 1) * doorsPerPage) < gameList.size()) {
             forwardArrow.setVisibility(View.VISIBLE);
         } else {
             forwardArrow.setVisibility(View.INVISIBLE);
@@ -234,10 +234,10 @@ public class Earth extends AppCompatActivity {
         finish();
         int doorIndex = Integer.parseInt((String) view.getTag()) - 1;
         String project = "org.alphatilesapps.alphatiles.";  // how to call this with code? It seemed to produce variable results
-        String country = Start.gameList.get((pageNumber * doorsPerPage) + doorIndex).gameCountry;
+        String country = gameList.get((pageNumber * doorsPerPage) + doorIndex).gameCountry;
         String activityClass = project + country;
 
-        int challengeLevel = Integer.parseInt(Start.gameList.get((pageNumber * doorsPerPage) + doorIndex).gameLevel);
+        int challengeLevel = Integer.parseInt(gameList.get((pageNumber * doorsPerPage) + doorIndex).gameLevel);
         int gameNumber = (pageNumber * doorsPerPage) + doorIndex + 1;
         String syllableGame = gameList.get((pageNumber * doorsPerPage) + doorIndex).gameMode;
         int stage;
@@ -276,7 +276,7 @@ public class Earth extends AppCompatActivity {
 
     public void goForward(View view) {
 
-        if (((pageNumber + 1) * doorsPerPage) < Start.gameList.size()) {
+        if (((pageNumber + 1) * doorsPerPage) < gameList.size()) {
             pageNumber++;
         }
         updateDoors();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
@@ -78,7 +78,7 @@ public class Ecuador extends GameActivity {
         int audioInstructionsResID;
         try {
 //          audioInstructionsResID = res.getIdentifier("ecuador_" + challengeLevel, "raw", context.getPackageName());
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
         } catch (NullPointerException e) {
             audioInstructionsResID = -1;
         }
@@ -456,7 +456,7 @@ public class Ecuador extends GameActivity {
         TextView chosenWord = findViewById(TILE_BUTTONS[t]);
         String chosenWordText = chosenWord.getText().toString();
 
-        if (chosenWordText.equals(Start.wordList.stripInstructionCharacters(wordInLOP))) {
+        if (chosenWordText.equals(wordList.stripInstructionCharacters(wordInLOP))) {
             // Good job!
             repeatLocked = false;
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -1,5 +1,7 @@
 package org.alphatilesapps.alphatiles;
 
+import static org.alphatilesapps.alphatiles.Start.gameList;
+import static org.alphatilesapps.alphatiles.Start.localAppName;
 import static org.alphatilesapps.alphatiles.Start.wordList;
 import static org.alphatilesapps.alphatiles.Start.syllableList;
 import static org.alphatilesapps.alphatiles.Start.tileListNoSAD;
@@ -56,7 +58,7 @@ public class Italy extends GameActivity {
         Resources res = context.getResources();
         int audioInstructionsResID;
         try {
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1)
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1)
                     .gameInstrLabel, "raw", context.getPackageName());
         } catch (NullPointerException e) {
             audioInstructionsResID = -1;
@@ -106,7 +108,7 @@ public class Italy extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         if (syllableGame.equals("S")) {
             sortableSyllArray = (Start.SyllableList) syllableList.clone();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
@@ -5,7 +5,6 @@ import androidx.constraintlayout.widget.ConstraintSet;
 
 import static org.alphatilesapps.alphatiles.Start.syllableList;
 import static org.alphatilesapps.alphatiles.Start.tileList;
-import static org.alphatilesapps.alphatiles.Start.wordList;
 
 import android.content.pm.ActivityInfo;
 import android.content.res.Resources;
@@ -84,7 +83,7 @@ public class Japan extends GameActivity {
         Resources res = context.getResources();
         int audioInstructionsResID;
         try {
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
 
         } catch (NullPointerException e) {
             audioInstructionsResID = -1;
@@ -137,7 +136,7 @@ public class Japan extends GameActivity {
 
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
 
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);     // forces landscape mode only
 
@@ -184,11 +183,11 @@ public class Japan extends GameActivity {
 
         chooseWord();
 
-        while(tileList.parseWordIntoTiles(wordInLOP).size() > MAX_TILES) { //JP: choose word w/ <= 12 tiles
+        while(tileList.parseWordIntoTiles(wordInLOP, wordInLOP).size() > MAX_TILES) { //JP: choose word w/ <= 12 tiles
             chooseWord();
         }
 
-        parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP);
+        parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP);
         parsedWordArrayFinal.removeAll(SAD);
         parsedWordSyllArrayFinal = syllableList.parseWordIntoSyllables(wordInLOP);
         parsedWordSyllArrayFinal.removeAll(SAD);
@@ -196,7 +195,7 @@ public class Japan extends GameActivity {
 
     private void displayWordRef() {
         TextView ref = findViewById(R.id.word);
-        ref.setText(wordList.stripInstructionCharacters(wordInLOP));
+        ref.setText(wordInLOPWithStandardizedSequenceOfCharacters(wordInLOP));
         ImageView image = findViewById(R.id.wordImage);
         int resID = getResources().getIdentifier(wordInLWC, "drawable", getPackageName());
         image.setImageResource(resID);
@@ -613,7 +612,7 @@ public class Japan extends GameActivity {
             // find number of tiles per correct syllable
             ArrayList<Integer> numTilesPerSyll = new ArrayList<>();
             for (String syll : parsedWordSyllArrayFinal) {
-                ArrayList<String> parsedSyllIntoTiles = tileList.parseWordIntoTiles(syll);
+                ArrayList<String> parsedSyllIntoTiles = tileList.parseWordIntoTilesPreliminary(syll);
                 numTilesPerSyll.add(parsedSyllIntoTiles.size());
                 parsedSyllIntoTiles.clear();
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -14,8 +14,6 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import org.alphatilesapps.alphatiles.Start.WordList;
-
 import static android.graphics.Color.BLACK;
 
 import androidx.constraintlayout.widget.ConstraintSet;
@@ -52,7 +50,7 @@ public class Mexico extends GameActivity {
         Resources res = context.getResources();
         int audioInstructionsResID;
         try {
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
         } catch (NullPointerException e) {
             audioInstructionsResID = -1;
         }
@@ -93,7 +91,7 @@ public class Mexico extends GameActivity {
         }
 
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         // new levels
         // Level 1: 3 pairs = 6
@@ -187,8 +185,8 @@ public class Mexico extends GameActivity {
                             wordInLOP,
                             "TEXT",
                             "UNSELECTED",
-                            String.valueOf(wordHashMap.get(wordInLWC).duration),    // audio clip duration in seconds
-                            wordHashMap.get(wordInLWC).adjustment,    // font adjustment
+                            String.valueOf(lwcWordHashMap.get(wordInLWC).duration),    // audio clip duration in seconds
+                            lwcWordHashMap.get(wordInLWC).adjustment,    // font adjustment
 
                     };
             memoryCollection.add(content);
@@ -198,8 +196,8 @@ public class Mexico extends GameActivity {
                             wordInLOP,
                             "IMAGE",
                             "UNSELECTED",
-                            String.valueOf(wordHashMap.get(wordInLWC).duration),    // audio clip duration in seconds
-                            wordHashMap.get(wordInLWC).adjustment,    // font adjustment
+                            String.valueOf(lwcWordHashMap.get(wordInLWC).duration),    // audio clip duration in seconds
+                            lwcWordHashMap.get(wordInLWC).adjustment,    // font adjustment
 
                     };
             memoryCollection.add(content);
@@ -238,7 +236,7 @@ public class Mexico extends GameActivity {
         // Can't remember if we tested if the problem went away once replaying the game involves finishing the activity and restarting
 
         if (appearance.equals("TEXT")) {
-            card.setText(Start.wordList.stripInstructionCharacters(wordInLOP));
+            card.setText(wordInLOPWithStandardizedSequenceOfCharacters(wordInLOP));
             card.setBackgroundResource(0);
         } else {
             card.setBackgroundResource(resID);
@@ -291,8 +289,8 @@ public class Mexico extends GameActivity {
             cardA.setBackgroundResource(0);
             cardB.setBackgroundResource(0);
 
-            cardA.setText(Start.wordList.stripInstructionCharacters(memoryCollection.get(cardHitA)[1]));
-            cardB.setText(Start.wordList.stripInstructionCharacters(memoryCollection.get(cardHitB)[1]));
+            cardA.setText(wordInLOPWithStandardizedSequenceOfCharacters(memoryCollection.get(cardHitA)[1]));
+            cardB.setText(wordInLOPWithStandardizedSequenceOfCharacters(memoryCollection.get(cardHitB)[1]));
 
             String tileColorStr = COLORS.get(cardHitA % 5);
             int tileColor = Color.parseColor(tileColorStr);
@@ -304,7 +302,6 @@ public class Mexico extends GameActivity {
             if (pairsCompleted == (visibleTiles / 2)) {
                 updatePointsAndTrackers((visibleTiles / 2));
             }
-
             playCorrectSoundThenActiveWordClip(pairsCompleted == (visibleTiles / 2));
 
         } else {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
@@ -18,11 +18,14 @@ import androidx.constraintlayout.widget.ConstraintSet;
 
 import java.util.Scanner;
 
+import static org.alphatilesapps.alphatiles.Start.langInfoList;
+import static org.alphatilesapps.alphatiles.Start.localAppName;
+
 
 public class Resources extends AppCompatActivity {
 
     Context context;
-    String scriptDirection = Start.langInfoList.find("Script direction (LTR or RTL)");
+    String scriptDirection = langInfoList.find("Script direction (LTR or RTL)");
 
     static int resourcesArraySize;      // the number of resources (plus the header row) in aa_resources.txt, as determined below
     static String[][] resourcesList;     // will capture the name, link and image name [3 items]
@@ -48,7 +51,7 @@ public class Resources extends AppCompatActivity {
 
         setContentView(R.layout.resources);
 
-        setTitle(Start.localAppName);
+        setTitle(localAppName);
 
         buildResourcesArray();
         loadResources();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -13,6 +13,8 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
 
 import static org.alphatilesapps.alphatiles.Start.*;
+import static org.alphatilesapps.alphatiles.Start.tileList;
+import static org.alphatilesapps.alphatiles.Start.wordList;
 
 public class Romania extends GameActivity {
 
@@ -33,7 +35,6 @@ public class Romania extends GameActivity {
     protected int[] getTileButtons() {
         return null;
     }
-
     protected int[] getWordImages() {
         return null;
     }
@@ -43,7 +44,7 @@ public class Romania extends GameActivity {
         Resources res = context.getResources();
         int audioInstructionsResID;
         try {
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
         } catch (Resources.NotFoundException e) {
             audioInstructionsResID = -1;
         }
@@ -71,7 +72,7 @@ public class Romania extends GameActivity {
         context = this;
         setContentView(R.layout.romania);
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         // Magnifying glass button (should probably be renamed)
         ImageView image = (ImageView) findViewById(R.id.repeatImage);
@@ -101,7 +102,7 @@ public class Romania extends GameActivity {
             button3.setVisibility(View.INVISIBLE);
         }
 
-        scanSetting = Integer.parseInt(Start.settingsList.find("Game 001 Scan Setting"));
+        scanSetting = Integer.parseInt(settingsList.find("Game 001 Scan Setting"));
 
         switch (scanSetting) {
             case 2:
@@ -117,7 +118,7 @@ public class Romania extends GameActivity {
         firstAlphabetTile = cumulativeStageBasedTileList.get(0);
         String startingAlphabetTile = prefs.getString("lastActiveTileGame001_player" + playerString, firstAlphabetTile);
 
-        scriptDirection = Start.langInfoList.find("Script direction (LTR or RTL)");
+        scriptDirection = langInfoList.find("Script direction (LTR or RTL)");
         if (scriptDirection.equals("RTL")) {
             ImageView backwardArrowImage = (ImageView) findViewById(R.id.backwardArrowImage);
             ImageView forwardArrowImage = (ImageView) findViewById(R.id.forwardArrowImage);
@@ -156,17 +157,17 @@ public class Romania extends GameActivity {
             case 2:
                 // CASE 2: check Group One, if count is zero, then check Group Two
                 // Group One = words that START with the active tile
-                groupCount = Start.wordList.numberOfWordsForActiveTile(activeTileString, 1);
+                groupCount = wordList.numberOfWordsForActiveTile(activeTileString, 1);
                 if (groupCount > 0) {
-                    groupOfWordsForActiveTile = Start.wordList.wordsForActiveTile(activeTileString, groupCount, 1);
+                    groupOfWordsForActiveTile = wordList.wordsForActiveTile(activeTileString, groupCount, 1);
                     failedToMatchInitialTile = false;
                 } else {
                     // Group Two = words that contain the active tile non-initially (but excluding initially)
                     failedToMatchInitialTile = true;
-                    groupCount = Start.wordList.numberOfWordsForActiveTile(activeTileString, 2);
+                    groupCount = wordList.numberOfWordsForActiveTile(activeTileString, 2);
 
                     if (groupCount > 0) {
-                        groupOfWordsForActiveTile = Start.wordList.wordsForActiveTile(activeTileString, groupCount, 2); // Group Two = words that contain the active tile non-initially (but excluding initially)
+                        groupOfWordsForActiveTile = wordList.wordsForActiveTile(activeTileString, groupCount, 2); // Group Two = words that contain the active tile non-initially (but excluding initially)
                     } else {
                         skipThisTile = true;
                     }
@@ -175,9 +176,9 @@ public class Romania extends GameActivity {
             case 3:
                 // CASE 3: check Group Three
                 // Group Three = words containing the active tile anywhere (initial and/or non-initial)
-                groupCount = Start.wordList.numberOfWordsForActiveTile(activeTileString, 3);
+                groupCount = wordList.numberOfWordsForActiveTile(activeTileString, 3);
                 if (groupCount > 0) {
-                    groupOfWordsForActiveTile = Start.wordList.wordsForActiveTile(activeTileString, groupCount, 3); // Group Three = words containing the active tile anywhere (initial and/or non-initial)
+                    groupOfWordsForActiveTile = wordList.wordsForActiveTile(activeTileString, groupCount, 3); // Group Three = words containing the active tile anywhere (initial and/or non-initial)
                 } else {
                     skipThisTile = true;
                 }
@@ -185,9 +186,9 @@ public class Romania extends GameActivity {
             default:
                 // CASE 1: check Group One
                 // Group One = words that START with the active tile
-                groupCount = Start.wordList.numberOfWordsForActiveTile(activeTileString, 1);
+                groupCount = wordList.numberOfWordsForActiveTile(activeTileString, 1);
                 if (groupCount > 0) {
-                    groupOfWordsForActiveTile = Start.wordList.wordsForActiveTile(activeTileString, groupCount, 1);
+                    groupOfWordsForActiveTile = wordList.wordsForActiveTile(activeTileString, groupCount, 1);
                     failedToMatchInitialTile = false;
                 } else { // There are no words at begin with the active tile
                     failedToMatchInitialTile = true;
@@ -213,12 +214,12 @@ public class Romania extends GameActivity {
 
             // Group 3 has all words containing the tile anywhere. This checks whether the current word is active-tile-initial or not
             if (scanSetting == 3) {
-                parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP); // KP
+                parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP); // KP
                 failedToMatchInitialTile = !activeTileString.equals(parsedWordArrayFinal.get(0));
             }
 
             TextView activeWord = (TextView) findViewById(R.id.activeWordTextView);
-            activeWord.setText(Start.wordList.stripInstructionCharacters(wordInLOP));
+            activeWord.setText(wordInLOPWithStandardizedSequenceOfCharacters(wordInLOP));
 
 
             ImageView image = (ImageView) findViewById(R.id.wordImage);
@@ -268,7 +269,7 @@ public class Romania extends GameActivity {
 
 
         if (scanSetting == 3) {
-            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP); // KP
+            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP); // KP
             failedToMatchInitialTile = !activeTileString.equals(parsedWordArrayFinal.get(0));
         }
 
@@ -276,7 +277,7 @@ public class Romania extends GameActivity {
         if (!skipThisTile) {
 
             TextView activeWord = (TextView) findViewById(R.id.activeWordTextView);
-            activeWord.setText(Start.wordList.stripInstructionCharacters(wordInLOP));
+            activeWord.setText(wordInLOPWithStandardizedSequenceOfCharacters(wordInLOP));
 
             ImageView image = (ImageView) findViewById(R.id.wordImage);
             if (groupCount > 0) {
@@ -327,7 +328,7 @@ public class Romania extends GameActivity {
 
 
         if (scanSetting == 3) {
-            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP); // KP
+            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP); // KP
             failedToMatchInitialTile = !activeTileString.equals(parsedWordArrayFinal.get(0));
         }
 
@@ -335,7 +336,7 @@ public class Romania extends GameActivity {
         if (!skipThisTile) {
 
             TextView activeWord = (TextView) findViewById(R.id.activeWordTextView);
-            activeWord.setText(Start.wordList.stripInstructionCharacters(wordInLOP));
+            activeWord.setText(wordInLOPWithStandardizedSequenceOfCharacters(wordInLOP));
 
             ImageView image = (ImageView) findViewById(R.id.wordImage);
             if (groupCount > 0) {
@@ -381,19 +382,19 @@ public class Romania extends GameActivity {
         activeTile = cumulativeStageBasedTileList.returnNextAlphabetTileDifferentiateTypes(oldTile);
 
         if (scanSetting == 1) {
-            while (Start.wordList.numberOfWordsForActiveTile(activeTile, 1) == 0) { // JP: prevents user from having to click
+            while (wordList.numberOfWordsForActiveTile(activeTile, 1) == 0) { // JP: prevents user from having to click
                 // the arrow multiple times to skip irrelevant tiles that are never word-initial
                 oldTile = activeTile;
                 activeTile = cumulativeStageBasedTileList.returnNextAlphabetTileDifferentiateTypes(oldTile);
             }
         } else if (scanSetting == 2) {
-            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || Start.wordList.numberOfWordsForActiveTile(activeTile, 2) == 0) {
+            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || wordList.numberOfWordsForActiveTile(activeTile, 2) == 0) {
                 oldTile = activeTile;
                 activeTile = cumulativeStageBasedTileList.returnNextAlphabetTileDifferentiateTypes(oldTile);
             }
         } else { // scanSetting 3
             while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) ||
-                    Start.wordList.numberOfWordsForActiveTile(activeTile, 3) == 0) {
+                    wordList.numberOfWordsForActiveTile(activeTile, 3) == 0) {
                 oldTile = activeTile;
                 activeTile = cumulativeStageBasedTileList.returnNextAlphabetTileDifferentiateTypes(oldTile);
             }
@@ -411,19 +412,19 @@ public class Romania extends GameActivity {
         String oldTile = activeTile;
         activeTile = cumulativeStageBasedTileList.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
         if (scanSetting == 1) {
-            while (Start.wordList.numberOfWordsForActiveTile(activeTile, 1) == 0) {
+            while (wordList.numberOfWordsForActiveTile(activeTile, 1) == 0) {
                 // JP: prevents user from having to click
                 // the arrow multiple times to skip irrelevant tiles that are never word-initial
                 oldTile = activeTile;
                 activeTile = cumulativeStageBasedTileList.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
             }
         } else if (scanSetting == 2) {
-            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || Start.wordList.numberOfWordsForActiveTile(activeTile, 2) == 0) {
+            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || wordList.numberOfWordsForActiveTile(activeTile, 2) == 0) {
                 oldTile = activeTile;
                 activeTile = cumulativeStageBasedTileList.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
             }
         } else { // scanSetting 3
-            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || Start.wordList.numberOfWordsForActiveTile(activeTile, 3) == 0) {
+            while ((activeTile.length() == 1 && Character.isWhitespace(activeTile.charAt(0))) || wordList.numberOfWordsForActiveTile(activeTile, 3) == 0) {
                 oldTile = activeTile;
                 activeTile = cumulativeStageBasedTileList.returnPreviousAlphabetTileDifferentiateTypes(oldTile);
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
@@ -23,11 +23,14 @@ import androidx.constraintlayout.widget.ConstraintSet;
 
 import static org.alphatilesapps.alphatiles.Start.keyList;
 import static org.alphatilesapps.alphatiles.Start.COLORS;
+import static org.alphatilesapps.alphatiles.Start.langInfoList;
+import static org.alphatilesapps.alphatiles.Start.localAppName;
+import static org.alphatilesapps.alphatiles.Start.nameList;
 
 public class SetPlayerName extends AppCompatActivity {
 
     Context context;
-    String scriptDirection = Start.langInfoList.find("Script direction (LTR or RTL)");
+    String scriptDirection = langInfoList.find("Script direction (LTR or RTL)");
 
     int keysInUse;
     int keyboardScreenNo; // for languages with more than 35 keys, page 1 will have 33 buttons and a forward/backward button
@@ -63,7 +66,7 @@ public class SetPlayerName extends AppCompatActivity {
 
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
 
-        setTitle(Start.localAppName);
+        setTitle(localAppName);
 
         playerNumber = getIntent().getIntExtra("playerNumber", -1);
 
@@ -74,9 +77,9 @@ public class SetPlayerName extends AppCompatActivity {
         String defaultName;
         String playerName;
 
-        String localWordForName = Start.langInfoList.find("NAME in local language");
+        String localWordForName = langInfoList.find("NAME in local language");
         if (localWordForName.equals("custom")) {
-            defaultName = Start.nameList.get(playerNumber);
+            defaultName = nameList.get(playerNumber);
         } else {
             defaultName = localWordForName + " " + playerNumber;
         }
@@ -186,12 +189,12 @@ public class SetPlayerName extends AppCompatActivity {
         if (keysInUse > KEYS.length) {
             TextView key34 = findViewById(KEYS[KEYS.length - 2]);
             key34.setBackgroundResource(R.drawable.zz_backward_green);
-            if (scriptDirection.equals("RTL")) {
+            if (scriptDirection.equals("RTL")) { //LM: LTR is default
                 key34.setRotationY(180);
             }
             key34.setText("");
             TextView key35 = findViewById(KEYS[KEYS.length - 1]);
-            if (scriptDirection.equals("RTL")) {
+            if (scriptDirection.equals("RTL")) { //LM: LTR is default
                 key35.setRotationY(180);
             }
             key35.setBackgroundResource(R.drawable.zz_forward_green);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
@@ -1,7 +1,5 @@
 package org.alphatilesapps.alphatiles;
 
-import android.content.SharedPreferences;
-import android.content.pm.ActivityInfo;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -61,7 +59,7 @@ public class Sudan extends GameActivity {
         Resources res = context.getResources();
         int audioInstructionsResID;
         try {
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
         } catch (NullPointerException e) {
             audioInstructionsResID = -1;
         }
@@ -96,7 +94,7 @@ public class Sudan extends GameActivity {
         context = this;
         int gameID = 0;
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
         determineNumPages(); // JP
 
         if (syllableGame.equals("S")) {
@@ -166,7 +164,6 @@ public class Sudan extends GameActivity {
     }
 
     public void splitTileListAcrossPages() {
-
         int numTiles = cumulativeStageBasedTileList.size() - SAD.size();
         int cont = 0;
         for (int i = 0; i < numPages + 1; i++) {
@@ -177,7 +174,6 @@ public class Sudan extends GameActivity {
                 cont++;
             }
         }
-
     }
 
     public void splitSyllablesListAcrossPages() {
@@ -204,7 +200,7 @@ public class Sudan extends GameActivity {
                 tileView.setText(pagesList.get(page).get(k));
             }
             String type;
-            if (differentiateTypes) {
+            if (differentiatesTileTypes) {
                 type = tileTypeHashMapWithMultipleTypesNoSAD.get(pagesList.get(page).get(k));
             } else {
                 type = tileHashMapNoSAD.find(pagesList.get(page).get(k)).tileType;
@@ -215,7 +211,11 @@ public class Sudan extends GameActivity {
                     typeColor = COLORS.get(1);
                     break;
                 case "V":
-                    typeColor = COLORS.get(2);
+                case "LV":
+                case "AV":
+                case "BV":
+                case "FV":
+                    typeColor = COLORS.get(0);
                     break;
                 case "T":
                     typeColor = COLORS.get(3);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -21,8 +21,8 @@ import static org.alphatilesapps.alphatiles.Testing.tempSoundPoolSwitch;
 
 public class Thailand extends GameActivity {
 
-    Start.TileList sortableTilesArray;
-    Start.SyllableList sortableSyllArray;
+    TileList sortableTilesArray;
+    SyllableList sortableSyllArray;
 
     ArrayList<String[]> fourChoices = new ArrayList<>();  // Will store LWC and LOP word or will store tile audio name and tile (lower or upper)
     // Or syllable audio name and syllable
@@ -61,7 +61,7 @@ public class Thailand extends GameActivity {
         Resources res = context.getResources();
         int audioInstructionsResID;
         try {
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1)
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1)
                     .gameInstrLabel, "raw", context.getPackageName());
         } catch (NullPointerException e) {
             audioInstructionsResID = -1;
@@ -128,13 +128,13 @@ public class Thailand extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         if (syllableGame.equals("S")) {
-            sortableSyllArray = (Start.SyllableList) syllableList.clone();
+            sortableSyllArray = (SyllableList) syllableList.clone();
             Collections.shuffle(sortableSyllArray);
         } else {
-            sortableTilesArray = (Start.TileList) tileListNoSAD.clone();
+            sortableTilesArray = (TileList) tileListNoSAD.clone();
             Collections.shuffle(sortableTilesArray);
         }
 
@@ -181,13 +181,13 @@ public class Thailand extends GameActivity {
                 boolean freshTile = false;
                 while (!freshTile) {
                     chooseWord();
-                    parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP);
+                    parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP);
                     refTile = parsedWordArrayFinal.get(0);
                     refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     while (challengeLevelThai == 1 && refTileType.equals("T")) {
                         // JP: disallow tone marker from being reference in level 1
                         chooseWord();
-                        parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP);
+                        parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP);
                         refTile = parsedWordArrayFinal.get(0);
                         refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     }
@@ -205,13 +205,13 @@ public class Thailand extends GameActivity {
                 boolean freshTile = false;
                 while (!freshTile) {
                     chooseWord();
-                    parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP);
+                    parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP);
                     refTile = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).upperTile;
                     refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     while (challengeLevelThai == 1 && refTileType.equals("T")) {
                         // JP: disallow tone marker from being reference in level 1
                         chooseWord();
-                        parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP);
+                        parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP);
                         refTile = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).upperTile;
                         refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     }
@@ -230,13 +230,13 @@ public class Thailand extends GameActivity {
                 boolean freshTile = false;
                 while (!freshTile) {
                     chooseWord();
-                    parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP);
+                    parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP);
                     refTile = parsedWordArrayFinal.get(0);
                     refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     while (challengeLevelThai == 1 && refTileType.equals("T")) {
                         // JP: disallow tone marker from being reference in level 1
                         chooseWord();
-                        parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP);
+                        parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP);
                         refTile = parsedWordArrayFinal.get(0);
                         refTileType = tileListNoSAD.get(tileListNoSAD.returnPositionInAlphabet(parsedWordArrayFinal.get(0))).tileType;
                     }
@@ -353,7 +353,7 @@ public class Thailand extends GameActivity {
             case "WORD_TEXT":
                 refItem.setBackgroundColor(WHITE);
                 refItem.setTextColor(Color.parseColor("#000000")); // black
-                refItem.setText(wordList.stripInstructionCharacters(wordInLOP));
+                refItem.setText(wordInLOPWithStandardizedSequenceOfCharacters(wordInLOP));
                 break;
             case "WORD_IMAGE":
                 int resID1 = getResources().getIdentifier(wordInLWC, "drawable", getPackageName());
@@ -405,8 +405,7 @@ public class Thailand extends GameActivity {
                     int choiceColorNo = Color.parseColor(choiceColorStr);
                     choiceButton.setBackgroundColor(choiceColorNo);
                     choiceButton.setTextColor(Color.parseColor("#000000")); // black
-                    //LOGGER.info("Remember: AB1: fourChoices.get(t)[1] = " + fourChoices.get(t)[1]);
-                    choiceButton.setText(wordList.stripInstructionCharacters((fourChoices.get(t)[1])));
+                    choiceButton.setText(wordInLOPWithStandardizedSequenceOfCharacters(fourChoices.get(t)[1]));
                     if (refType.contains("SYLL") && !hasSyllableAudio) {
                         choiceButton.setClickable(true);
                     }
@@ -486,7 +485,7 @@ public class Thailand extends GameActivity {
                 break;
             case "WORD_IMAGE":
             case "WORD_AUDIO":
-                refItemText = wordList.stripInstructionCharacters(wordInLOP);
+                refItemText = wordInLOPWithStandardizedSequenceOfCharacters(wordInLOP);
                 break;
             default:
                 break;
@@ -501,7 +500,7 @@ public class Thailand extends GameActivity {
         } else if (!choiceType.equals("WORD_IMAGE")) {
             chosenItemText = chosenItem.getText().toString();   // all cases except WORD_IMAGE
         } else {
-            chosenItemText = wordList.stripInstructionCharacters(fourChoices.get(t)[1]);             // when WORD_IMAGE
+            chosenItemText = wordInLOPWithStandardizedSequenceOfCharacters(fourChoices.get(t)[1]);             // when WORD_IMAGE
         }
 
         boolean goodMatch = false;
@@ -564,7 +563,7 @@ public class Thailand extends GameActivity {
                 switch (refType) {
                     case "TILE_LOWER":
                     case "TILE_AUDIO":
-                        parsedChosenWordArrayFinal = tileList.parseWordIntoTiles(fourChoices.get(t)[1]);
+                        parsedChosenWordArrayFinal = tileList.parseWordIntoTiles(chosenItemText, wordInLOP);
                         if (parsedChosenWordArrayFinal.get(0).equals(refItemText)) {
                             goodMatch = true;
                         }
@@ -578,7 +577,7 @@ public class Thailand extends GameActivity {
                         }
                         break;
                     case "TILE_UPPER":
-                        parsedChosenWordArrayFinal = tileList.parseWordIntoTiles(fourChoices.get(t)[1]);
+                        parsedChosenWordArrayFinal = tileList.parseWordIntoTiles(chosenItemText, wordInLOP);
                         if (refItemText != null && refItemText.equals(tileListNoSAD.get(tileListNoSAD
                                 .returnPositionInAlphabet(parsedChosenWordArrayFinal.get(0))).upperTile)) {
                             goodMatch = true;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -7,6 +7,8 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import androidx.constraintlayout.widget.ConstraintLayout;
@@ -25,7 +27,7 @@ public class UnitedStates extends GameActivity {
 
     int upperTileLimit = 5;
     int neutralFontSize;
-    String[] selections = new String[]{"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}; // KP
+    String[] selections = new String[]{"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}; // KP
     String lastWord = "";
     String secondToLastWord = "";
     String thirdToLastWord = "";
@@ -48,7 +50,7 @@ public class UnitedStates extends GameActivity {
         Resources res = context.getResources();
         int audioInstructionsResID;
         try {
-            audioInstructionsResID = res.getIdentifier(Start.gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
+            audioInstructionsResID = res.getIdentifier(gameList.get(gameNumber - 1).gameInstrLabel, "raw", context.getPackageName());
         } catch (NullPointerException e) {
             audioInstructionsResID = -1;
         }
@@ -89,7 +91,8 @@ public class UnitedStates extends GameActivity {
         super.onCreate(savedInstanceState);
         context = this;
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
+
+        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         int gameID = 0;
         switch (challengeLevel) {
@@ -150,13 +153,13 @@ public class UnitedStates extends GameActivity {
         int lengthOfLOPWord = Integer.MAX_VALUE;
         while(lengthOfLOPWord > upperTileLimit) {
             chooseWord();
-            lengthOfLOPWord = tileList.parseWordIntoTiles(wordInLOP).size();
+            lengthOfLOPWord = tileList.parseWordIntoTiles(wordInLOP, wordInLOP).size();
         }
 
         if (syllableGame.equals("S")) {
             parsedWordArrayFinal = syllableList.parseWordIntoSyllables(wordInLOP); // JP
         } else {
-            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP); // KP
+            parsedWordArrayFinal = tileList.parseWordIntoTiles(wordInLOP, wordInLOP); // KP
         }
 
         ImageView image = (ImageView) findViewById(R.id.wordImage);
@@ -199,18 +202,18 @@ public class UnitedStates extends GameActivity {
                     c = Util.parsedWordTileLength;
                 } else {
                     if (syllableGame.equals("S")) {
-                        for (int d = 0; d < Start.syllableList.size(); d++) {
+                        for (int d = 0; d < syllableList.size(); d++) {
                             if (SAD.contains(parsedWordArrayFinal.get(c))) {
                                 correspondingRow = tileList.returnPositionInAlphabet(parsedWordArrayFinal.get(c));
                                 break;
-                            } else if (Start.syllableList.get(d).syllable.equals(parsedWordArrayFinal.get(c))) {
+                            } else if (syllableList.get(d).syllable.equals(parsedWordArrayFinal.get(c))) {
                                 correspondingRow = d;
                                 break;
                             }
                         }
                     } else {
-                        for (int d = 0; d < Start.tileList.size(); d++) {
-                            if (Start.tileList.get(d).baseTile.equals(parsedWordArrayFinal.get(c))) {
+                        for (int d = 0; d < tileList.size(); d++) {
+                            if (tileList.get(d).baseTile.equals(parsedWordArrayFinal.get(c))) {
                                 correspondingRow = d;
                                 break;
                             }
@@ -220,19 +223,19 @@ public class UnitedStates extends GameActivity {
 
                 Random rand = new Random();
                 int randomNum = rand.nextInt(2); // Choosing whether correct tile goes above ( =0 ) or below ( =1 )
-                randomNum2 = rand.nextInt(Start.ALT_COUNT); // KP // choosing between 2nd and 4th item of game tiles array
+                randomNum2 = rand.nextInt(ALT_COUNT); // KP // choosing between 2nd and 4th item of game tiles array
                 if (randomNum == 0) {
                     tileButtonA.setText(parsedWordArrayFinal.get(c));   // the correct tile
                     if (syllableGame.equals("S") && !SAD.contains(parsedWordArrayFinal.get(c))) {
-                        tileButtonB.setText(Start.syllableList.get(correspondingRow).distractors[randomNum2]);   // the (incorrect) suggested alternative
+                        tileButtonB.setText(syllableList.get(correspondingRow).distractors[randomNum2]);   // the (incorrect) suggested alternative
                     } else {
-                        tileButtonB.setText(Start.tileList.get(correspondingRow).altTiles[randomNum2]);   // the (incorrect) suggested alternative
+                        tileButtonB.setText(tileList.get(correspondingRow).altTiles[randomNum2]);   // the (incorrect) suggested alternative
                     }
                 } else {
                     if (syllableGame.equals("S") && !SAD.contains(parsedWordArrayFinal.get(c))) {
-                        tileButtonA.setText(Start.syllableList.get(correspondingRow).distractors[randomNum2]);   // the (incorrect) suggested alternative
+                        tileButtonA.setText(syllableList.get(correspondingRow).distractors[randomNum2]);   // the (incorrect) suggested alternative
                     } else {
-                        tileButtonA.setText(Start.tileList.get(correspondingRow).altTiles[randomNum2]);   // the (incorrect) suggested alternative
+                        tileButtonA.setText(tileList.get(correspondingRow).altTiles[randomNum2]);   // the (incorrect) suggested alternative
                     }
                     tileButtonB.setText(parsedWordArrayFinal.get(c));   // the correct tile
                 }
@@ -255,21 +258,30 @@ public class UnitedStates extends GameActivity {
 
     }
 
-    public void buildWord(String tileNumber, String tileString) {
+    public void buildWord(int tileIndex) {
 
         TextView constructedWord = findViewById(R.id.activeWordTextView);
 
-        StringBuilder displayedWord = new StringBuilder(); // KP
-
-        for (int j = 0; j < selections.length; j++) {
-            if (!selections[j].equals("")) {
-                displayedWord.append(selections[j]);
+        List<String> selectionsList = new ArrayList<String>();
+        for (int i = 0; i < selections.length; i++) {
+            if (!selections[i].equals("")) {
+                selectionsList.add(selections[i]);
             }
         }
 
-        constructedWord.setText(displayedWord);
+        int lastSelectedIndex;
+        if (tileIndex % 2 == 0) {
+            lastSelectedIndex = tileIndex / 2;
+        } else {
+            lastSelectedIndex = (tileIndex - 1) / 2;
+        }
 
-        if (displayedWord.toString().equals(Start.wordList.stripInstructionCharacters(wordInLOP))) {
+        String displayedWord = combineTilesToMakeWord(selectionsList, parsedWordArrayFinal, lastSelectedIndex, wordInLOP);
+
+        constructedWord.setText(displayedWord);
+        String correctAnswerText = combineTilesToMakeWord(parsedWordArrayFinal, parsedWordArrayFinal, -1, wordInLOP);
+
+        if (displayedWord.equals(correctAnswerText)) {
 
             // Good job!
             repeatLocked = false;
@@ -317,7 +329,7 @@ public class UnitedStates extends GameActivity {
         selections[tileIndex] = tile.getText().toString();
         selections[otherTileIndex] = "";
 
-        buildWord((String) view.getTag(), selections[tileIndex]);
+        buildWord(tileIndex);
 
     }
 


### PR DESCRIPTION
In this PR,
1) Methods were added and changed to allow parsing of complex tiles such as those in Thai and Lao script languages
2) A readability improvement was made, from importing inline e.g. Start.tileList, Start.wordList, etc, to importing once at the top and then referring to these static objects simply as tileList, wordList, etc.

Since tile type is necessary information for parsing complex tiles, several methods have new parameters used for accessing this type information, e.g. a reference to the original word when parsing a pseudoword, in order to access the wordlist mixed types info.

There are two levels of word parsing. Both return the same thing in strictly unidirectional parsing, and they differ as follows for Thai and Lao script parsing: 
parseWordIntoTilesPreliminary() is a greedy search that goes from beginning to end of the word, getting the longest sequences possible that match tiles in the tile list (which can be broken up with periods). 
If the script type given in langinfo is "Thai" or "Lao", parseWordIntoTiles() then goes over this preliminary tile array and finds any complex tiles to combine, using type information and script structure. The default, or with any other script type given in langinfo, is to return the preliminaryTileArray from parseWordIntoTiles(). 
So, parseWordIntoTiles (a method of the tileList) is the authoritative source for the tiles in a word. But, the preliminaryTileArray is used in wordsearch and a few other games, and for accessing tile type info from the word list.