### PR TITLE
Better parsing and typing of complex tiles

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 144
-        versionName "2.1.1"
+        versionCode 145
+        versionName "2.1.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -780,6 +780,9 @@ public abstract class GameActivity extends AppCompatActivity {
             previousString = previousTile.text;
             if(previousString.contains(placeholderCharacter) && previousString.length()==2) { // Filter these placeholders out; keep the complex tile ones
                 previousString = previousString.replace(placeholderCharacter, "");
+            } else if (previousString.endsWith(placeholderCharacter) &&
+                    (previousString.length() - previousString.replaceAll(placeholderCharacter, "").length()) > 1) { // More than one placeholder character in this tile, to portray medial complex vowel
+                previousString = previousString.substring(0, previousString.length()-1);
             }
         }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
@@ -200,10 +200,15 @@ public class LoadingScreen extends AppCompatActivity {
         tileDurations = new HashMap();
 
         for (Start.Tile tile : tileList) {
-            int resId = res.getIdentifier(tile.audioForThisTileType, "raw", context.getPackageName());
-            int duration = getAssetDuration(resId) + 100;
-            tileAudioIDs.put(tile.audioForThisTileType, gameSounds.load(context, resId, 2));
-            tileDurations.put(tile.audioForThisTileType, duration);
+            if(!tile.audioForThisTileType.equals("zz_no_audio_needed")) {
+                int resId = res.getIdentifier(tile.audioForThisTileType, "raw", context.getPackageName());
+                int duration = getAssetDuration(resId) + 100;
+                tileAudioIDs.put(tile.audioForThisTileType, gameSounds.load(context, resId, 2));
+                tileDurations.put(tile.audioForThisTileType, duration);
+            } else {
+                totalAudio--;
+            }
+
         }
         LOGGER.info("LoadProgress: completed loadTileAudio()");
     }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -1625,46 +1625,71 @@ public class Start extends AppCompatActivity {
                 // See if the blocks of length one, two, three or four Unicode characters matches game tiles
                 // Choose the longest block that matches a game tile and add that as the next segment in the parsed word array
                 charBlockLength = 0;
-                if (tileHashMap.containsKey(next1Chars) || tileHashMap.containsKey(placeholderCharacter + next1Chars) || tileHashMap.containsKey(next1Chars + placeholderCharacter)) {
+                if (tileHashMap.containsKey(next1Chars) || tileHashMap.containsKey(placeholderCharacter + next1Chars) || tileHashMap.containsKey(next1Chars + placeholderCharacter) || tileHashMap.containsKey(placeholderCharacter + next1Chars + placeholderCharacter)) {
                     // If charBlockLength is already assigned 2 or 3 or 4, it should not overwrite with 1
                     charBlockLength = 1;
                 }
-                if (tileHashMap.containsKey(next2Chars)) {
+                if (tileHashMap.containsKey(next2Chars) || tileHashMap.containsKey(placeholderCharacter + next2Chars) || tileHashMap.containsKey(next2Chars + placeholderCharacter) || tileHashMap.containsKey(placeholderCharacter + next2Chars + placeholderCharacter)) {
                     // The value 2 can overwrite 1 but it can't overwrite 3 or 4
                     charBlockLength = 2;
                 }
-                if (tileHashMap.containsKey(next3Chars)) {
+                if (tileHashMap.containsKey(next3Chars) || tileHashMap.containsKey(placeholderCharacter + next3Chars) || tileHashMap.containsKey(next3Chars + placeholderCharacter) || tileHashMap.containsKey(placeholderCharacter + next3Chars + placeholderCharacter)) {
                     // The value 3 can overwrite 1 or 2 but it can't overwrite 4
                     charBlockLength = 3;
                 }
-                if (tileHashMap.containsKey(next4Chars)) {
+                if (tileHashMap.containsKey(next4Chars) || tileHashMap.containsKey(placeholderCharacter + next4Chars) || tileHashMap.containsKey(next4Chars + placeholderCharacter) || tileHashMap.containsKey(placeholderCharacter + next4Chars + placeholderCharacter)) {
                     // The value 4 can overwrite 1 or 2 or 3
                     charBlockLength = 4;
                 }
-
 
                 // Add the selected game tile (the longest selected from the previous loop) to the parsed word array
                 String tileString = "";
                 switch (charBlockLength) {
                     case 1:
-                        if (tileHashMap.containsKey(next1Chars)){
+                        if (tileHashMap.containsKey(next1Chars)) {
                             tileString = next1Chars;
                         } else if (tileHashMap.containsKey(placeholderCharacter + next1Chars)) { // For AV/BV/FV/AD/D stored with placeholder
                             tileString = placeholderCharacter + next1Chars;
                         } else if (tileHashMap.containsKey(next1Chars + placeholderCharacter)) { // For LV stored with placeholder
                             tileString = next1Chars + placeholderCharacter;
+                        } else if (tileHashMap.containsKey(placeholderCharacter + next1Chars + placeholderCharacter)) { // For medial vowel
+                            tileString = placeholderCharacter + next1Chars + placeholderCharacter;
                         }
                         break;
                     case 2:
-                        tileString = next2Chars;
+                        if (tileHashMap.containsKey(next2Chars)) {
+                            tileString = next2Chars;
+                        } else if (tileHashMap.containsKey(placeholderCharacter + next2Chars)) { // For AV/BV/FV/AD/D stored with placeholder
+                            tileString = placeholderCharacter + next2Chars;
+                        } else if (tileHashMap.containsKey(next2Chars + placeholderCharacter)) { // For LV stored with placeholder
+                            tileString = next2Chars + placeholderCharacter;
+                        } else if (tileHashMap.containsKey(placeholderCharacter + next2Chars + placeholderCharacter)) { // For medial vowel
+                            tileString = placeholderCharacter + next2Chars + placeholderCharacter;
+                        }
                         i++;
                         break;
                     case 3:
-                        tileString = next3Chars;
+                        if (tileHashMap.containsKey(next3Chars)) {
+                            tileString = next3Chars;
+                        } else if (tileHashMap.containsKey(placeholderCharacter + next3Chars)) { // For AV/BV/FV/AD/D stored with placeholder
+                            tileString = placeholderCharacter + next3Chars;
+                        } else if (tileHashMap.containsKey(next3Chars + placeholderCharacter)) { // For LV stored with placeholder
+                            tileString = next3Chars + placeholderCharacter;
+                        } else if (tileHashMap.containsKey(placeholderCharacter + next3Chars + placeholderCharacter)) { // For medial vowel
+                            tileString = placeholderCharacter + next3Chars + placeholderCharacter;
+                        }
                         i += 2;
                         break;
                     case 4:
-                        tileString = next4Chars;
+                        if (tileHashMap.containsKey(next4Chars)) {
+                            tileString = next4Chars;
+                        } else if (tileHashMap.containsKey(placeholderCharacter + next4Chars)) { // For AV/BV/FV/AD/D stored with placeholder
+                            tileString = placeholderCharacter + next4Chars;
+                        } else if (tileHashMap.containsKey(next4Chars + placeholderCharacter)) { // For LV stored with placeholder
+                            tileString = next4Chars + placeholderCharacter;
+                        } else if (tileHashMap.containsKey(placeholderCharacter + next4Chars + placeholderCharacter)) { // For medial vowel
+                            tileString = placeholderCharacter + next4Chars + placeholderCharacter;
+                        }
                         i += 3;
                         break;
                     default:
@@ -1730,19 +1755,19 @@ public class Start extends AppCompatActivity {
                     // See if the blocks of length one, two, three or four Unicode characters matches game tiles
                     // Choose the longest block that matches a game tile and add that as the next segment in the parsed word array
                     charBlockLength = 0;
-                    if (tileHashMap.containsKey(next1Chars) || tileHashMap.containsKey(placeholderCharacter + next1Chars) || tileHashMap.containsKey(next1Chars + placeholderCharacter)) {
+                    if (tileHashMap.containsKey(next1Chars) || tileHashMap.containsKey(placeholderCharacter + next1Chars) || tileHashMap.containsKey(next1Chars + placeholderCharacter) || tileHashMap.containsKey(placeholderCharacter + next1Chars + placeholderCharacter)) {
                         // If charBlockLength is already assigned 2 or 3 or 4, it should not overwrite with 1
                         charBlockLength = 1;
                     }
-                    if (tileHashMap.containsKey(next2Chars)) {
+                    if (tileHashMap.containsKey(next2Chars) || tileHashMap.containsKey(placeholderCharacter + next2Chars) || tileHashMap.containsKey(next2Chars + placeholderCharacter) || tileHashMap.containsKey(placeholderCharacter + next2Chars + placeholderCharacter)) {
                         // The value 2 can overwrite 1 but it can't overwrite 3 or 4
                         charBlockLength = 2;
                     }
-                    if (tileHashMap.containsKey(next3Chars)) {
+                    if (tileHashMap.containsKey(next3Chars) || tileHashMap.containsKey(placeholderCharacter + next3Chars) || tileHashMap.containsKey(next3Chars + placeholderCharacter) || tileHashMap.containsKey(placeholderCharacter + next3Chars + placeholderCharacter)) {
                         // The value 3 can overwrite 1 or 2 but it can't overwrite 4
                         charBlockLength = 3;
                     }
-                    if (tileHashMap.containsKey(next4Chars)) {
+                    if (tileHashMap.containsKey(next4Chars) || tileHashMap.containsKey(placeholderCharacter + next4Chars) || tileHashMap.containsKey(next4Chars + placeholderCharacter) || tileHashMap.containsKey(placeholderCharacter + next4Chars + placeholderCharacter)) {
                         // The value 4 can overwrite 1 or 2 or 3
                         charBlockLength = 4;
                     }
@@ -1752,24 +1777,50 @@ public class Start extends AppCompatActivity {
                     String tileString = "";
                     switch (charBlockLength) {
                         case 1:
-                            if (tileHashMap.containsKey(next1Chars)){
+                            if (tileHashMap.containsKey(next1Chars)) {
                                 tileString = next1Chars;
                             } else if (tileHashMap.containsKey(placeholderCharacter + next1Chars)) { // For AV/BV/FV/AD/D stored with placeholder
                                 tileString = placeholderCharacter + next1Chars;
                             } else if (tileHashMap.containsKey(next1Chars + placeholderCharacter)) { // For LV stored with placeholder
                                 tileString = next1Chars + placeholderCharacter;
+                            } else if (tileHashMap.containsKey(placeholderCharacter + next1Chars + placeholderCharacter)) { // For medial vowel
+                                tileString = placeholderCharacter + next1Chars + placeholderCharacter;
                             }
                             break;
                         case 2:
-                            tileString = next2Chars;
+                            if (tileHashMap.containsKey(next2Chars)) {
+                                tileString = next2Chars;
+                            } else if (tileHashMap.containsKey(placeholderCharacter + next2Chars)) { // For AV/BV/FV/AD/D stored with placeholder
+                                tileString = placeholderCharacter + next2Chars;
+                            } else if (tileHashMap.containsKey(next2Chars + placeholderCharacter)) { // For LV stored with placeholder
+                                tileString = next2Chars + placeholderCharacter;
+                            } else if (tileHashMap.containsKey(placeholderCharacter + next2Chars + placeholderCharacter)) { // For medial vowel
+                                tileString = placeholderCharacter + next2Chars + placeholderCharacter;
+                            }
                             i++;
                             break;
                         case 3:
-                            tileString = next3Chars;
+                            if (tileHashMap.containsKey(next3Chars)) {
+                                tileString = next3Chars;
+                            } else if (tileHashMap.containsKey(placeholderCharacter + next3Chars)) { // For AV/BV/FV/AD/D stored with placeholder
+                                tileString = placeholderCharacter + next3Chars;
+                            } else if (tileHashMap.containsKey(next3Chars + placeholderCharacter)) { // For LV stored with placeholder
+                                tileString = next3Chars + placeholderCharacter;
+                            } else if (tileHashMap.containsKey(placeholderCharacter + next3Chars + placeholderCharacter)) { // For medial vowel
+                                tileString = placeholderCharacter + next3Chars + placeholderCharacter;
+                            }
                             i += 2;
                             break;
                         case 4:
-                            tileString = next4Chars;
+                            if (tileHashMap.containsKey(next4Chars)) {
+                                tileString = next4Chars;
+                            } else if (tileHashMap.containsKey(placeholderCharacter + next4Chars)) { // For AV/BV/FV/AD/D stored with placeholder
+                                tileString = placeholderCharacter + next4Chars;
+                            } else if (tileHashMap.containsKey(next4Chars + placeholderCharacter)) { // For LV stored with placeholder
+                                tileString = next4Chars + placeholderCharacter;
+                            } else if (tileHashMap.containsKey(placeholderCharacter + next4Chars + placeholderCharacter)) { // For medial vowel
+                                tileString = placeholderCharacter + next4Chars + placeholderCharacter;
+                            }
                             i += 3;
                             break;
                         default:


### PR DESCRIPTION
This commit makes it possible to parse out larger tiles, especially when a team is storing some tiles with placeholder characters. These changes are made in the validator as well as the app.

It also amends an issue discovered in the Validator, in the reporting of needed MixedDefs when multi type tiles are present and no MixedDefs have been specified.