### PR TITLE
Fix bug (since 2.0.0) with trio mismatches (word text distinct from w…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 141
-        versionName "2.0.9"
+        versionCode 143
+        versionName "2.1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -306,7 +306,17 @@ public class Mexico extends GameActivity {
             cardA.setTextColor(tileColor); // theme color
             cardB.setTextColor(tileColor); // theme color
 
-            refWord.wordInLWC = memoryCollection.get(cardHitA)[0];
+            // necessary so that playCorrectSoundThenActiveWordClip below plays the right audio file (via refWord)
+            // TODO: calls to play audio in all games should include the LWC word value, not just trust that the active refWord.wordInLWC value is correct
+            // TODO: this is because there are many multi-word games (Italy, Mexico, Myanmar, China, others?) that can call many different audio files
+            refWord = new Start.Word(
+                    memoryCollection.get(cardHitA)[0],
+                    "",
+                    0,
+                    "",
+                    "",
+                    ""
+            );
 
             if (pairsCompleted == (visibleGameButtons / 2)) {
                 updatePointsAndTrackers((visibleGameButtons / 2));


### PR DESCRIPTION
…ord image/word audio pair), resulting from refWord.wordInLWC update in Mexico.

Prior to 2.0.0, the field of the game, wordInLWC, was overwritten. As of 2.0.0, it overwrites a field of refWord, which caused problems, because refWord was selected from chooseWord(), which takes a word from the wordlist, so a word in the wordlist had a field overwritten.