### PR TITLE
(1) Thailand word : upper (2) Add default placeholder (3) Fix validator negative index possibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 135
-        versionName "2.0.4"
+        versionCode 136
+        versionName "2.0.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -671,7 +671,11 @@ public class Start extends AppCompatActivity {
                 }
             }
         }
+
         placeholderCharacter = settingsList.find("Stand-in base for combining tiles"); // For Thai, Lao combining tiles
+        if (placeholderCharacter.equals("")) {
+            placeholderCharacter = " ";
+        }
 
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -541,7 +541,7 @@ public class Thailand extends GameActivity {
                     case "WORD_IMAGE":
                     case "WORD_AUDIO":
                         Tile firstAudibleTileInRefWord = firstAudibleTile(refWord);
-                        if (chosenItemText.equals(firstAudibleTileInRefWord.text)) {
+                        if (chosenItemText.equals(firstAudibleTileInRefWord.upper)) {
                             goodMatch = true;
                         }
                         break;

--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -506,8 +506,8 @@ public class Validator {
                         }
 
                         if (!charIsPartOfLongerKeyString) {
-                            String unicodeString = "(Unicode) " + (int) LOPwordString.charAt(i - 1);
-                            fatalErrors.add("In wordList, the word \"" + LOPwordString + "\" contains the character \"" + LOPwordString.charAt(i - 1) +
+                            String unicodeString = "(Unicode) " + (int) LOPwordString.charAt(i);
+                            fatalErrors.add("In wordList, the word \"" + LOPwordString + "\" contains the character \"" + LOPwordString.charAt(i) +
                                     "\" which is not in the keyboard. " + unicodeString);
                         }
                     }


### PR DESCRIPTION
(1)
Thailand games matching a reference word (text, image or audio) to an upper case tile choice could not be completed (e.g. a <> A). Reference now fixed.

(2)
Added space as the default placeholderCharacter when not specified in settings. (When unspecified for non-complex scripts (e.g. Roman), Colombia, Peru, Brazil and maybe others do not work correctly.)

(3)
Updated i-1 to i in two places, as needed. Issue revealed when checking a minimally ("workshop ready") language pack with an empty keyboard tab.