### PR TITLE
Arabic complex parsing & RTL loading bar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 148
-        versionName "2.2.0"
+        versionCode 149
+        versionName "2.2.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -40,7 +40,6 @@ android {
     productFlavors {
         //Alpha Tiles internal team developers can find active product flavor definitions here:
         // https://docs.google.com/document/d/1a3satcmHFa5r6l7THrKLgxSWVCs-Mp2yOGyzk4oETsk/edit
-
         tpxTeocuitlapa {
             dimension "language"
             applicationIdSuffix ".blue.tpxTeocuitlapa"

--- a/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
@@ -2,6 +2,7 @@ package org.alphatilesapps.alphatiles;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
@@ -10,8 +11,10 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.media.MediaMetadataRetriever;
 import android.media.SoundPool;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -22,6 +25,7 @@ import static org.alphatilesapps.alphatiles.Start.gameSounds;
 import static org.alphatilesapps.alphatiles.Start.totalAudio;
 import static org.alphatilesapps.alphatiles.Start.tileAudioIDs;
 import static org.alphatilesapps.alphatiles.Start.tileList;
+import static org.alphatilesapps.alphatiles.Start.langInfoList;
 import static org.alphatilesapps.alphatiles.Start.tileDurations;
 import static org.alphatilesapps.alphatiles.Start.hasTileAudio;
 import static org.alphatilesapps.alphatiles.Start.syllableAudioIDs;
@@ -56,6 +60,13 @@ public class LoadingScreen extends AppCompatActivity {
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
         progressBar = findViewById(R.id.progressBar);
+        String scriptDirection = langInfoList.find("Script direction (LTR or RTL)");
+        if (scriptDirection.equals("RTL")) {
+            forceRTLIfSupported();
+            progressBar.setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
+        } else {
+            forceLTRIfSupported();
+        }
         context = this;
 
         String verName = BuildConfig.VERSION_NAME;
@@ -129,9 +140,11 @@ public class LoadingScreen extends AppCompatActivity {
                 mHandler.post(new Runnable() {
                     @Override
                     public void run() {
+
                         progressBar.getProgressDrawable().setColorFilter(
                                 Color.rgb(reds[mod_color[0]], greens[mod_color[0]], blues[mod_color[0]]),
                                 android.graphics.PorterDuff.Mode.SRC_IN);
+
                     }
                 });
             }
@@ -253,6 +266,22 @@ public class LoadingScreen extends AppCompatActivity {
             return Math.round((maxWordWidthInPixels * 100.0) / (wordWidthInPixels * 100));
         }
 
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    private void forceRTLIfSupported() {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            getWindow().getDecorView().setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    private void forceLTRIfSupported() {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            getWindow().getDecorView().setLayoutDirection(View.LAYOUT_DIRECTION_LTR);
+        }
     }
 
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -71,7 +71,7 @@ public class Start extends AppCompatActivity {
     public static Boolean hasSAD = false;
     public static double stageCorrespondenceRatio;
     public static int numberOfAvatars = 12;
-    public static String scriptType; // LM Can be "Thai", "Lao", or "Khmer" for special tile parsing. If nothing specified, tile parsing defaults to unidirectional.
+    public static String scriptType; // LM Can be "Thai", "Lao", "Khmer", or "Arabic" for special tile parsing. If nothing specified, tile parsing defaults to unidirectional.
 
     public static String placeholderCharacter; // LM Takes the place of a consonant for combining characters in complex scripts
     public static TileList CONSONANTS = new TileList();
@@ -699,7 +699,7 @@ public class Start extends AppCompatActivity {
         }
 
         localAppName = langInfoList.find("Game Name");
-        scriptType = langInfoList.find("Script type"); // If "Thai", "Lao", or "Khmer", special tile parsing occurs
+        scriptType = langInfoList.find("Script type"); // If "Thai", "Lao", "Khmer", or "Arabic", special tile parsing occurs
 
         String localWordForName = langInfoList.find("NAME in local language");
         if (localWordForName.equals("custom")) {
@@ -912,7 +912,7 @@ public class Start extends AppCompatActivity {
 
             String activeTileType = activeTile.typeOfThisTileInstance;
 
-            if(scriptType.matches("(Thai|Lao|Khmer)") && activeTileType.matches("LV") && scanSetting==1){
+            if(scriptType.matches("(Thai|Lao|Khmer|Arabic)") && activeTileType.matches("LV") && scanSetting==1){
                 return 0;
             }
 
@@ -920,7 +920,7 @@ public class Start extends AppCompatActivity {
             for (int i = 0; i < size(); i++) {
                 ArrayList<Tile> parsedWordArrayFinal = tileList.parseWordIntoTiles(get(i).wordInLOP, get(i));
                 int t = 0;
-                if(scriptType.matches("(Thai|Lao|Khmer)") && scanSetting==1) { // Find first sound tile (not LV, which is pronounced after the consonant it precedes)
+                if(scriptType.matches("(Thai|Lao|Khmer|Arabic)") && scanSetting==1) { // Find first sound tile (not LV, which is pronounced after the consonant it precedes)
                     Tile initialTile;
                     String initialTileType = "LV";
                     t = -1;
@@ -979,7 +979,7 @@ public class Start extends AppCompatActivity {
             for (int i = 0; i < size(); i++) {
                 parsedWordArrayFinal = tileList.parseWordIntoTiles(get(i).wordInLOP, get(i));
                 int t = 0;
-                if(scriptType.matches("(Thai|Lao|Khmer)") && scanSetting==1) { // Find first sound tile (not LV, which is pronounced after the consonant it precedes)
+                if(scriptType.matches("(Thai|Lao|Khmer|Arabic)") && scanSetting==1) { // Find first sound tile (not LV, which is pronounced after the consonant it precedes)
                     Tile initialTile;
                     String initialTileType = "LV";
                     t = -1;
@@ -1401,7 +1401,7 @@ public class Start extends AppCompatActivity {
 
         public ArrayList<Tile> parseWordIntoTiles (String stringToParse, Word referenceWord) {
             ArrayList<Tile> parsedWordArrayPreliminary = parseWordIntoTilesPreliminary(stringToParse, referenceWord);
-            if (!scriptType.matches("(Thai|Lao|Khmer)")) {
+            if (!scriptType.matches("(Thai|Lao|Khmer|Arabic)")) {
                 return parsedWordArrayPreliminary;
             } else {
                 if(placeholderCharacter.isEmpty()) {
@@ -1463,7 +1463,7 @@ public class Start extends AppCompatActivity {
                 String vowelStringSoFar = "";
                 String vowelTypeSoFar = "";
                 String diacriticStringSoFar = "";
-                Tile nonCombiningVowelFromPreviousSyllable = null;
+                ArrayList<Tile> nonCombiningVowelsFromPreviousSyllable = new ArrayList<>();
                 for (int b = previousConsonantIndex + 1; b < currentConsonantIndex; b++) {
                     currentTile = parsedWordArrayPreliminary.get(b);
                     currentTileString = currentTile.text;
@@ -1476,12 +1476,12 @@ public class Start extends AppCompatActivity {
                             vowelTypeSoFar = tileHashMap.find(vowelStringSoFar).tileType; // complex tiles do not get multityping
                         }
                     } else if (currentTileType.equals("V")) {
-                        nonCombiningVowelFromPreviousSyllable = currentTile;
+                        nonCombiningVowelsFromPreviousSyllable.add(currentTile);
                     }
                 }
 
                 // Find vowel, diacritic, space, and dash symbols that occur between current and next consonants
-                Tile nonComplexV = null;
+                ArrayList<Tile> nonComplexVsorXs = new ArrayList<>();
                 for (int a = currentConsonantIndex + 1; a < nextConsonantIndex; a++) {
                     currentTile = parsedWordArrayPreliminary.get(a);
                     currentTileString = currentTile.text;
@@ -1515,15 +1515,15 @@ public class Start extends AppCompatActivity {
                         diacriticStringSoFar+=currentTileString;
                     } else if (currentTileType.equals("SAD")) { // Save any Space-And-Dash chars that comes between syllables.
                         SADTiles.add(currentTile);
-                    } else if (!foundNextConsonant && currentTileType.equals("V")){ // There is a V (not LV/FV/AV/BV) on the end of the word
-                        nonComplexV = currentTile;
+                    } else if (!foundNextConsonant && currentTileType.matches("(V|X)")){ // These don't combine and should be added in order of occurence
+                        nonComplexVsorXs.add(currentTile);
                     }
                 }
 
 
                 // Add saved items to the tile array
-                if(!(nonCombiningVowelFromPreviousSyllable==null)){
-                    parsedWordTileArray.add(nonCombiningVowelFromPreviousSyllable);
+                if(!(nonCombiningVowelsFromPreviousSyllable.isEmpty())){
+                    parsedWordTileArray.addAll(nonCombiningVowelsFromPreviousSyllable);
                 }
                 if (!(currentConsonant==null)) {
                     // Combine diacritics with consonant if that combination is in the tileList. Ex:บ๋
@@ -1576,8 +1576,8 @@ public class Start extends AppCompatActivity {
                     }
 
                     // If a V is found before the (next) consonant, add it. It is syllable-initial or -mid.
-                    if (!(nonComplexV == null)) {
-                        parsedWordTileArray.add(nonComplexV);
+                    if (!(nonComplexVsorXs.isEmpty())) {
+                        parsedWordTileArray.addAll(nonComplexVsorXs);
                     }
 
                     // Add any other diacritics after any Vs.

--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -121,7 +121,7 @@ public class Validator {
 
 
     /**
-     * Could be Roman, Thai, Lao, or Khmer. Read from langinfo
+     * Could be Roman, Thai, Lao, Khmer, Arabic. Read from langinfo
      */
     public static String scriptType;
     /**
@@ -2141,7 +2141,7 @@ public class Validator {
      */
     private ArrayList<String> parseTypeSpecification(Word word) throws ValidatorException {
         ArrayList<Tile> wordAsSimpleTileList;
-        if (scriptType.matches("(Thai|Lao|Khmer)")) { // Type specifications must map to all simple, contiguous tile pieces, and not to the final parsing, which contains any complex tiles
+        if (scriptType.matches("(Thai|Lao|Khmer|Arabic)")) { // Type specifications must map to all simple, contiguous tile pieces, and not to the final parsing, which contains any complex tiles
             wordAsSimpleTileList = tileList.parseWordIntoTilesPreliminary(word);
         } else {
             wordAsSimpleTileList = tileList.parseWordIntoTiles(word);
@@ -2219,7 +2219,7 @@ public class Validator {
     private ArrayList<String> parseAbbreviatedTypeSpecification(Word word) throws ValidatorException {
         Tab gameTilesTab = langPackGoogleSheet.getTabFromName("gametiles");
         ArrayList<Tile> wordAsSimpleTileList;
-        if (scriptType.matches("(Thai|Lao|Khmer)")) { // Type specifications must be given for all contiguous tile pieces (not mapped to the final parsing, which will get complex tiles)
+        if (scriptType.matches("(Thai|Lao|Khmer|Arabic)")) { // Type specifications must be given for all contiguous tile pieces (not mapped to the final parsing, which will get complex tiles)
             wordAsSimpleTileList = tileList.parseWordIntoTilesPreliminary(word);
         } else {
             wordAsSimpleTileList = tileList.parseWordIntoTiles(word);
@@ -2609,7 +2609,7 @@ public class Validator {
         public ArrayList<Tile> parseWordIntoTiles(Word wordListWord) {
 
             ArrayList<Tile> parsedWordArrayPreliminary = parseWordIntoTilesPreliminary(wordListWord);
-            if (!scriptType.matches("(Thai|Lao|Khmer)")) {
+            if (!scriptType.matches("(Thai|Lao|Khmer|Arabic)")) {
                 return parsedWordArrayPreliminary;
             }
 


### PR DESCRIPTION
Complex tiles with placeholders can now be parsed for Arabic script language packs (Script type = "Arabic" in langinfo).
The progress bar on the loading screen now loads from right to left for RTL language packs (Script direction = "RTL" in langinfo)