### PR TITLE
Validator catch "bad request" token response exception

### DIFF
--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -2388,15 +2388,18 @@ public class Validator {
         }
         // if the token is revoked or expired, deletes the token and then rebuilds the services
         catch (TokenResponseException | GoogleJsonResponseException e){
-            String errorDescription;
+            boolean badToken = false;
             if (e instanceof TokenResponseException){
-                errorDescription = ((TokenResponseException) e).getDetails().get("error_description").toString();
+                badToken = true;
             }
             else{
-                errorDescription = ((GoogleJsonResponseException) e).getDetails().get("message").toString();
+                String errorDescription = ((GoogleJsonResponseException) e).getDetails().get("message").toString();
+                if (errorDescription.contains("Request had invalid authentication credentials. Expected OAuth 2 access token")){
+                    badToken = true;
+                }
             }
 
-            if (errorDescription.equals("Token has been expired or revoked.") || errorDescription.contains("Request had invalid authentication credentials. Expected OAuth 2 access token")) {
+            if (badToken) {
                 deleteDirectory(Paths.get("tokens"));
                 sheetsService =
                         new Sheets.Builder(HTTP_TRANSPORT, JSON_FACTORY, getCrdntls(HTTP_TRANSPORT))


### PR DESCRIPTION
A very small fix was added to deal with the following situation:

- As we know, access tokens currently expire 7 days after creation. 
- Usually, this results in an error with a message "Token has been expired or revoked". The code knows how to deal with this and asks for permission to create a new token. (The error is caught internally, and the user never sees the error message.) 
- However, google does not keep an infinite record of all the tokens that were previously expired/revoked. About 12 hours after the token was expired/revoked, Google starts giving a "bad request" error message instead, as it no longer knows that what you're feeding it is an expired/revoked token and not just gibberish. 
- When testing, we had only tested very recently expired/revoked tokens, and did not realize the error message eventually switch from "Token has been expired or revoked" to "bad request"