### PR TITLE
Allow teams to specify placeholder base for combining characters

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 133
-        versionName "2.0.2"
+        versionCode 134
+        versionName "2.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -365,12 +365,12 @@ public class Brazil extends GameActivity {
                     blankTile.text = "\u200B"; // The word will default to containing a placeholder circle. Add zero-width space, instead of line.
                     parsedRefWordTileArray.set(index_to_remove, blankTile);
                 } else {
-                    blankTile.text = "◌"; // Since Khmer has lots of placeholder circles, we'll use them for all consonant blanks.
+                    blankTile.text = placeholderCharacter; // Since Khmer has lots of placeholder circles, we'll use them for all consonant blanks.
                     parsedRefWordTileArray.set(index_to_remove, blankTile);
                 }
             }
             if (scriptType.matches("(Thai|Lao)") && correctTile.typeOfThisTileInstance.equals("C")){
-                blankTile.text = "◌";
+                blankTile.text = placeholderCharacter;
                 parsedRefWordTileArray.set(index_to_remove, blankTile);
             }
             word = combineTilesToMakeWord(parsedRefWordTileArray, refWord, index_to_remove);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -33,6 +33,7 @@ import static org.alphatilesapps.alphatiles.Start.SILENT_PRELIMINARY_TILES;
 import static org.alphatilesapps.alphatiles.Start.differentiatesTileTypes;
 import static org.alphatilesapps.alphatiles.Start.gameList;
 import static org.alphatilesapps.alphatiles.Start.stageCorrespondenceRatio;
+import static org.alphatilesapps.alphatiles.Start.placeholderCharacter;
 import static org.alphatilesapps.alphatiles.Start.tileHashMap;
 import static org.alphatilesapps.alphatiles.Start.tileList;
 import static org.alphatilesapps.alphatiles.Start.tileStagesLists;
@@ -777,16 +778,16 @@ public abstract class GameActivity extends AppCompatActivity {
         if(indexOfReplacedTile>0){
             previousTile = tilesInThisWordOption.get(indexOfReplacedTile-1);
             previousString = previousTile.text;
-            if(previousString.contains("◌") && previousString.length()==2) { // Filter these placeholders out; keep the complex tile ones
-                previousString = previousString.replace("◌", "");
+            if(previousString.contains(placeholderCharacter) && previousString.length()==2) { // Filter these placeholders out; keep the complex tile ones
+                previousString = previousString.replace(placeholderCharacter, "");
             }
         }
 
         int index = 0;
         for (Start.Tile thisTile : tilesInThisWordOption) {
             String stringToAppend = thisTile.text;
-            if(stringToAppend.contains("◌") && stringToAppend.length() == 2) { // Filter these placeholders out; keep the complex tile ones
-                stringToAppend = stringToAppend.replace("◌", "");
+            if(stringToAppend.contains(placeholderCharacter) && stringToAppend.length() == 2) { // Filter these placeholders out; keep the complex tile ones
+                stringToAppend = stringToAppend.replace(placeholderCharacter, "");
             }
             if (thisTile.typeOfThisTileInstance.matches("(C|PC)")){
                 previousConsonant = thisTile.text;
@@ -795,14 +796,14 @@ public abstract class GameActivity extends AppCompatActivity {
             }
             if(thisTile.typeOfThisTileInstance.matches("(D|AD)")) {
                 previousDiacritics = thisTile.text;
-                if(previousDiacritics.contains("◌") && previousAboveOrBelowVowel.length()==2) { // Filter these placeholders out; keep the complex tile ones
-                    previousDiacritics = previousDiacritics.replace("◌", "");
+                if(previousDiacritics.contains(placeholderCharacter) && previousAboveOrBelowVowel.length()==2) { // Filter these placeholders out; keep the complex tile ones
+                    previousDiacritics = previousDiacritics.replace(placeholderCharacter, "");
                 }
             }
             if(thisTile.typeOfThisTileInstance.matches("(AV|BV)")){
                 previousAboveOrBelowVowel = thisTile.text;
-                if(previousAboveOrBelowVowel.contains("◌") && previousAboveOrBelowVowel.length()==2) { // Filter these placeholders out; keep the complex tile ones
-                    previousAboveOrBelowVowel = previousAboveOrBelowVowel.replace("◌", "");
+                if(previousAboveOrBelowVowel.contains(placeholderCharacter) && previousAboveOrBelowVowel.length()==2) { // Filter these placeholders out; keep the complex tile ones
+                    previousAboveOrBelowVowel = previousAboveOrBelowVowel.replace(placeholderCharacter, "");
                 }
             }
 
@@ -825,26 +826,26 @@ public abstract class GameActivity extends AppCompatActivity {
                 // ^Now it's in the right place.
                 builder.append(stringToAppend);
             } else if (replacingLVwithOtherV && index == (indexOfReplacedTile + 1) && previousTile.typeOfThisTileInstance.equals("V")){
-                stringToAppend = previousString.replace("◌", stringToAppend); // [LV+◌+FV], replace the ◌ with the consonant tile you are adding now
+                stringToAppend = previousString.replace(placeholderCharacter, stringToAppend); // [LV+◌+FV], replace the placeholder with the consonant tile you are adding now
                 builder.append(stringToAppend);
             } else if (replacingOtherVwithLV && index==indexOfReplacedTile) {
                 builder.append(stringToAppend); // Add the LV first
                 builder.append(previousString); // Now add the C
             } else {
-                if (stringToAppend.contains("◌")) {
+                if (stringToAppend.contains(placeholderCharacter)) {
                     // Put the previous consonant and (optional) above/below vowel as the base of diacritics
                     // Or consonant and diacritics as the base of a vowel with a placeholder
                     // The stackInProperSequence() method will make some more fixes later if necessary
                     String base = "";
                     if(thisTile.typeOfThisTileInstance.matches("(D|AD)")){
-                        base = previousConsonant + previousAboveOrBelowVowel.replace("◌", "");
-                        stringToAppend = stringToAppend.replace("◌", base);
+                        base = previousConsonant + previousAboveOrBelowVowel.replace(placeholderCharacter, "");
+                        stringToAppend = stringToAppend.replace(placeholderCharacter, base);
                     } else if (thisTile.typeOfThisTileInstance.matches("(AV|BV|FV|V)")){
-                        base = previousConsonant + previousAboveOrBelowVowel.replace("◌", "") + previousDiacritics.replace("◌", "");
-                        stringToAppend = stringToAppend.replace("◌", base);
+                        base = previousConsonant + previousAboveOrBelowVowel.replace(placeholderCharacter, "") + previousDiacritics.replace(placeholderCharacter, "");
+                        stringToAppend = stringToAppend.replace(placeholderCharacter, base);
                     } else if (thisTile.typeOfThisTileInstance.equals("LV")) { // Can happen in the sequence if we are replacing a vowel
-                        base = previousConsonant + previousDiacritics.replace("◌", "");
-                        stringToAppend = stringToAppend.replace("◌", "") + base;
+                        base = previousConsonant + previousDiacritics.replace(placeholderCharacter, "");
+                        stringToAppend = stringToAppend.replace(placeholderCharacter, "") + base;
                     }
                     builder.delete(builder.length() - base.length(), builder.length());
                 }
@@ -884,10 +885,10 @@ public abstract class GameActivity extends AppCompatActivity {
                 }
             }
             if (tileHashMap.containsKey(String.valueOf(correctlyStackedString.charAt(0)))
-             || tileHashMap.containsKey("◌" + String.valueOf(correctlyStackedString.charAt(0)))) {
+             || tileHashMap.containsKey(placeholderCharacter + String.valueOf(correctlyStackedString.charAt(0)))) {
                 Start.Tile firstCharAsTile = tileHashMap.get(String.valueOf(correctlyStackedString.charAt(0)));
                 if (firstCharAsTile==null) {
-                    firstCharAsTile = tileHashMap.get("◌" + String.valueOf(correctlyStackedString.charAt(0)));
+                    firstCharAsTile = tileHashMap.get(placeholderCharacter + String.valueOf(correctlyStackedString.charAt(0)));
                 }
                 if(firstCharAsTile.tileType.matches("(AV|BV|FV|AD)")) {
                     String wonkyBeginningSequence = String.valueOf(correctlyStackedString.charAt(0)) + String.valueOf(correctlyStackedString.charAt(1));
@@ -917,10 +918,10 @@ public abstract class GameActivity extends AppCompatActivity {
         for (int i = 0; i < wordListWord.wordInLOP.replace(".", "").length(); i++) {
             Start.Tile thisTile = tileHashMap.get(String.valueOf(wordListWord.wordInLOP.replace(".", "").charAt(i)));
             if (thisTile == null) { // try with a placeholder prefix
-                thisTile = tileHashMap.get("◌" + String.valueOf(wordListWord.wordInLOP.replace(".", "").charAt(i)));
+                thisTile = tileHashMap.get(placeholderCharacter + String.valueOf(wordListWord.wordInLOP.replace(".", "").charAt(i)));
             }
             if (thisTile == null) { // try with a placeholder suffix
-                thisTile = tileHashMap.get(String.valueOf(wordListWord.wordInLOP.replace(".", "").charAt(i)) + "◌");
+                thisTile = tileHashMap.get(String.valueOf(wordListWord.wordInLOP.replace(".", "").charAt(i)) + placeholderCharacter);
             }
             if (!(thisTile == null)) {
                 String thisTileString = thisTile.text;
@@ -931,7 +932,7 @@ public abstract class GameActivity extends AppCompatActivity {
                     int preliminaryTileIndex = -1;
                     int cumulativeCharIndex = -1;
                     for (Start.Tile preliminaryTile : parsedWordListWordTileArrayPreliminary) { // Figure out which instance (0th, 1st, 2nd) of this char it is
-                        cumulativeCharIndex += preliminaryTile.text.replace("◌", "").length();
+                        cumulativeCharIndex += preliminaryTile.text.replace(placeholderCharacter, "").length();
                         preliminaryTileIndex++;
                         if(cumulativeCharIndex==i) {
                             break;
@@ -941,7 +942,7 @@ public abstract class GameActivity extends AppCompatActivity {
                 } else {
                     typeOfThisInstanceOfThisTile = thisTile.tileType;
                 }
-                thisTileString = thisTileString.replace("◌", ""); // Remove any placeholders stored with single-char tiles
+                thisTileString = thisTileString.replace(placeholderCharacter, ""); // Remove any placeholders stored with single-char tiles
                 if (typeOfThisInstanceOfThisTile.equals("AV")) {
                     AVs.add(thisTileString);
                 } else if (typeOfThisInstanceOfThisTile.equals("AD")) {
@@ -957,8 +958,8 @@ public abstract class GameActivity extends AppCompatActivity {
         // Add other non-ambiguous AV, AD, FV, and BV tiles to avoid
         for(Start.Tile tile : tileList) {
             if (!MULTITYPE_TILES.contains(tile.text) && tile.text.length()==1
-            || (tile.text.contains("◌") && tile.text.length()==2)) {
-                String thisTileString = tile.text.replace("◌", "");
+            || (tile.text.contains(placeholderCharacter) && tile.text.length()==2)) {
+                String thisTileString = tile.text.replace(placeholderCharacter, "");
                 if (tile.tileType.equals("AV")) {
                     AVs.add(thisTileString);
                 } else if (tile.tileType.equals("AD")) {
@@ -984,7 +985,7 @@ public abstract class GameActivity extends AppCompatActivity {
         }
         for (int f = 0; f < FVs.size(); f++) {
             for (int d = 0; d < ADs.size(); d++) {
-                if(!tileHashMap.containsKey(FVs.get(f) + ADs.get(d)) && !tileHashMap.containsKey("◌" + FVs.get(f) + ADs.get(d))){
+                if(!tileHashMap.containsKey(FVs.get(f) + ADs.get(d)) && !tileHashMap.containsKey(placeholderCharacter + FVs.get(f) + ADs.get(d))){
                     prohibitedCharSequences.add(FVs.get(f) + ADs.get(d));
                 }
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -73,6 +73,7 @@ public class Start extends AppCompatActivity {
     public static int numberOfAvatars = 12;
     public static String scriptType; // LM Can be "Thai", "Lao", or "Khmer" for special tile parsing. If nothing specified, tile parsing defaults to unidirectional.
 
+    public static String placeholderCharacter; // LM Takes the place of a consonant for combining characters in complex scripts
     public static TileList CONSONANTS = new TileList();
     public static TileList PLACEHOLDER_CONSONANTS = new TileList();
     public static TileList SILENT_PRELIMINARY_TILES = new TileList();
@@ -670,6 +671,7 @@ public class Start extends AppCompatActivity {
                 }
             }
         }
+        placeholderCharacter = settingsList.find("Stand-in base for combining tiles"); // For Thai, Lao combining tiles
 
     }
 
@@ -1381,6 +1383,10 @@ public class Start extends AppCompatActivity {
             ArrayList<Tile> parsedWordArrayPreliminary = parseWordIntoTilesPreliminary(stringToParse, referenceWord);
             if (!scriptType.matches("(Thai|Lao|Khmer)")) {
                 return parsedWordArrayPreliminary;
+            } else {
+                if(placeholderCharacter.isEmpty()) {
+                    placeholderCharacter = "◌";
+                }
             }
 
             ArrayList<Tile> parsedWordTileArray = new ArrayList<>();
@@ -1463,15 +1469,15 @@ public class Start extends AppCompatActivity {
                     if (currentTileType.matches("(AV|BV|FV)")) { // Prepare to add current AV/BV/FV to vowel-so-far
                         if(tileHashMap.containsKey(vowelStringSoFar)){ // Vowel composite so far is parsable as one tile in the tile list
                             if(vowelTypeSoFar.equals("LV")){
-                                if(!vowelStringSoFar.endsWith("◌")){
-                                    vowelStringSoFar += "◌";
+                                if(!vowelStringSoFar.endsWith(placeholderCharacter)){
+                                    vowelStringSoFar += placeholderCharacter;
                                 }
-                            } else if (vowelTypeSoFar.matches("(AV|BV|FV)") && !vowelStringSoFar.startsWith("◌")){
-                                vowelStringSoFar = "◌" + vowelStringSoFar; // Put the placeholder before the previous AV/BV/FV before adding current AV/BV/FV to it
+                            } else if (vowelTypeSoFar.matches("(AV|BV|FV)") && !vowelStringSoFar.startsWith(placeholderCharacter)){
+                                vowelStringSoFar = placeholderCharacter + vowelStringSoFar; // Put the placeholder before the previous AV/BV/FV before adding current AV/BV/FV to it
                             }
                         }
-                        if (vowelStringSoFar.contains("◌") && currentTileString.contains("◌")) {
-                            currentTileString = currentTileString.replace("◌", ""); // Just want one ◌
+                        if (vowelStringSoFar.contains(placeholderCharacter) && currentTileString.contains(placeholderCharacter)) {
+                            currentTileString = currentTileString.replace(placeholderCharacter, ""); // Just want one placeholder
                         }
                         vowelStringSoFar += currentTileString;
                         if (vowelStringSoFar.equals(currentTileString)) { // the vowel so far is a preliminary tile
@@ -1480,11 +1486,11 @@ public class Start extends AppCompatActivity {
                             vowelTypeSoFar = tileHashMap.find(vowelStringSoFar).tileType;
                         }
                     } else if (currentTileType.matches("(AD|D)")) { // Save any AD (Above/After Diacritics) or other Diacritics between consonants
-                        if(!diacriticStringSoFar.isEmpty() && !diacriticStringSoFar.contains("◌")){
-                            diacriticStringSoFar = "◌" + diacriticStringSoFar; // For complex diacritics
+                        if(!diacriticStringSoFar.isEmpty() && !diacriticStringSoFar.contains(placeholderCharacter)){
+                            diacriticStringSoFar = placeholderCharacter + diacriticStringSoFar; // For complex diacritics
                         }
-                        if(diacriticStringSoFar.contains("◌") && currentTileString.contains("◌")) { // Just want one ◌
-                            currentTileString = currentTileString.replace("◌", "");
+                        if(diacriticStringSoFar.contains(placeholderCharacter) && currentTileString.contains(placeholderCharacter)) { // Just want one placeholder
+                            currentTileString = currentTileString.replace(placeholderCharacter, "");
                         }
                         diacriticStringSoFar+=currentTileString;
                     } else if (currentTileType.equals("SAD")) { // Save any Space-And-Dash chars that comes between syllables.
@@ -1501,8 +1507,8 @@ public class Start extends AppCompatActivity {
                 }
                 if (!(currentConsonant==null)) {
                     // Combine diacritics with consonant if that combination is in the tileList. Ex:บ๋
-                    if (!diacriticStringSoFar.isEmpty() && tileHashMap.containsKey(currentConsonant.text + diacriticStringSoFar.replace("◌", ""))) {
-                        currentConsonant = tileHashMap.find(currentConsonant.text + diacriticStringSoFar.replace("◌", ""));
+                    if (!diacriticStringSoFar.isEmpty() && tileHashMap.containsKey(currentConsonant.text + diacriticStringSoFar.replace(placeholderCharacter, ""))) {
+                        currentConsonant = tileHashMap.find(currentConsonant.text + diacriticStringSoFar.replace(placeholderCharacter, ""));
                         diacriticStringSoFar = "";
                     }
 
@@ -1615,7 +1621,7 @@ public class Start extends AppCompatActivity {
                 // See if the blocks of length one, two, three or four Unicode characters matches game tiles
                 // Choose the longest block that matches a game tile and add that as the next segment in the parsed word array
                 charBlockLength = 0;
-                if (tileHashMap.containsKey(next1Chars) || tileHashMap.containsKey("◌" + next1Chars) || tileHashMap.containsKey(next1Chars + "◌")) {
+                if (tileHashMap.containsKey(next1Chars) || tileHashMap.containsKey(placeholderCharacter + next1Chars) || tileHashMap.containsKey(next1Chars + placeholderCharacter)) {
                     // If charBlockLength is already assigned 2 or 3 or 4, it should not overwrite with 1
                     charBlockLength = 1;
                 }
@@ -1639,10 +1645,10 @@ public class Start extends AppCompatActivity {
                     case 1:
                         if (tileHashMap.containsKey(next1Chars)){
                             tileString = next1Chars;
-                        } else if (tileHashMap.containsKey("◌" + next1Chars)) { // For AV/BV/FV/AD/D stored with ◌
-                            tileString = "◌" + next1Chars;
-                        } else if (tileHashMap.containsKey(next1Chars + "◌")) { // For LV stored with ◌
-                            tileString = next1Chars + "◌";
+                        } else if (tileHashMap.containsKey(placeholderCharacter + next1Chars)) { // For AV/BV/FV/AD/D stored with placeholder
+                            tileString = placeholderCharacter + next1Chars;
+                        } else if (tileHashMap.containsKey(next1Chars + placeholderCharacter)) { // For LV stored with placeholder
+                            tileString = next1Chars + placeholderCharacter;
                         }
                         break;
                     case 2:
@@ -1720,7 +1726,7 @@ public class Start extends AppCompatActivity {
                     // See if the blocks of length one, two, three or four Unicode characters matches game tiles
                     // Choose the longest block that matches a game tile and add that as the next segment in the parsed word array
                     charBlockLength = 0;
-                    if (tileHashMap.containsKey(next1Chars) || tileHashMap.containsKey("◌" + next1Chars) || tileHashMap.containsKey(next1Chars + "◌")) {
+                    if (tileHashMap.containsKey(next1Chars) || tileHashMap.containsKey(placeholderCharacter + next1Chars) || tileHashMap.containsKey(next1Chars + placeholderCharacter)) {
                         // If charBlockLength is already assigned 2 or 3 or 4, it should not overwrite with 1
                         charBlockLength = 1;
                     }
@@ -1744,10 +1750,10 @@ public class Start extends AppCompatActivity {
                         case 1:
                             if (tileHashMap.containsKey(next1Chars)){
                                 tileString = next1Chars;
-                            } else if (tileHashMap.containsKey("◌" + next1Chars)) { // For AV/BV/FV/AD/D stored with ◌
-                                tileString = "◌" + next1Chars;
-                            } else if (tileHashMap.containsKey(next1Chars + "◌")) { // For LV stored with ◌
-                                tileString = next1Chars + "◌";
+                            } else if (tileHashMap.containsKey(placeholderCharacter + next1Chars)) { // For AV/BV/FV/AD/D stored with placeholder
+                                tileString = placeholderCharacter + next1Chars;
+                            } else if (tileHashMap.containsKey(next1Chars + placeholderCharacter)) { // For LV stored with placeholder
+                                tileString = next1Chars + placeholderCharacter;
                             }
                             break;
                         case 2:


### PR DESCRIPTION
This is for languages with combining characters that require a generic base - placeholder - to be shown in isolation (instead of around another grapheme).

For example, a team can specify × as a stand-in for a base character, where ×າ is a vowel that follows a base character (in this script, Lao, that base would be a consonant or placeholder consonant).

The default placeholder the app looks for is ◌.