### PR TITLE
Validator updates 6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 141
-        versionName "2.0.9"
+        versionCode 144
+        versionName "2.1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/validator/src/main/java/org/alphatilesapps/validator/FilePresence.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/FilePresence.java
@@ -1,0 +1,178 @@
+package org.alphatilesapps.validator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+
+/// A class to manage checks for whether files exist
+public class FilePresence {
+    ArrayList<File> files = new ArrayList<>();
+    HashSet<String> folders = new HashSet<>();
+    HashMap<String, TagData> tagData = new HashMap<>();
+    public ArrayList<Message> fatalErrors = new ArrayList<>();
+    public ArrayList<Message> warnings = new ArrayList<>();
+    public ArrayList<Message> recommendations = new ArrayList<>();
+    /// Add a required file with subfolder and tag
+    public void add(String tag, String subfolder, String file, String mimeType, String reason, boolean optional) {
+        for(File other : files) {
+            if(!file.isEmpty() && other.name.equals(file) && other.folderName.equals(subfolder))
+                return;
+        }
+        folders.add(subfolder);
+        files.add(new File(tag, subfolder, file, mimeType, reason, optional));
+        tagData.putIfAbsent(tag, new TagData());
+    }
+    public void addAll(String tag, String subfolder, ArrayList<String> files, String mimeType, String reason, boolean optional) {
+        for(String file : files) {
+            add(tag, subfolder, file, mimeType, reason, optional);
+        }
+    }
+    public void check(Validator.GoogleDriveFolder langPack, boolean showExcess) {
+        ArrayList<ExcessFile> excessFiles = new ArrayList<>();
+        for(String folderName : folders) {
+            try {
+                Validator.GoogleDriveFolder folder = langPack.getFolderFromName(folderName);
+                for (int i = 0; i < folder.getFolderContents().size();) {
+                    Validator.GoogleDriveItem item = folder.getFolderContents().get(i);
+                    boolean excess = true;
+                    String stripped = item.getName().split("\\.")[0];
+                    for(File file : files) {
+                        if (!file.folderName.equals(folderName) || !file.incorrect) continue;
+                        boolean nameMatches = !file.hasName || file.name.equals(stripped);
+                        boolean typeMatches = false;
+                        for (String type : file.mimeTypes) {
+                            if (item.getMimeType().startsWith(type)) {
+                                typeMatches = true;
+                                break;
+                            }
+                        }
+                        if (nameMatches && typeMatches) {
+                            excess = false;
+                            file.incorrect = false;
+                            break;
+                        }
+                    }
+                    if (excess) {
+                        if(showExcess)
+                            warnings.add(new Message(Message.Tag.FilePresence, "Item " + item.getName() + " in folder " + folderName + " is not used and will not be downloaded"));
+                        excessFiles.add(new ExcessFile(folderName, stripped));
+                        folder.getFolderContents().remove(i);
+                    } else {
+                        i++;
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+        for(File file : files) {
+            TagData data = tagData.get(file.tag);
+            if(!file.incorrect) {
+                data.count++;
+            } else if(!file.optional) {
+                data.failed = true;
+                float minError = 0.4f;
+                ExcessFile closestMatch = null;
+                for(ExcessFile excess : excessFiles) {
+                    float error = wordDistance(excess.name, file.name)/(float)file.name.length();
+                    if(error < minError) {
+                        minError = error;
+                        closestMatch = excess;
+                    }
+                }
+                if(closestMatch != null)
+                    recommendations.add(new Message(Message.Tag.FilePresence, "Unused item " + closestMatch.name + " and missing item " + file.name + " are similar, did you make a typo?"));
+                if(file.hasName) {
+                    String extensionNote = "";
+                    if(file.name.contains(".")) {
+                        String actual = file.name.split("\\.")[0];
+                        extensionNote = ". Don't use file extensions in the google sheet, try changing " + file.name + " to " + actual + " there";
+                    }
+                    if(!file.reason.isEmpty()) {
+                        fatalErrors.add(new Message(Message.Tag.FilePresence, "Item " + file.name + ", which is required because "
+                                + file.reason + ", is missing from folder " + file.folderName + " or has the wrong mime type" + extensionNote));
+                    } else {
+                        fatalErrors.add(new Message(Message.Tag.FilePresence, "Required item " + file.name + " is missing from folder " + file.folderName + " or has the wrong mime type" + extensionNote));
+                    }
+                } else {
+                    fatalErrors.add(new Message(Message.Tag.FilePresence, "Required item of type " + file.mimeTypes + " is missing from folder " + file.folderName));
+                }
+            }
+        }
+    }
+    public boolean okay(String tag) {
+        TagData data = tagData.get(tag);
+        return data == null || !data.failed;
+    }
+    public boolean empty(String tag) {
+        TagData data = tagData.get(tag);
+        return data == null || data.count == 0;
+    }
+
+    static class ExcessFile {
+        String folder;
+        String name;
+        public ExcessFile(String folder, String name) {
+            this.folder = folder;
+            this.name = name;
+        }
+    }
+    static class File {
+        boolean optional;
+        boolean incorrect = true;
+        boolean hasName = true;
+        String tag;
+        Set<String> mimeTypes;
+        String folderName;
+        String name;
+        String reason;
+        File(String tag, String folderName, String name, String mimeTypes, String reason, boolean optional) {
+            this.tag = tag;
+            this.name = name;
+            if(name.isBlank()) {
+                hasName = false;
+            }
+            this.folderName = folderName;
+            this.optional = optional;
+            String[] split = mimeTypes.split(",");
+            this.mimeTypes = new HashSet<>();
+            for(String type : split) {
+                this.mimeTypes.add(type.strip());
+            }
+            this.reason = reason;
+        }
+    }
+    static class TagData {
+        int count = 0;
+        boolean failed = false;
+    }
+    // Word distance algorithm from https://www.baeldung.com/java-levenshtein-distance
+    public static int costOfSubstitution(char a, char b) {
+        return a == b ? 0 : 1;
+    }
+    public static int min(int... numbers) {
+        return Arrays.stream(numbers)
+                .min().orElse(Integer.MAX_VALUE);
+    }
+    static int wordDistance(String x, String y) {
+        int[][] dp = new int[x.length() + 1][y.length() + 1];
+
+        for (int i = 0; i <= x.length(); i++) {
+            for (int j = 0; j <= y.length(); j++) {
+                if (i == 0) {
+                    dp[i][j] = j;
+                }
+                else if (j == 0) {
+                    dp[i][j] = i;
+                }
+                else {
+                    dp[i][j] = min(dp[i - 1][j - 1]
+                                    + costOfSubstitution(x.charAt(i - 1), y.charAt(j - 1)),
+                            dp[i - 1][j] + 1,
+                            dp[i][j - 1] + 1);
+                }
+            }
+        }
+        return dp[x.length()][y.length()];
+    }
+}

--- a/validator/src/main/java/org/alphatilesapps/validator/Message.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Message.java
@@ -6,6 +6,7 @@ import java.util.Set;
 public class Message {
     public enum Tag {
         FilePresence,
+        PreWorkshop,
         Etc
     }
     public String content;
@@ -15,7 +16,7 @@ public class Message {
         this.content = content;
     }
     public static Set<Tag> allTags() {
-        return Set.of(Tag.FilePresence, Tag.Etc);
+        return Set.of(Tag.FilePresence, Tag.Etc, Tag.PreWorkshop);
     }
 
     @Override

--- a/validator/src/main/java/org/alphatilesapps/validator/Message.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Message.java
@@ -1,0 +1,34 @@
+package org.alphatilesapps.validator;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class Message {
+    public enum Tag {
+        FilePresence,
+        Etc
+    }
+    public String content;
+    public Tag tag;
+    public Message(Tag tag, String content) {
+        this.tag = tag;
+        this.content = content;
+    }
+    public static Set<Tag> allTags() {
+        return Set.of(Tag.FilePresence, Tag.Etc);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof Message) {
+            Message other = (Message)obj;
+            return other.tag == tag && other.content.equals(content);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(content, tag);
+    }
+}

--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -186,7 +186,7 @@ public class Validator {
                 }
                 Set<Message.Tag> tagsToShow;
                 if (checks.preWorkshop) {
-                    tagsToShow = Set.of(Message.Tag.FilePresence);
+                    tagsToShow = Set.of(Message.Tag.PreWorkshop);
                 } else {
                     tagsToShow = Message.allTags();
                 }
@@ -1020,6 +1020,7 @@ public class Validator {
                     true
             );
         }
+        filePresence.folderMessageTag("audio_words", Message.Tag.PreWorkshop);
         filePresence.check(langPackDriveFolder, checks.showExcess);
         warnings.addAll(filePresence.warnings);
         fatalErrors.addAll(filePresence.fatalErrors);
@@ -1087,6 +1088,7 @@ public class Validator {
         } catch (ValidatorException e) {
             warn(Message.Tag.Etc, FAILED_CHECK_WARNING + "the images_words_low_res folder or the wordlist tab");
         }
+        filePresence.folderMessageTag("images_words", Message.Tag.PreWorkshop);
         filePresence.check(langPackDriveFolder, checks.showExcess);
         warnings.addAll(filePresence.warnings);
         fatalErrors.addAll(filePresence.fatalErrors);

--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -2403,7 +2403,7 @@ public class Validator {
         public boolean preWorkshop = false;
         public boolean copySyllables = false;
         public Checks(JPanel dialog) {
-            addCheck(dialog, "Pre-workshop check", (ActionEvent e) -> preWorkshop = !preWorkshop, false);
+            addCheck(dialog, "Pre-workshop checks only", (ActionEvent e) -> preWorkshop = !preWorkshop, false);
             addCheck(dialog, "Show recommendations", (ActionEvent e) -> showRecommendations = !showRecommendations);
             addCheck(dialog, "Show excess file warnings", (ActionEvent e) -> showExcess = !showExcess);
             addCheck(dialog, "Copy syllables draft to clipboard", (ActionEvent e) -> copySyllables = !copySyllables, false);


### PR DESCRIPTION
Validator items
[# 09] retains .json on redownload of language pack
[# 16] report missing AudioName2 and AudioName3 files
[# 43] new method "filepresence" of reviewing missing/excess media
[# 45] option to copy a draft syllable table to clipboard
[# 48] correct warning when file extension included in resource tab col C
[# 56] set port to -1 instead of 8888, which resolves Mac error with no impact on Windows, Linux
[# 63] add option to run only preworkshop checks (wordlist and word images/audio)
[also] option to exclude excess media from report
[also] use "distractor" alongside any reference to "alternates" to make validation report consistent with setup instructions