### PR TITLE
Update advance arrow color scheme (v1.5.1)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 108
-        versionName "1.5.0"
+        versionCode 109
+        versionName "1.5.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -226,6 +226,7 @@ public class Brazil extends GameActivity {
         }
 
         repeatLocked = true;
+        setAdvanceArrowToGray();
         if (syllableGame.equals("S")) {
             Collections.shuffle(sortableSyllArray);
         } else {
@@ -659,6 +660,7 @@ public class Brazil extends GameActivity {
         if (correctTile.equals(gameTileString)) {
             // Good job! You chose the right tile
             repeatLocked = false;
+            setAdvanceArrowToBlue();
             updatePointsAndTrackers(1);
 
             for (int i = 0; i < parsedWordArrayFinal.size(); i++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/China.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/China.java
@@ -132,6 +132,7 @@ public class China extends GameActivity {
         }
 
         repeatLocked = true;
+        setAdvanceArrowToGray();
         chooseWords();
         setUpTiles();
         setAllTilesClickable();
@@ -258,6 +259,7 @@ public class China extends GameActivity {
 
         if (areAllLinesSolved()) {
             repeatLocked = false;
+            setAdvanceArrowToBlue();
 
             updatePointsAndTrackers(4);
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -147,6 +147,7 @@ public class Colombia extends GameActivity {
     public void playAgain() {
 
         repeatLocked = true;
+        setAdvanceArrowToGray();
 
         TextView wordToBuild = (TextView) findViewById(R.id.activeWordTextView);
 
@@ -161,8 +162,6 @@ public class Colombia extends GameActivity {
 
         ImageView wordImage = (ImageView) findViewById(R.id.wordImage);
         wordImage.setClickable(true);
-        ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
-        repeatImage.setImageResource(R.drawable.zz_forward);
 
         loadKeyboard();
 
@@ -440,6 +439,7 @@ public class Colombia extends GameActivity {
             playCorrectSoundThenActiveWordClip(false);
 
             repeatLocked = false;
+            setAdvanceArrowToBlue();
 
         } else { // Word is partial and, for the moment, assumed to be incorrect
             wordToBuild.setBackgroundColor(Color.parseColor("#A9A9A9")); // gray for wrong

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
@@ -126,6 +126,7 @@ public class Ecuador extends GameActivity {
     public void playAgain() {
 
         repeatLocked = true;
+        setAdvanceArrowToGray();
         setBoxes();
         setTextBoxColors();
         Collections.shuffle(wordList); // KP
@@ -459,6 +460,7 @@ public class Ecuador extends GameActivity {
         if (chosenWordText.equals(Start.wordList.stripInstructionCharacters(wordInLOP))) {
             // Good job!
             repeatLocked = false;
+            setAdvanceArrowToBlue();
 
             updatePointsAndTrackers(2);
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -419,11 +419,7 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     protected void setOptionsRowUnclickable() {
-        ImageView repeatImage = findViewById(R.id.repeatImage);
         ImageView wordImage = findViewById(R.id.wordImage);
-        repeatImage.setBackgroundResource(0);
-        repeatImage.setImageResource(R.drawable.zz_forward_inactive);
-        repeatImage.setClickable(false);
         if (wordImage != null)
             wordImage.setClickable(false);
         if (getWordImages() != null)
@@ -431,15 +427,13 @@ public abstract class GameActivity extends AppCompatActivity {
                 wordImage = findViewById(getWordImages()[i]);
                 wordImage.setClickable(false);
             }
+        ImageView repeatImage = findViewById(R.id.repeatImage);
+        repeatImage.setClickable(false);
     }
 
     protected void setOptionsRowClickable() {
-        ImageView repeatImage = findViewById(R.id.repeatImage);
         ImageView wordImage = findViewById(R.id.wordImage);
         ImageView gamesHomeImage = findViewById(R.id.gamesHomeImage);
-        repeatImage.setBackgroundResource(0);
-        repeatImage.setImageResource(R.drawable.zz_forward);
-        repeatImage.setClickable(true);
         gamesHomeImage.setClickable(true);
         if (wordImage != null)
             wordImage.setClickable(true);
@@ -448,6 +442,20 @@ public abstract class GameActivity extends AppCompatActivity {
                 wordImage = findViewById(getWordImages()[i]);
                 wordImage.setClickable(true);
             }
+        ImageView repeatImage = findViewById(R.id.repeatImage);
+        repeatImage.setClickable(true);
+    }
+
+    protected void setAdvanceArrowToBlue() {
+        ImageView repeatImage = findViewById(R.id.repeatImage);
+        repeatImage.setBackgroundResource(0);
+        repeatImage.setImageResource(R.drawable.zz_forward);
+    }
+
+    protected void setAdvanceArrowToGray() {
+        ImageView repeatImage = findViewById(R.id.repeatImage);
+        repeatImage.setBackgroundResource(0);
+        repeatImage.setImageResource(R.drawable.zz_forward_inactive);
     }
 
     public void clickPicHearAudio(View view) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -169,6 +169,7 @@ public class Georgia extends GameActivity {
         }
 
         repeatLocked = true;
+        setAdvanceArrowToGray();
         if (syllableGame.equals("S")) {
             Collections.shuffle(sortableSyllArray); //JP
         }
@@ -456,6 +457,7 @@ public class Georgia extends GameActivity {
         if (correct.equals(selectedTile)) {
             // Good job! You chose the right tile
             repeatLocked = false;
+            setAdvanceArrowToBlue();
             updatePointsAndTrackers(1);
 
             for (int t = 0; t < TILE_BUTTONS.length; t++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -192,6 +192,7 @@ public class Italy extends GameActivity {
 
     public void playAgain() {
         repeatLocked = true;
+        setAdvanceArrowToGray();
         deckIndex = -1;
         gameCards.removeAll(gameCards);
         for (int card = 0; card < 16; card++) {
@@ -303,6 +304,7 @@ public class Italy extends GameActivity {
     }
 
     public void respondToLoteria() {
+        setAdvanceArrowToBlue();
         playCorrectSoundThenActiveWordClip(true);
         updatePointsAndTrackers(4);
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
@@ -173,6 +173,7 @@ public class Japan extends GameActivity {
 
     private void play() {
         repeatLocked = true;
+        setAdvanceArrowToGray();
         setWord();
         displayWordRef();
         displayTileChoices();
@@ -180,8 +181,6 @@ public class Japan extends GameActivity {
         setTilesUnclickable();
         ImageView wordImage = (ImageView) findViewById(R.id.wordImage);
         wordImage.setClickable(true);
-        ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
-        repeatImage.setImageResource(R.drawable.zz_forward);
     }
 
     private void setWord() {
@@ -596,6 +595,7 @@ public class Japan extends GameActivity {
         if (config.toString().equals(wordInLOPNoSAD)) { // completely correct
             //great job!
             repeatLocked = false;
+            setAdvanceArrowToBlue();
             playCorrectSoundThenActiveWordClip(false); //JP not sure what this bool is for
             updatePointsAndTrackers(1);
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -145,6 +145,8 @@ public class Mexico extends GameActivity {
 
     public void playAgain() {
 
+        repeatLocked = true;
+        setAdvanceArrowToGray();
         setCardTextToEmpty();
         chooseMemoryWords();
         Collections.shuffle(memoryCollection); // KP
@@ -313,6 +315,7 @@ public class Mexico extends GameActivity {
 
             if (pairsCompleted == (visibleTiles / 2)) {
                 updatePointsAndTrackers((visibleTiles / 2));
+                setAdvanceArrowToBlue();
             }
 
             playCorrectSoundThenActiveWordClip(pairsCompleted == (visibleTiles / 2));

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -183,6 +183,7 @@ public class Myanmar extends GameActivity {
     public void playAgain() {
 
         repeatLocked = true;
+        setAdvanceArrowToGray();
         wordsCompleted = 0;
         clickCount = 0;
         firstClickIndex = 0;
@@ -629,6 +630,7 @@ public class Myanmar extends GameActivity {
             // Play word and "correct" sounds and then clear the image from word bank
             wordInLWC = sevenWordsInLopLwc[indexOfFoundWord][0];
             if (wordsCompleted == completionGoal) {
+                setAdvanceArrowToBlue();
                 updatePointsAndTrackers(wordsCompleted);
             }
             playCorrectSoundThenActiveWordClip(wordsCompleted == completionGoal);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
@@ -118,6 +118,7 @@ public class Peru extends GameActivity {
 
     public void playAgain() {
         repeatLocked = true;
+        setAdvanceArrowToGray();
         chooseWord();
         parsedWordArrayFinal = Start.tileList.parseWordIntoTiles(wordInLOP); // KP
         int tileLength = parsedWordArrayFinal.size();
@@ -138,8 +139,6 @@ public class Peru extends GameActivity {
 
         ImageView wordImage = (ImageView) findViewById(R.id.wordImage);
         wordImage.setClickable(true);
-        ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
-        repeatImage.setImageResource(R.drawable.zz_forward);
 
         Random rand = new Random();
         int indexOfCorrectAnswerAmongChoices = rand.nextInt(4);
@@ -270,6 +269,7 @@ public class Peru extends GameActivity {
         if (chosenWordText.equals(Start.wordList.stripInstructionCharacters(wordInLOP))) {
             // Good job!
             repeatLocked = false;
+            setAdvanceArrowToBlue();
 
            updatePointsAndTrackers(2);
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -163,6 +163,7 @@ public class Thailand extends GameActivity {
     public void playAgain() {
 
         repeatLocked = true;
+        setAdvanceArrowToGray();
 
         TextView refItem = findViewById(R.id.referenceItem);
         refItem.setText("");
@@ -607,6 +608,7 @@ public class Thailand extends GameActivity {
         if (goodMatch) {
             // Good job!
             repeatLocked = false;
+            setAdvanceArrowToBlue();
             updatePointsAndTrackers(1);
 
             for (int b = 0; b < TILE_BUTTONS.length; b++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -146,6 +146,7 @@ public class UnitedStates extends GameActivity {
     public void playAgain() {
 
         repeatLocked = true;
+        setAdvanceArrowToGray();
         selections = new String[]{"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}; // KP
         int lengthOfLOPWord = Integer.MAX_VALUE;
         while(lengthOfLOPWord > upperTileLimit) {
@@ -165,8 +166,6 @@ public class UnitedStates extends GameActivity {
 
         ImageView wordImage = (ImageView) findViewById(R.id.wordImage);
         wordImage.setClickable(true);
-        ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
-        repeatImage.setImageResource(R.drawable.zz_forward);
 
         switch (challengeLevel) {
             case 2:
@@ -278,6 +277,7 @@ public class UnitedStates extends GameActivity {
 
             // Good job!
             repeatLocked = false;
+            setAdvanceArrowToBlue();
             constructedWord.setTextColor(Color.parseColor("#006400")); // dark green
             constructedWord.setTypeface(constructedWord.getTypeface(), Typeface.BOLD);
 

--- a/app/src/main/res/layout/brazil_cl1.xml
+++ b/app/src/main/res/layout/brazil_cl1.xml
@@ -339,7 +339,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/brazil_cl3.xml
+++ b/app/src/main/res/layout/brazil_cl3.xml
@@ -595,7 +595,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/china.xml
+++ b/app/src/main/res/layout/china.xml
@@ -547,7 +547,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/colombia.xml
+++ b/app/src/main/res/layout/colombia.xml
@@ -1106,7 +1106,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/colombia_syllables.xml
+++ b/app/src/main/res/layout/colombia_syllables.xml
@@ -644,14 +644,15 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
+        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:layout_constraintVertical_bias="0.0"
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/ecuador.xml
+++ b/app/src/main/res/layout/ecuador.xml
@@ -391,14 +391,15 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
+        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:layout_constraintVertical_bias="0.0"
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/georgia.xml
+++ b/app/src/main/res/layout/georgia.xml
@@ -646,7 +646,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/georgia_syll.xml
+++ b/app/src/main/res/layout/georgia_syll.xml
@@ -639,7 +639,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/italy.xml
+++ b/app/src/main/res/layout/italy.xml
@@ -247,7 +247,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <ImageView
         android:id="@+id/wordImage01"

--- a/app/src/main/res/layout/japan_12.xml
+++ b/app/src/main/res/layout/japan_12.xml
@@ -218,7 +218,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline8"

--- a/app/src/main/res/layout/japan_7.xml
+++ b/app/src/main/res/layout/japan_7.xml
@@ -211,14 +211,15 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
+        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:layout_constraintVertical_bias="0.0"
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline8"

--- a/app/src/main/res/layout/mexico.xml
+++ b/app/src/main/res/layout/mexico.xml
@@ -618,7 +618,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/myanmar.xml
+++ b/app/src/main/res/layout/myanmar.xml
@@ -1514,14 +1514,15 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
+        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:layout_constraintVertical_bias="0.0"
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/peru.xml
+++ b/app/src/main/res/layout/peru.xml
@@ -320,7 +320,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/romania.xml
+++ b/app/src/main/res/layout/romania.xml
@@ -238,7 +238,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"

--- a/app/src/main/res/layout/thailand.xml
+++ b/app/src/main/res/layout/thailand.xml
@@ -326,14 +326,15 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
+        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructions"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:layout_constraintVertical_bias="1.0"
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/thailand2.xml
+++ b/app/src/main/res/layout/thailand2.xml
@@ -329,7 +329,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/united_states_cl1.xml
+++ b/app/src/main/res/layout/united_states_cl1.xml
@@ -473,7 +473,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/united_states_cl2.xml
+++ b/app/src/main/res/layout/united_states_cl2.xml
@@ -559,7 +559,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"

--- a/app/src/main/res/layout/united_states_cl3.xml
+++ b/app/src/main/res/layout/united_states_cl3.xml
@@ -646,7 +646,7 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward" />
+        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"


### PR DESCRIPTION
Previously, the advance arrow had this scheme:

gray = sound is playing (button locked)
blue = no sound playing (but button may or may not be locked)

The new scheme is:

gray = button locked
blue = button unlocked

One exception is that when a round is completed, the arrow will instantly turn blue even though the button will still be locked while the correct sound and item audio (word, tile, etc.) and possibly final sound sequence are played. So the code could be further improved to delay the gray to blue switch until after the audio files are completed.