### PR TITLE
Update to comply with API35 edge to edge

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 156
-        versionName "2.3.3"
+        versionCode 157
+        versionName "2.4.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
     implementation 'com.google.zxing:core:3.2.1'
     implementation 'com.google.android.material:material:1.12.0'
-    implementation platform('com.google.firebase:firebase-bom:33.6.0')
+    implementation platform('com.google.firebase:firebase-bom:33.7.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.segment.analytics.android:analytics:4.+'
     testImplementation 'androidx.test.ext:junit:1.2.1'

--- a/app/src/main/java/org/alphatilesapps/alphatiles/About.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/About.java
@@ -38,8 +38,6 @@ public class About extends AppCompatActivity {
         ActivityLayouts.applyEdgeToEdge(this, R.id.aboutCL);
         ActivityLayouts.setStatusAndNavColors(this);
 
-        setTitle(Start.localAppName);
-
         TextView localName = findViewById(R.id.gameNameInLOP);
         localName.setText(Start.localAppName);
         TextView lgNamesPlusCountry = findViewById(R.id.langNamesPlusCountry);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/About.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/About.java
@@ -35,6 +35,9 @@ public class About extends AppCompatActivity {
 
         setContentView(R.layout.about);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.aboutCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         setTitle(Start.localAppName);
 
         TextView localName = findViewById(R.id.gameNameInLOP);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/ActivityLayouts.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/ActivityLayouts.java
@@ -42,9 +42,8 @@ public final class ActivityLayouts {
         Window window = activity.getWindow();
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
         window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-        window.setStatusBarColor(activity.getResources().getColor(R.color.WHITE));
-        window.setNavigationBarColor(activity.getResources().getColor(R.color.WHITE));
-
+        window.setStatusBarColor(activity.getResources().getColor(R.color.themeBlue));
+        window.setNavigationBarColor(activity.getResources().getColor(R.color.themeBlue));
     }
 
 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/ActivityLayouts.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/ActivityLayouts.java
@@ -1,0 +1,50 @@
+package org.alphatilesapps.alphatiles;
+
+import android.app.Activity;
+import android.os.Build;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+
+import androidx.activity.ComponentActivity;
+import androidx.activity.EdgeToEdge;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+// https://developer.android.com/develop/ui/views/layout/edge-to-edge-manually
+// https://stackoverflow.com/questions/76868700/set-insets-for-all-activities-android
+// https://stackoverflow.com/questions/57293449/go-edge-to-edge-on-android-correctly-with-windowinsets
+
+public final class ActivityLayouts {
+
+    public static void applyEdgeToEdge(ComponentActivity activity, int fittedViewId) {
+
+        View view = activity.findViewById(fittedViewId);
+
+        EdgeToEdge.enable(activity);
+
+        // Set Listener
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            mlp.topMargin = insets.top;
+            mlp.bottomMargin = insets.bottom;
+            mlp.leftMargin = insets.left;
+            mlp.rightMargin = insets.right;
+            v.setLayoutParams(mlp);
+            return windowInsets;
+        });
+
+    }
+    public static void setStatusAndNavColors (Activity activity) {
+        Window window = activity.getWindow();
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+        window.setStatusBarColor(activity.getResources().getColor(R.color.WHITE));
+        window.setNavigationBarColor(activity.getResources().getColor(R.color.WHITE));
+
+    }
+
+}

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -9,9 +9,6 @@ import android.widget.TextView;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
-
 import java.util.HashSet;
 import java.util.Random;
 import java.util.ArrayList;
@@ -74,24 +71,10 @@ public class Brazil extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID = 0;
-        if (challengeLevel == 3 || challengeLevel == 6) {
-            gameID = R.id.brazil_cl3_CL;
-        } else {
-            gameID = R.id.brazil_cl1_CL;
-        }
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
 
     }
 
@@ -166,9 +149,6 @@ public class Brazil extends GameActivity {
 
         Collections.shuffle(MULTITYPE_TILES);
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-
-        setTitle(localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
         if (syllableGame.equals("S")) {
             visibleGameButtons = 4;
         } else {
@@ -198,7 +178,7 @@ public class Brazil extends GameActivity {
         }
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         updatePointsAndTrackers(0);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -105,18 +105,22 @@ public class Brazil extends GameActivity {
             setContentView(R.layout.brazil_cl1);
         }
 
+        int gameID = 0;
+        if (challengeLevel == 3 || challengeLevel == 6) {
+            gameID = R.id.brazil_cl3_CL;
+        } else {
+            gameID = R.id.brazil_cl1_CL;
+        }
+
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
 
             instructionsImage.setRotationY(180);
             repeatImage.setRotationY(180);
-            int gameID = 0;
-            if (challengeLevel == 3 || challengeLevel == 6) {
-                gameID = R.id.brazil_cl3_CL;
-            } else {
-                gameID = R.id.brazil_cl1_CL;
-            }
             fixConstraintsRTL(gameID);
         }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Celebration.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Celebration.java
@@ -22,6 +22,9 @@ public class Celebration extends AppCompatActivity {
         context = this;
         setContentView(R.layout.celebration);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.celebrationCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         gameSounds.play(correctFinalSoundID, 1.0f, 1.0f, 2, 0, 1.0f);
 
     }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Chile.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Chile.java
@@ -89,6 +89,10 @@ public class Chile extends GameActivity {
         LOGGER.log(Level.INFO, "Chile start");
         context = this;
         setContentView(R.layout.chile);
+
+        ActivityLayouts.applyEdgeToEdge(this, R.id.chileCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         updatePointsAndTrackers(0);
         setAdvanceArrowToGray();
         if (scriptDirection.equals("RTL")) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Chile.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Chile.java
@@ -9,9 +9,6 @@ import android.widget.GridView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -68,19 +65,11 @@ public class Chile extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
         // Copied from Sudan.java
         View instructionsButton = findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
 
-        int gameID = R.id.chileCL;
-
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage,ConstraintSet.END,R.id.backspace,ConstraintSet.START,0);
-        //constraintSet.connect(R.id.backspace,ConstraintSet.START,R.id.gamesHomeImage,ConstraintSet.END,0);
-        constraintSet.applyTo(constraintLayout);
     }
 
     @Override
@@ -101,8 +90,6 @@ public class Chile extends GameActivity {
         }
         data.guesses = baseGuessCount - challengeLevel + 1;
         int guessBoxID = R.id.guessBox;
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
         guessBox = findViewById(guessBoxID);
         guessAdapter = new TileAdapter(tiles);
         guessAdapter.setFontScale(data.fontScale);
@@ -144,7 +131,7 @@ public class Chile extends GameActivity {
         currentRow = 0;
         int iID = getAudioInstructionsResID();
         if(iID == 0 || iID == -1) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
     }
     private void resetTiles() {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/China.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/China.java
@@ -82,6 +82,10 @@ public class China extends GameActivity {
         context = this;
         setContentView(R.layout.china);
         int gameID = R.id.chinaCL;
+
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
         setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/China.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/China.java
@@ -17,9 +17,6 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Random;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
-
 //Game of 15
 public class China extends GameActivity {
     ArrayList<Start.Word> threeFourTileWords = new ArrayList<>();
@@ -48,19 +45,11 @@ public class China extends GameActivity {
     };
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
 
-        int gameID = R.id.chinaCL;
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
     }
 
     @Override
@@ -86,9 +75,6 @@ public class China extends GameActivity {
         ActivityLayouts.applyEdgeToEdge(this, gameID);
         ActivityLayouts.setStatusAndNavColors(this);
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
@@ -100,7 +86,7 @@ public class China extends GameActivity {
         }
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         visibleGameButtons = 16;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
@@ -83,6 +83,9 @@ public class ChoosePlayer extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.choose_player);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.choosePlayerCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
         if (scriptDirection.equals("RTL")) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -7,9 +7,6 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -64,24 +61,9 @@ public class Colombia extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID;
-        if (syllableGame.equals("S")) {
-            gameID = R.id.colombiaCL_syll;
-        } else {
-            gameID = R.id.colombiaCL;
-        }
-
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
 
     }
 
@@ -113,11 +95,8 @@ public class Colombia extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         keyboardScreenNo = 1;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -98,6 +98,9 @@ public class Colombia extends GameActivity {
             gameID = R.id.colombiaCL;
         }
 
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
@@ -62,8 +62,6 @@ public class Earth extends AppCompatActivity {
             activePlayerImage.setRotationY(180);
         }
 
-        setTitle(Start.localAppName);
-
         SharedPreferences prefs = getSharedPreferences(ChoosePlayer.SHARED_PREFS, MODE_PRIVATE);
         globalPoints = getIntent().getIntExtra("globalPoints", 0);
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
@@ -32,9 +32,9 @@ public class Earth extends AppCompatActivity {
     int playerNumber = -1;
     String playerString;
     char grade;
-    int pageNumber; // Games 001 to 023 are displayed on page 1, games 024 to 046 are displayed on page 2, etc.
+    int pageNumber; // Games 001 to 033 are displayed on page 1, games 034 to 066 are displayed on page 2, etc.
     int globalPoints;
-    int doorsPerPage = 23;
+    int doorsPerPage = 33;
     ConstraintLayout earthCL;
 
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
@@ -47,6 +47,9 @@ public class Earth extends AppCompatActivity {
         setContentView(R.layout.earth);
         earthCL = findViewById(R.id.earthCL);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.earthCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
         if (scriptDirection.equals("RTL")) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
@@ -90,6 +90,9 @@ public class Ecuador extends GameActivity {
         context = this;
         setContentView(R.layout.ecuador);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.ecuadorCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
@@ -55,20 +55,11 @@ public class Ecuador extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID = R.id.ecuadorCL;
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
-
+        
     }
 
     @Override
@@ -91,7 +82,6 @@ public class Ecuador extends GameActivity {
         setContentView(R.layout.ecuador);
 
         ActivityLayouts.applyEdgeToEdge(this, R.id.ecuadorCL);
-        ActivityLayouts.setStatusAndNavColors(this);
 
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
@@ -103,12 +93,8 @@ public class Ecuador extends GameActivity {
             fixConstraintsRTL(R.id.ecuadorCL);
         }
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         visibleGameButtons = GAME_BUTTONS.length;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -248,7 +248,15 @@ public abstract class GameActivity extends AppCompatActivity {
         gameNumberBox.setBackgroundColor(gameColor);
         pointsEarned.setBackgroundColor(gameColor);
         TextView challengeLevelBox = findViewById(R.id.challengeLevelView);
-        challengeLevelBox.setText(String.valueOf(challengeLevel));
+
+        int displayedChallengeLevel = challengeLevel;
+        if (gameList.get(gameNumber-1).country.equals("Brazil") && challengeLevel != 7) {
+            displayedChallengeLevel = displayedChallengeLevel - 3;
+        }
+        if (gameList.get(gameNumber-1).country.equals("Georgia") && challengeLevel > 6) {
+            displayedChallengeLevel = displayedChallengeLevel - 6;
+        }
+        challengeLevelBox.setText(String.valueOf(displayedChallengeLevel));
 
         // Update tracker icons
         for (int t = 0; t < TRACKERS.length; t++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
+import android.graphics.Color;
 import android.media.MediaPlayer;
 import android.os.Build;
 import android.os.Bundle;
@@ -31,6 +32,7 @@ import java.util.logging.Logger;
 
 import static org.alphatilesapps.alphatiles.Start.MULTITYPE_TILES;
 import static org.alphatilesapps.alphatiles.Start.SILENT_PRELIMINARY_TILES;
+import static org.alphatilesapps.alphatiles.Start.colorList;
 import static org.alphatilesapps.alphatiles.Start.differentiatesTileTypes;
 import static org.alphatilesapps.alphatiles.Start.gameList;
 import static org.alphatilesapps.alphatiles.Start.stageCorrespondenceRatio;
@@ -107,7 +109,7 @@ public abstract class GameActivity extends AppCompatActivity {
 
     protected abstract int getAudioInstructionsResID();
 
-    protected abstract void centerGamesHomeImage();
+    protected abstract void hideInstructionAudioImage();
 
     private static final Logger LOGGER = Logger.getLogger(GameActivity.class.getName());
 
@@ -239,6 +241,14 @@ public abstract class GameActivity extends AppCompatActivity {
         points+=pointsIncrease;
         TextView pointsEarned = findViewById(R.id.pointsTextView);
         pointsEarned.setText(String.valueOf(points));
+
+        TextView gameNumberBox = findViewById(R.id.gameNumberView);
+        gameNumberBox.setText(String.valueOf(gameNumber));
+        int gameColor = Color.parseColor(colorList.get(Integer.parseInt(gameList.get(gameNumber-1).color)));
+        gameNumberBox.setBackgroundColor(gameColor);
+        pointsEarned.setBackgroundColor(gameColor);
+        TextView challengeLevelBox = findViewById(R.id.challengeLevelView);
+        challengeLevelBox.setText(String.valueOf(challengeLevel));
 
         // Update tracker icons
         for (int t = 0; t < TRACKERS.length; t++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -249,8 +249,14 @@ public abstract class GameActivity extends AppCompatActivity {
         pointsEarned.setBackgroundColor(gameColor);
         TextView challengeLevelBox = findViewById(R.id.challengeLevelView);
 
-        int displayedChallengeLevel = challengeLevel;
-        if (gameList.get(gameNumber-1).country.equals("Brazil") && challengeLevel != 7) {
+        int displayedChallengeLevel;
+        if (gameList.get(gameNumber-1).country.equals("Thailand")) {
+            displayedChallengeLevel = challengeLevel / 100;
+        }
+        else {
+            displayedChallengeLevel = challengeLevel;
+        }
+        if (gameList.get(gameNumber-1).country.equals("Brazil") && challengeLevel > 3 && challengeLevel != 7) {
             displayedChallengeLevel = displayedChallengeLevel - 3;
         }
         if (gameList.get(gameNumber-1).country.equals("Georgia") && challengeLevel > 6) {
@@ -497,8 +503,10 @@ public abstract class GameActivity extends AppCompatActivity {
                 wordImage = findViewById(getWordImages()[i]);
                 wordImage.setClickable(false);
             }
-        ImageView repeatImage = findViewById(R.id.repeatImage);
-        repeatImage.setClickable(false);
+        if (!gameList.get(gameNumber-1).country.equals("Romania")&&!gameList.get(gameNumber-1).country.equals("Sudan")) {
+            ImageView repeatImage = findViewById(R.id.repeatImage);
+            repeatImage.setClickable(false);
+        }
     }
 
     protected void setOptionsRowClickable() {
@@ -512,8 +520,10 @@ public abstract class GameActivity extends AppCompatActivity {
                 wordImage = findViewById(getWordImages()[i]);
                 wordImage.setClickable(true);
             }
-        ImageView repeatImage = findViewById(R.id.repeatImage);
-        repeatImage.setClickable(true);
+        if (!gameList.get(gameNumber-1).country.equals("Romania")&&!gameList.get(gameNumber-1).country.equals("Sudan")) {
+            ImageView repeatImage = findViewById(R.id.repeatImage);
+            repeatImage.setClickable(true);
+        }
     }
 
     protected void setAdvanceArrowToBlue() {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -116,6 +116,9 @@ public class Georgia extends GameActivity {
             gameID = R.id.georgiaCL;
         }
 
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -7,9 +7,6 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -70,23 +67,10 @@ public class Georgia extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-        int gameID = 0;
-        if (syllableGame.equals("S")) {
-            gameID = R.id.georgiaCL_syll;
-        } else {
-            gameID = R.id.georgiaCL;
-        }
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
     }
 
     @Override
@@ -129,9 +113,6 @@ public class Georgia extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         switch (challengeLevel) {
             case 11:
             case 8:
@@ -154,7 +135,7 @@ public class Georgia extends GameActivity {
         }
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         incorrectAnswersSelected = new ArrayList<>(visibleGameButtons-1);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -91,6 +91,9 @@ public class Italy extends GameActivity {
         setContentView(R.layout.italy);
         int gameID = R.id.italyCL;
 
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -13,9 +13,6 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
-
 import java.util.Collections;
 
 import static org.alphatilesapps.alphatiles.Start.colorList;
@@ -65,22 +62,11 @@ public class Italy extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID = R.id.italyCL;
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet
-                .START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet
-                .END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
-
+        
     }
 
     @Override
@@ -94,7 +80,6 @@ public class Italy extends GameActivity {
         ActivityLayouts.applyEdgeToEdge(this, gameID);
         ActivityLayouts.setStatusAndNavColors(this);
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
@@ -109,8 +94,6 @@ public class Italy extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         if (syllableGame.equals("S")) {
             sortableSyllArray = (Start.SyllableList) syllableList.clone();
             Collections.shuffle(sortableSyllArray);
@@ -120,7 +103,7 @@ public class Italy extends GameActivity {
         }
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         updatePointsAndTrackers(0);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
@@ -105,6 +105,9 @@ public class Japan extends GameActivity {
             gameID = R.id.japancl_12;
         }
 
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
 
         setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Japan.java
@@ -62,23 +62,9 @@ public class Japan extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID = 0;
-        if (challengeLevel == 1) {
-            gameID = R.id.japancl_7;
-        } else {
-            gameID = R.id.japancl_12;
-        }
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
     }
 
     @Override
@@ -108,10 +94,6 @@ public class Japan extends GameActivity {
         ActivityLayouts.applyEdgeToEdge(this, gameID);
         ActivityLayouts.setStatusAndNavColors(this);
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);     // forces landscape mode only
 
         if (scriptDirection.equals("RTL")) {
@@ -125,7 +107,7 @@ public class Japan extends GameActivity {
         }
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         updatePointsAndTrackers(0);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
@@ -15,6 +15,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -57,6 +59,9 @@ public class LoadingScreen extends AppCompatActivity {
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_loading_screen);
+        ActivityLayouts.applyEdgeToEdge(this, R.id.activityloadingscreenCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
         progressBar = findViewById(R.id.progressBar);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Malaysia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Malaysia.java
@@ -59,6 +59,10 @@ public class Malaysia extends GameActivity {
         setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
         determineNumPages();
         setContentView(R.layout.malaysia);
+
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         assignPages();
         displayWords(0);
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Malaysia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Malaysia.java
@@ -3,8 +3,6 @@ package org.alphatilesapps.alphatiles;
 import static org.alphatilesapps.alphatiles.Start.colorList;
 import static org.alphatilesapps.alphatiles.Start.gameSounds;
 
-import android.util.Log;
-
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -19,7 +17,6 @@ import static org.alphatilesapps.alphatiles.Start.*; //one new
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 
 public class Malaysia extends GameActivity {
     List<List<Start.Word>> wordPagesLists = new ArrayList<>();
@@ -55,8 +52,6 @@ public class Malaysia extends GameActivity {
         super.onCreate(savedInstanceState);
         context = this;
         int gameID = R.id.malaysiaCL;
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
         determineNumPages();
         setContentView(R.layout.malaysia);
 
@@ -67,7 +62,7 @@ public class Malaysia extends GameActivity {
         displayWords(0);
 
         if (scriptDirection.equals("RTL")) fixConstraintsRTLMalaysia(gameID);
-        if (getAudioInstructionsResID() == 0) centerGamesHomeImage();
+        if (getAudioInstructionsResID() == 0) hideInstructionAudioImage();
         showOrHideScrollingArrows();
         setAllImagesBlank();
         setAllGameButtonsClickable();
@@ -154,19 +149,10 @@ public class Malaysia extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
-        // TO DO: TEST THIS WITH A LANGUAGE THAT DOESN'T HAVE INSTRUCTION AUDIO, CONNECT BACK ARROW
+    protected void hideInstructionAudioImage() {
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
 
-        int gameID = R.id.malaysiaCL;
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        //constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        //constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
     }
 
     private void fixConstraintsRTLMalaysia(int gameID) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -9,14 +9,10 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-
 import java.util.ArrayList;
 import java.util.Collections;
 
 import static android.graphics.Color.BLACK;
-
-import androidx.constraintlayout.widget.ConstraintSet;
 
 import static org.alphatilesapps.alphatiles.Start.*;
 
@@ -57,20 +53,11 @@ public class Mexico extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID = R.id.mexicoCL;
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
-
+        
     }
 
     @Override
@@ -91,9 +78,6 @@ public class Mexico extends GameActivity {
 
             fixConstraintsRTL(R.id.mexicoCL);
         }
-
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         // new levels
         // Level 1: 3 pairs = 6
@@ -120,7 +104,7 @@ public class Mexico extends GameActivity {
 
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         updatePointsAndTrackers(0);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -79,6 +79,9 @@ public class Mexico extends GameActivity {
         context = this;
         setContentView(R.layout.mexico);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.mexicoCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = findViewById(R.id.instructions);
             ImageView repeatImage = findViewById(R.id.repeatImage);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -145,18 +145,6 @@ public class Myanmar extends GameActivity {
         pixelHeight = (int) (scaling * percentHeight * heightOfDisplay);
         wordToBuild.setTextSize(TypedValue.COMPLEX_UNIT_PX, pixelHeight);
 
-        // Requires an extra step since the image is anchored to guidelines NOT the textview whose font size we want to edit
-        TextView pointsEarned = findViewById(R.id.pointsTextView);
-        ImageView pointsEarnedImage = (ImageView) findViewById(R.id.pointsImage);
-        ConstraintLayout.LayoutParams lp3 = (ConstraintLayout.LayoutParams) pointsEarnedImage.getLayoutParams();
-        int bottomToTopId3 = lp3.bottomToTop;
-        int topToTopId3 = lp3.topToTop;
-        percentBottomToTop = ((ConstraintLayout.LayoutParams) findViewById(bottomToTopId3).getLayoutParams()).guidePercent;
-        percentTopToTop = ((ConstraintLayout.LayoutParams) findViewById(topToTopId3).getLayoutParams()).guidePercent;
-        percentHeight = percentBottomToTop - percentTopToTop;
-        pixelHeight = (int) (0.5 * scaling * percentHeight * heightOfDisplay);
-        pointsEarned.setTextSize(TypedValue.COMPLEX_UNIT_PX, pixelHeight);
-
     }
 
     public void repeatGame(View View) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -94,6 +94,9 @@ public class Myanmar extends GameActivity {
         context = this;
         setContentView(R.layout.myanmar);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.myanmarCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -12,7 +12,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
 
 import java.util.ArrayList;
 import java.util.Objects;
@@ -68,20 +67,11 @@ public class Myanmar extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID = R.id.myanmarCL;
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
-
+        
     }
 
     private static final int[] WORD_IMAGES = {
@@ -107,12 +97,8 @@ public class Myanmar extends GameActivity {
             fixConstraintsRTL(R.id.myanmarCL);
         }
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         setTextSizes();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
@@ -7,9 +7,6 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,19 +46,10 @@ public class Peru extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID = R.id.peruCL;
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
 
     }
 
@@ -84,12 +72,8 @@ public class Peru extends GameActivity {
             fixConstraintsRTL(R.id.peruCL);
         }
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         if (challengeLevel == 2) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
@@ -71,6 +71,9 @@ public class Peru extends GameActivity {
         context = this;
         setContentView(R.layout.peru);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.peruCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
@@ -48,6 +48,9 @@ public class Resources extends AppCompatActivity {
 
         setContentView(R.layout.resources);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.resourcesCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         setTitle(Start.localAppName);
 
         buildResourcesArray();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
@@ -51,8 +51,6 @@ public class Resources extends AppCompatActivity {
         ActivityLayouts.applyEdgeToEdge(this, R.id.resourcesCL);
         ActivityLayouts.setStatusAndNavColors(this);
 
-        setTitle(Start.localAppName);
-
         buildResourcesArray();
         loadResources();
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -81,6 +81,10 @@ public class Romania extends GameActivity {
         super.onCreate(savedInstanceState);
         context = this;
         setContentView(R.layout.romania);
+
+        ActivityLayouts.applyEdgeToEdge(this, R.id.romaniaCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel;
         setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -13,8 +13,6 @@ import android.text.SpannableStringBuilder;
 import android.text.Spannable;
 import android.text.style.StyleSpan;
 import android.graphics.Typeface;
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
 
 import static org.alphatilesapps.alphatiles.Start.*;
 
@@ -64,16 +62,10 @@ public class Romania extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
 
-        int gameID = R.id.romaniaCL;
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
     }
 
     @Override
@@ -84,9 +76,6 @@ public class Romania extends GameActivity {
 
         ActivityLayouts.applyEdgeToEdge(this, R.id.romaniaCL);
         ActivityLayouts.setStatusAndNavColors(this);
-
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         ImageView image = (ImageView) findViewById(R.id.repeatImage);
         image.setVisibility(View.INVISIBLE);
@@ -153,7 +142,7 @@ public class Romania extends GameActivity {
         }
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         int i = 0;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -77,43 +77,7 @@ public class Romania extends GameActivity {
         ActivityLayouts.applyEdgeToEdge(this, R.id.romaniaCL);
         ActivityLayouts.setStatusAndNavColors(this);
 
-        ImageView image = (ImageView) findViewById(R.id.repeatImage);
-        image.setVisibility(View.INVISIBLE);
-
-        Boolean showFilterOptions;
-        String hasFilterSetting = settingsList.find("Show filter options for Game 001");
-        if (!hasFilterSetting.equals("")) {
-            showFilterOptions = Boolean.parseBoolean(hasFilterSetting);
-        } else {
-            showFilterOptions = false;
-        }
-
-        ImageView button1 = (ImageView) findViewById(R.id.toggleInitialOnly);
-        ImageView button2 = (ImageView) findViewById(R.id.toggleInitialPlusGaps);
-        ImageView button3 = (ImageView) findViewById(R.id.toggleAllOfAll);
-
-        if (showFilterOptions) {
-            button1.setVisibility(View.VISIBLE);
-            button2.setVisibility(View.VISIBLE);
-            button3.setVisibility(View.VISIBLE);
-        } else {
-            button1.setVisibility(View.INVISIBLE);
-            button2.setVisibility(View.INVISIBLE);
-            button3.setVisibility(View.INVISIBLE);
-        }
-
         scanSetting = Integer.parseInt(Start.settingsList.find("Game 001 Scan Setting"));
-        //scanSetting = 2;
-        switch (scanSetting) {
-            case 2:
-                setInitialPlusGaps();
-                break;
-            case 3:
-                setAllOfAll();
-                break;
-            default:
-                setInitialOnly();
-        }
 
         tileToStartOn = cumulativeStageBasedTileList.get(0).text;
         typeOfTileToStartOn = cumulativeStageBasedTileList.get(0).typeOfThisTileInstance;
@@ -220,8 +184,8 @@ public class Romania extends GameActivity {
         TextView gameTile = (TextView) findViewById(R.id.tileBoxTextView);
         String tileText = activeTile.text;
         gameTile.setText(tileText);
-        TextView magTile = (TextView) findViewById(R.id.tileInMagnifyingGlass);
-        magTile.setText(indexWithinGroup + 1 + " / " + String.valueOf(String.valueOf(groupCount)));
+        TextView numberOfTotal = (TextView) findViewById(R.id.numberOfTotalText);
+        numberOfTotal.setText(indexWithinGroup + 1 + " / " + String.valueOf(String.valueOf(groupCount)));
 
         gameTile.setClickable(true);
 
@@ -312,8 +276,8 @@ public class Romania extends GameActivity {
             TextView gameTile = (TextView) findViewById(R.id.tileBoxTextView);
             gameTile.setBackgroundColor(tileColor);
             activeWord.setBackgroundColor(tileColor);
-            TextView magTile = (TextView) findViewById(R.id.tileInMagnifyingGlass);
-            magTile.setText(indexWithinGroup + 1 + " / " + String.valueOf(groupCount));
+            TextView numberOfTotal = (TextView) findViewById(R.id.numberOfTotalText);
+            numberOfTotal.setText(indexWithinGroup + 1 + " / " + String.valueOf(groupCount));
 
             if (failedToMatchInitialTile) {
                 tileColorStr = "#A9A9A9"; // dark gray
@@ -366,9 +330,9 @@ public class Romania extends GameActivity {
             TextView gameTile = (TextView) findViewById(R.id.tileBoxTextView);
             gameTile.setBackgroundColor(tileColor);
             activeWord.setBackgroundColor(tileColor);
-            TextView magTile = (TextView) findViewById(R.id.tileInMagnifyingGlass);
+            TextView numberOfTotal = (TextView) findViewById(R.id.numberOfTotalText);
 
-            magTile.setText(indexWithinGroup + 1 + " / " + String.valueOf(groupCount));
+            numberOfTotal.setText(indexWithinGroup + 1 + " / " + String.valueOf(groupCount));
             if (failedToMatchInitialTile) {
                 tileColorStr = "#A9A9A9"; // dark gray
                 tileColor = Color.parseColor(tileColorStr);
@@ -459,66 +423,6 @@ public class Romania extends GameActivity {
         goToPreviousWord(activeTile);
     }
 
-    public void setToggleToInitialOnly(View view) {
-        setInitialOnly();
-    }
-
-    public void setInitialOnly() {
-        scanSetting = 1;
-
-        ImageView toggleOne = (ImageView) findViewById(R.id.toggleInitialOnly);
-        ImageView toggleTwo = (ImageView) findViewById(R.id.toggleInitialPlusGaps);
-        ImageView toggleThree = (ImageView) findViewById(R.id.toggleAllOfAll);
-
-        int resID1 = getResources().getIdentifier("zz_toggle_initial_only_on", "drawable", getPackageName());
-        int resID2 = getResources().getIdentifier("zz_toggle_initial_plus_gaps_off", "drawable", getPackageName());
-        int resID3 = getResources().getIdentifier("zz_toggle_all_of_all_off", "drawable", getPackageName());
-
-        toggleOne.setImageResource(resID1);
-        toggleTwo.setImageResource(resID2);
-        toggleThree.setImageResource(resID3);
-    }
-
-    public void setToggleToInitialPlusGaps(View view) {
-        setInitialPlusGaps();
-    }
-
-    public void setInitialPlusGaps() {
-        scanSetting = 2;
-
-        ImageView toggleOne = (ImageView) findViewById(R.id.toggleInitialOnly);
-        ImageView toggleTwo = (ImageView) findViewById(R.id.toggleInitialPlusGaps);
-        ImageView toggleThree = (ImageView) findViewById(R.id.toggleAllOfAll);
-
-        int resID1 = getResources().getIdentifier("zz_toggle_initial_only_off", "drawable", getPackageName());
-        int resID2 = getResources().getIdentifier("zz_toggle_initial_plus_gaps_on", "drawable", getPackageName());
-        int resID3 = getResources().getIdentifier("zz_toggle_all_of_all_off", "drawable", getPackageName());
-
-        toggleOne.setImageResource(resID1);
-        toggleTwo.setImageResource(resID2);
-        toggleThree.setImageResource(resID3);
-    }
-
-    public void setToggleToAllOfAll(View view) {
-        setAllOfAll();
-    }
-
-    public void setAllOfAll() {
-        scanSetting = 3;
-
-        ImageView toggleOne = (ImageView) findViewById(R.id.toggleInitialOnly);
-        ImageView toggleTwo = (ImageView) findViewById(R.id.toggleInitialPlusGaps);
-        ImageView toggleThree = (ImageView) findViewById(R.id.toggleAllOfAll);
-
-        int resID1 = getResources().getIdentifier("zz_toggle_initial_only_off", "drawable", getPackageName());
-        int resID2 = getResources().getIdentifier("zz_toggle_initial_plus_gaps_off", "drawable", getPackageName());
-        int resID3 = getResources().getIdentifier("zz_toggle_all_of_all_on", "drawable", getPackageName());
-
-        toggleOne.setImageResource(resID1);
-        toggleTwo.setImageResource(resID2);
-        toggleThree.setImageResource(resID3);
-    }
-
     @Override
     protected void setAllGameButtonsUnclickable() {
         TextView tileBox = findViewById(R.id.tileBoxTextView);
@@ -537,8 +441,8 @@ public class Romania extends GameActivity {
         backwardArrow.setBackgroundResource(0);
         backwardArrow.setImageResource(R.drawable.zz_backward_inactive);
 
-        TextView magTile = findViewById(R.id.tileInMagnifyingGlass);
-        magTile.setClickable(false);
+        TextView numberOfTotal = findViewById(R.id.numberOfTotalText);
+        numberOfTotal.setClickable(false);
     }
 
     @Override
@@ -559,8 +463,8 @@ public class Romania extends GameActivity {
         backwardArrow.setBackgroundResource(0);
         backwardArrow.setImageResource(R.drawable.zz_backward);
 
-        TextView magTile = findViewById(R.id.tileInMagnifyingGlass);
-        magTile.setClickable(true);
+        TextView numberOfTotal = findViewById(R.id.numberOfTotalText);
+        numberOfTotal.setClickable(true);
     }
 
     public void clickPicHearAudio(View view) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
@@ -65,8 +65,6 @@ public class SetPlayerName extends AppCompatActivity {
 
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
 
-        setTitle(Start.localAppName);
-
         playerNumber = getIntent().getIntExtra("playerNumber", -1);
 
         ImageView avatar = findViewById(R.id.avatar);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
@@ -50,6 +50,9 @@ public class SetPlayerName extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.set_player_name);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.setPlayerNameCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
         if (scriptDirection.equals("RTL")) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Share.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Share.java
@@ -28,6 +28,9 @@ public class Share extends AppCompatActivity {
 
         setContentView(R.layout.share);
 
+        ActivityLayouts.applyEdgeToEdge(this, R.id.shareCL);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         // the link is in the second line of the file.
         Scanner scanner = new Scanner(getResources().openRawResource(R.raw.aa_share));
         scanner.nextLine();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
@@ -104,6 +104,9 @@ public class Sudan extends GameActivity {
             showCorrectNumTiles(0);
         }
 
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
@@ -92,13 +92,13 @@ public class Sudan extends GameActivity {
 
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
-            ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
+            ImageView nextSet = (ImageView) findViewById(R.id.nextSet);
 
-            ImageView repeatImage2 = (ImageView) findViewById(R.id.repeatImage2);
-            repeatImage2.setRotationY(180);
+            ImageView previousSet = (ImageView) findViewById(R.id.previousSet);
+            previousSet.setRotationY(180);
 
             instructionsImage.setRotationY(180);
-            repeatImage.setRotationY(180);
+            nextSet.setRotationY(180);
 
             fixConstraintsRTLSudan(gameID);
         }
@@ -113,12 +113,12 @@ public class Sudan extends GameActivity {
         ConstraintLayout constraintLayout = findViewById(gameID);
         ConstraintSet constraintSet = new ConstraintSet();
         constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.repeatImage2, ConstraintSet.END, R.id.gamesHomeImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.START, R.id.repeatImage2, ConstraintSet.END, 0);
+        constraintSet.connect(R.id.previousSet, ConstraintSet.END, R.id.gamesHomeImage, ConstraintSet.START, 0);
+        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.START, R.id.previousSet, ConstraintSet.END, 0);
         constraintSet.connect(R.id.instructions, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
         constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.instructions, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.instructions, ConstraintSet.END, 0);
-        constraintSet.connect(R.id.instructions, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
+        constraintSet.connect(R.id.nextSet, ConstraintSet.START, R.id.instructions, ConstraintSet.END, 0);
+        constraintSet.connect(R.id.instructions, ConstraintSet.END, R.id.nextSet, ConstraintSet.START, 0);
         constraintSet.applyTo(constraintLayout);
     }
 
@@ -268,8 +268,8 @@ public class Sudan extends GameActivity {
     }
 
     public void showOrHideScrollingArrows() {
-        ImageView nextPageArrow = findViewById(R.id.repeatImage);
-        ImageView prevPageArrow = findViewById(R.id.repeatImage2);
+        ImageView nextPageArrow = findViewById(R.id.nextSet);
+        ImageView prevPageArrow = findViewById(R.id.previousSet);
         if (currentPageNumber == numPages) {
             nextPageArrow.setVisibility(View.INVISIBLE);
         } else {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
@@ -62,25 +62,10 @@ public class Sudan extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
-        // TO DO: TEST THIS WITH A LANGUAGE THAT DOESN'T HAVE INSTRUCTION AUDIO, CONNECT BACK ARROW
+    protected void hideInstructionAudioImage() {
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
 
-        int gameID;
-        if (syllableGame.equals("S")) {
-            gameID = R.id.sudansyllCL;
-        } else {
-            gameID = R.id.sudanCL;
-        }
-
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
     }
 
     @Override
@@ -88,8 +73,6 @@ public class Sudan extends GameActivity {
         super.onCreate(savedInstanceState);
         context = this;
         int gameID = 0;
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
         determineNumPages(); // JP
 
         if (syllableGame.equals("S")) {
@@ -121,7 +104,7 @@ public class Sudan extends GameActivity {
         }
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
         showOrHideScrollingArrows();
     }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -3,8 +3,11 @@ package org.alphatilesapps.alphatiles;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.media.MediaPlayer;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -113,6 +116,9 @@ public class Thailand extends GameActivity {
             setContentView(R.layout.thailand);
             gameID = R.id.thailandCL;
         }
+
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
 
         String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
         if (scriptDirection.equals("RTL")) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -3,16 +3,10 @@ package org.alphatilesapps.alphatiles;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.media.MediaPlayer;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
-import android.view.Window;
-import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.TextView;
-
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -70,27 +64,11 @@ public class Thailand extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
 
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID;
-        if (choiceType.equals("WORD_TEXT")) {
-            gameID = R.id.thailand2CL;
-        } else {
-            gameID = R.id.thailandCL;
-        }
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet
-                .START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet
-                .END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
-
+        
     }
 
 
@@ -120,7 +98,6 @@ public class Thailand extends GameActivity {
         ActivityLayouts.applyEdgeToEdge(this, gameID);
         ActivityLayouts.setStatusAndNavColors(this);
 
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
@@ -129,10 +106,8 @@ public class Thailand extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
-
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         visibleGameButtons = GAME_BUTTONS.length;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -117,6 +117,9 @@ public class UnitedStates extends GameActivity {
                 gameID = R.id.united_states_cl1_CL;
         }
 
+        ActivityLayouts.applyEdgeToEdge(this, gameID);
+        ActivityLayouts.setStatusAndNavColors(this);
+
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -10,9 +10,6 @@ import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.Random;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.constraintlayout.widget.ConstraintSet;
-
 import android.graphics.Typeface;
 import android.widget.Button;
 
@@ -61,40 +58,16 @@ public class UnitedStates extends GameActivity {
     }
 
     @Override
-    protected void centerGamesHomeImage() {
+    protected void hideInstructionAudioImage() {
         ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
-
-        int gameID = 0;
-        switch (challengeLevel) {
-            case 1:
-                gameID = R.id.united_states_cl1_CL;
-                break;
-            case 2:
-                gameID = R.id.united_states_cl2_CL;
-                break;
-            case 3:
-                gameID = R.id.united_states_cl3_CL;
-                break;
-            default:
-                break;
-        }
-        ConstraintLayout constraintLayout = findViewById(gameID);
-        ConstraintSet constraintSet = new ConstraintSet();
-        constraintSet.clone(constraintLayout);
-        constraintSet.connect(R.id.gamesHomeImage, ConstraintSet.END, R.id.repeatImage, ConstraintSet.START, 0);
-        constraintSet.connect(R.id.repeatImage, ConstraintSet.START, R.id.gamesHomeImage, ConstraintSet.END, 0);
-        constraintSet.centerHorizontally(R.id.gamesHomeImage, gameID);
-        constraintSet.applyTo(constraintLayout);
-
+        
     }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         context = this;
-        String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
-        setTitle(Start.localAppName + ": " + gameNumber + "    (" + gameUniqueID + ")");
 
         int gameID = 0;
         switch (challengeLevel) {
@@ -131,7 +104,7 @@ public class UnitedStates extends GameActivity {
         }
 
         if (getAudioInstructionsResID() == 0) {
-            centerGamesHomeImage();
+            hideInstructionAudioImage();
         }
 
         updatePointsAndTrackers(0);

--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -153,7 +153,7 @@
         android:id="@+id/bottomMiddleSpacer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:tag="SR2"
+        android:tag="BMS"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH18"
         app:layout_constraintEnd_toStartOf="@+id/logoSILImage"
         app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"

--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -10,11 +10,11 @@
 
     <ImageView
         android:id="@+id/logoImage"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:layout_constraintVertical_bias="1.0"
         app:srcCompat="@drawable/zz_alphatileslogoandtext"
@@ -143,11 +143,21 @@
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH18"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH17"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH18"
+        app:layout_constraintEnd_toStartOf="@+id/logoSILImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH17"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -157,8 +167,8 @@
         android:onClick="playAudioInstructionsAbout"
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH18"
-        app:layout_constraintEnd_toStartOf="@+id/logoSILImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineH17"
         app:srcCompat="@drawable/zz_instructions" />
 
@@ -167,8 +177,8 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH18"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineH17"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_sil" />
@@ -290,7 +300,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.92" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH18"
@@ -304,13 +314,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.95" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_loading_screen.xml
+++ b/app/src/main/res/layout/activity_loading_screen.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activityloadingscreenCL"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".LoadingScreen">

--- a/app/src/main/res/layout/brazil_cl1.xml
+++ b/app/src/main/res/layout/brazil_cl1.xml
@@ -406,7 +406,7 @@
         android:id="@+id/bottomMiddleSpacer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:tag="SR2"
+        android:tag="BMS"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toStartOf="@+id/repeatImage"
         app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"

--- a/app/src/main/res/layout/brazil_cl1.xml
+++ b/app/src/main/res/layout/brazil_cl1.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Brazil">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV12"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/wordImage"
@@ -272,48 +391,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/pointsImage"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playerAvatar"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -321,8 +418,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -332,13 +429,13 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
-        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV12"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
         app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
@@ -353,84 +450,84 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.12" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.46" />
+        app:layout_constraintGuide_percent="0.52" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.50" />
+        app:layout_constraintGuide_percent="0.54" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.63" />
+        app:layout_constraintGuide_percent="0.67" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4.5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.66" />
+        app:layout_constraintGuide_percent="0.69" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.75" />
+        app:layout_constraintGuide_percent="0.79" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5.5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.76" />
+        app:layout_constraintGuide_percent="0.81" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.85" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.03" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
@@ -451,6 +548,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.97" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/brazil_cl1.xml
+++ b/app/src/main/res/layout/brazil_cl1.xml
@@ -281,7 +281,7 @@
         app:layout_constraintEnd_toStartOf="@+id/guidelineV12"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
-        app:srcCompat="@drawable/zz_alphatileslogo" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <TextView
         android:id="@+id/activeWordTextView"

--- a/app/src/main/res/layout/brazil_cl3.xml
+++ b/app/src/main/res/layout/brazil_cl3.xml
@@ -662,7 +662,7 @@
         android:id="@+id/bottomMiddleSpacer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:tag="SR2"
+        android:tag="BMS"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toStartOf="@+id/repeatImage"
         app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"

--- a/app/src/main/res/layout/brazil_cl3.xml
+++ b/app/src/main/res/layout/brazil_cl3.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Brazil">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV12"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/wordImage"
@@ -528,48 +647,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/pointsImage"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -577,8 +674,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -588,14 +685,15 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
-        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV12"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
         app:srcCompat="@drawable/zz_forward_inactive" />
+
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"
@@ -609,146 +707,146 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.41" />
+        app:layout_constraintGuide_percent="0.44" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.58" />
+        app:layout_constraintGuide_percent="0.61" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.68" />
+        app:layout_constraintGuide_percent="0.71" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.78" />
+        app:layout_constraintGuide_percent="0.81" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.88" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.03" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.17" />
+        app:layout_constraintGuide_percent="0.155" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.19" />
+        app:layout_constraintGuide_percent="0.177" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.33" />
+        app:layout_constraintGuide_percent="0.322" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.35" />
+        app:layout_constraintGuide_percent="0.344" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.489" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.51" />
+        app:layout_constraintGuide_percent="0.511" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.656" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.67" />
+        app:layout_constraintGuide_percent="0.678" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.81" />
+        app:layout_constraintGuide_percent="0.823" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.83" />
+        app:layout_constraintGuide_percent="0.845" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.97" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/celebration.xml
+++ b/app/src/main/res/layout/celebration.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/celebrationCL"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".Celebration">

--- a/app/src/main/res/layout/chile.xml
+++ b/app/src/main/res/layout/chile.xml
@@ -7,28 +7,82 @@
     android:layout_height="match_parent"
     android:background="#FFFFFF"
     tools:context=".Chile">
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH0"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintGuide_percent="0.04"
-        android:orientation="horizontal" />
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHneg1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintGuide_percent="0.01"
-        android:orientation="horizontal" />
 
-   <ImageView
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -149,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -158,16 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/keyboardBoxDivider"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintGuide_percent="0.5"
-        android:orientation="horizontal" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <GridView
         android:id="@+id/guessBox"
@@ -202,46 +303,92 @@
         android:contentDescription="@string/playerAvatar"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintStart_toEndOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         app:srcCompat="@drawable/zz_games_home" />
 
+    <TextView
+        android:id="@+id/bottomInstructionsSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BIS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/backspace"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
+
     <ImageView
         android:id="@+id/instructions"
-        android:paddingHorizontal="4dp"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/playAgain"
         android:onClick="playAudioInstructions"
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/backspace"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomInstructionsSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         app:srcCompat="@drawable/zz_instructions" />
 
     <ImageView
+        android:id="@+id/backspace"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/guidelineHSys2"
+        app:layout_constraintStart_toEndOf="@id/bottomInstructionsSpacer"
+        app:layout_constraintTop_toBottomOf="@id/guidelineHSys1"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:srcCompat="@drawable/zz_deletetext" />
+
+    <ImageView
+        android:id="@+id/complete_word"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/guidelineHSys2"
+        app:layout_constraintStart_toStartOf="@id/repeatImage"
+        app:layout_constraintEnd_toEndOf="@id/repeatImage"
+        app:layout_constraintTop_toBottomOf="@id/guidelineHSys1"
+        app:srcCompat="@drawable/zz_complete" />
+
+    <ImageView
         android:id="@+id/repeatImage"
-        android:paddingHorizontal="4dp"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/playAgain"
-        android:adjustViewBounds="true"
-        app:layout_constraintVertical_bias="0.0"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintStart_toEndOf="@+id/backspace"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         app:srcCompat="@drawable/zz_forward" />
 
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHneg1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintGuide_percent="0.01"
+        android:orientation="horizontal" />
 
- <androidx.constraintlayout.widget.Guideline
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintGuide_percent="0.06"
+        android:orientation="horizontal" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/keyboardBoxDivider"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintGuide_percent="0.5"
+        android:orientation="horizontal" />
+
+    <androidx.constraintlayout.widget.Guideline
      android:id="@+id/guidelineHSys1"
      android:layout_width="wrap_content"
      android:layout_height="wrap_content"
      android:orientation="horizontal"
-     app:layout_constraintGuide_percent="0.89" />
+     app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -250,66 +397,12 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.99" />
 
- <androidx.constraintlayout.widget.Guideline
-     android:id="@+id/guidelineHSys"
-     android:layout_width="wrap_content"
-     android:layout_height="wrap_content"
-     android:orientation="horizontal"
-     app:layout_constraintGuide_percent="0.99" />
-    <ImageView
-        android:id="@+id/pointsImage"
-        android:paddingHorizontal="4dp"
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-            android:id="@+id/pointsTextView"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:gravity="center"
-            android:maxLines="1"
-            android:padding="7dp"
-            android:text="@string/pointsScored"
-            android:textAlignment="center"
-            android:textColor="#FFFFFF"
-            android:textStyle="bold"
-            app:autoSizeMaxTextSize="25sp"
-            app:autoSizeMinTextSize="5sp"
-            app:autoSizeStepGranularity="2sp"
-            app:autoSizeTextType="uniform"
-            app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-            app:layout_constraintDimensionRatio="1"
-            app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-            app:layout_constraintStart_toStartOf="@+id/pointsImage"
-            app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-    <ImageView
-        android:id="@+id/backspace"
-        android:paddingHorizontal="4dp"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
-
-        app:layout_constraintBottom_toTopOf="@id/guidelineHSys"
-        app:layout_constraintStart_toEndOf="@id/instructions"
-        app:layout_constraintTop_toBottomOf="@id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_deletetext" />
-
-    <ImageView
-        android:id="@+id/complete_word"
-        android:paddingHorizontal="4dp"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:adjustViewBounds="true"
-        app:layout_constraintBottom_toTopOf="@id/guidelineHSys"
-        app:layout_constraintStart_toEndOf="@id/backspace"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/guidelineHSys1"
-        app:layout_constraintVertical_bias="0.0"
-        app:srcCompat="@drawable/zz_complete" />
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/middleLine"
@@ -317,5 +410,12 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.5" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/china.xml
+++ b/app/src/main/res/layout/china.xml
@@ -282,7 +282,7 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         android:contentDescription="@string/activeWordPicture"
-        app:srcCompat="@drawable/zz_alphatileslogosmall" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <ImageView
     android:id="@+id/wordImage02"
@@ -296,7 +296,7 @@
     app:layout_constraintStart_toStartOf="@+id/guidelineV9"
     app:layout_constraintTop_toTopOf="@+id/guidelineH3"
     android:contentDescription="@string/activeWordPicture"
-    app:srcCompat="@drawable/zz_alphatileslogosmall" />
+    app:srcCompat="@drawable/zz_sil" />
 
     <ImageView
         android:id="@+id/wordImage03"
@@ -310,7 +310,7 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         android:contentDescription="@string/activeWordPicture"
-        app:srcCompat="@drawable/zz_alphatileslogosmall" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <ImageView
         android:id="@+id/wordImage04"
@@ -324,7 +324,7 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         android:contentDescription="@string/activeWordPicture"
-        app:srcCompat="@drawable/zz_alphatileslogosmall" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <TextView
         android:id="@+id/tile01"

--- a/app/src/main/res/layout/china.xml
+++ b/app/src/main/res/layout/china.xml
@@ -614,7 +614,7 @@
         android:id="@+id/bottomMiddleSpacer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:tag="SR2"
+        android:tag="BMS"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toStartOf="@+id/repeatImage"
         app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"

--- a/app/src/main/res/layout/china.xml
+++ b/app/src/main/res/layout/china.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".China">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV12"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/wordImage01"
@@ -480,48 +599,26 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineH7" />
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -529,8 +626,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -542,8 +639,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV12"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -561,146 +658,146 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.09" />
+        app:layout_constraintGuide_percent="0.10" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.25" />
+        app:layout_constraintGuide_percent="0.27" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.29" />
+        app:layout_constraintGuide_percent="0.31" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.45" />
+        app:layout_constraintGuide_percent="0.48" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.52" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.68" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.69" />
+        app:layout_constraintGuide_percent="0.72" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.85" />
+        app:layout_constraintGuide_percent="0.88" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.03" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.19" />
+        app:layout_constraintGuide_percent="0.17" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.21" />
+        app:layout_constraintGuide_percent="0.19" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.37" />
+        app:layout_constraintGuide_percent="0.35" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.39" />
+        app:layout_constraintGuide_percent="0.37" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.55" />
+        app:layout_constraintGuide_percent="0.53" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.57" />
+        app:layout_constraintGuide_percent="0.55" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.73" />
+        app:layout_constraintGuide_percent="0.71" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.75" />
+        app:layout_constraintGuide_percent="0.73" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.97" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/choose_player.xml
+++ b/app/src/main/res/layout/choose_player.xml
@@ -460,7 +460,7 @@
         android:onClick="playAudioInstructionsChoosePlayer"
         android:rotationY="0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH16"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
         app:layout_constraintStart_toStartOf="@+id/guidelineV5"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:srcCompat="@drawable/zz_instructions" />
@@ -470,7 +470,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.04" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
@@ -491,14 +491,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.25" />
+        app:layout_constraintGuide_percent="0.24" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.29" />
+        app:layout_constraintGuide_percent="0.26" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
@@ -519,21 +519,21 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.50" />
+        app:layout_constraintGuide_percent="0.49" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.54" />
+        app:layout_constraintGuide_percent="0.50" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.66" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
@@ -547,14 +547,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.75" />
+        app:layout_constraintGuide_percent="0.74" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.79" />
+        app:layout_constraintGuide_percent="0.76" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH14"
@@ -575,7 +575,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="1.00" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"

--- a/app/src/main/res/layout/colombia.xml
+++ b/app/src/main/res/layout/colombia.xml
@@ -1218,14 +1218,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"

--- a/app/src/main/res/layout/colombia.xml
+++ b/app/src/main/res/layout/colombia.xml
@@ -1174,7 +1174,7 @@
         android:id="@+id/bottomMiddleSpacer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:tag="SR2"
+        android:tag="BMS"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toStartOf="@+id/repeatImage"
         app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"

--- a/app/src/main/res/layout/colombia.xml
+++ b/app/src/main/res/layout/colombia.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Colombia">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,54 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/wordImage"
         android:layout_width="0dp"
@@ -173,7 +293,7 @@
         android:textColor="#FFFFFF"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV9"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -190,7 +310,7 @@
         android:onClick="deleteLastKeyed"
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV10"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:srcCompat="@drawable/zz_deletetext" />
@@ -212,7 +332,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -356,7 +476,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH6"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
@@ -381,7 +501,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -524,7 +644,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH8"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
@@ -549,7 +669,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -692,7 +812,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH10"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
@@ -717,7 +837,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH12"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -860,7 +980,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH12"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11"
         app:autoSizeTextType="uniform"
@@ -885,7 +1005,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -1028,7 +1148,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH14"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
         app:autoSizeTextType="uniform"
@@ -1039,60 +1159,38 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
         android:onClick="playAudioInstructions"
-        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
         app:srcCompat="@drawable/zz_instructions" />
 
     <ImageView
@@ -1101,8 +1199,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -1127,195 +1225,209 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.06019152" />
+        app:layout_constraintGuide_percent="0.07" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.27" />
+        app:layout_constraintGuide_percent="0.33" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.28" />
+        app:layout_constraintGuide_percent="0.35" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.37" />
+        app:layout_constraintGuide_percent="0.45" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.38" />
+        app:layout_constraintGuide_percent="0.47" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.46" />
+        app:layout_constraintGuide_percent="0.55" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.47" />
+        app:layout_constraintGuide_percent="0.56" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.55" />
+        app:layout_constraintGuide_percent="0.64" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.56" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.64" />
+        app:layout_constraintGuide_percent="0.73" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.74" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.73" />
+        app:layout_constraintGuide_percent="0.82" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.74" />
+        app:layout_constraintGuide_percent="0.83" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH14"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.82" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.136" />
+        app:layout_constraintGuide_percent="0.144" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.144" />
+        app:layout_constraintGuide_percent="0.151" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.28" />
+        app:layout_constraintGuide_percent="0.285" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.288" />
+        app:layout_constraintGuide_percent="0.292" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.424" />
+        app:layout_constraintGuide_percent="0.426" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.432" />
+        app:layout_constraintGuide_percent="0.433" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.568" />
+        app:layout_constraintGuide_percent="0.567" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.576" />
+        app:layout_constraintGuide_percent="0.574" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.712" />
+        app:layout_constraintGuide_percent="0.708" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.72" />
+        app:layout_constraintGuide_percent="0.715" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.856" />
+        app:layout_constraintGuide_percent="0.849" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.864" />
+        app:layout_constraintGuide_percent="0.856" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV13"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/colombia_syllables.xml
+++ b/app/src/main/res/layout/colombia_syllables.xml
@@ -281,7 +281,7 @@
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
-        app:srcCompat="@drawable/zz_alphatileslogo" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <TextView
         android:id="@+id/activeWordTextView"

--- a/app/src/main/res/layout/colombia_syllables.xml
+++ b/app/src/main/res/layout/colombia_syllables.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Colombia">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/wordImage"
@@ -157,7 +276,7 @@
         android:layout_height="0dp"
         android:contentDescription="@string/activeWordPicture"
         android:onClick="clickPicHearAudio"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH1.5"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
@@ -174,7 +293,7 @@
         android:textColor="#FFFFFF"
         android:textSize="32sp"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH3"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineV4"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV5.5"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:autoSizeTextType="uniform"
@@ -193,7 +312,7 @@
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH3"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/guidelineV5"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV5.5"
         app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:srcCompat="@drawable/zz_deletetext" />
 
@@ -528,7 +647,7 @@
         android:tag="16"
         android:text="@string/gametile16"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
@@ -550,7 +669,7 @@
         android:tag="17"
         android:text="@string/gametile17"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV4"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
@@ -572,7 +691,7 @@
         android:tag="18"
         android:text="@string/gametile18"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV5"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
@@ -584,48 +703,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -633,8 +730,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -644,14 +741,13 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
-        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:layout_constraintVertical_bias="0.0"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
         app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
@@ -666,126 +762,140 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
+        app:layout_constraintGuide_percent="0.08" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH1.5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.31" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.30" />
+        app:layout_constraintGuide_percent="0.33" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.41" />
+        app:layout_constraintGuide_percent="0.43" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline3.5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.42"/>
+        app:layout_constraintGuide_percent="0.45"/>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.52" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.50" />
+        app:layout_constraintGuide_percent="0.53" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.57" />
+        app:layout_constraintGuide_percent="0.60" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.58" />
+        app:layout_constraintGuide_percent="0.61" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.68" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.66" />
+        app:layout_constraintGuide_percent="0.69" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.73" />
+        app:layout_constraintGuide_percent="0.75" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.74" />
+        app:layout_constraintGuide_percent="0.76" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.81" />
+        app:layout_constraintGuide_percent="0.83" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.82" />
+        app:layout_constraintGuide_percent="0.84" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH14"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.03" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
@@ -799,14 +909,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.35" />
+        app:layout_constraintGuide_percent="0.34" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.66" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
@@ -816,10 +926,17 @@
         app:layout_constraintGuide_percent="0.67" />
 
     <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV5.5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.76" />
+
+    <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.97" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/earth.xml
+++ b/app/src/main/res/layout/earth.xml
@@ -915,10 +915,11 @@
         android:onClick="playAudioInstructionsEarth"
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toEndOf="@+id/bottomInstructionsSpacer"
-        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintVertical_bias="0.0"
         app:srcCompat="@drawable/zz_instructions" />
 
     <TextView

--- a/app/src/main/res/layout/earth.xml
+++ b/app/src/main/res/layout/earth.xml
@@ -10,18 +10,6 @@
     tools:context=".Earth">
 
     <ImageView
-        android:id="@+id/changeAvatarImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/home"
-        android:onClick="goBackToChoosePlayer"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/guidelineV8"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH0"
-        app:srcCompat="@drawable/zz_change_avatar" />
-
-    <ImageView
         android:id="@+id/activePlayerImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -29,21 +17,9 @@
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH0"
         app:srcCompat="@drawable/zz_avatar01" />
-
-    <ImageView
-        android:id="@+id/resourcePromo"
-        android:layout_width="73dp"
-        android:layout_height="73dp"
-        android:contentDescription="@string/resourcePromo"
-        android:onClick="goToResources"
-        android:src="@drawable/zz_resource_promo"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage" />
 
     <TextView
         android:id="@+id/avatarName"
@@ -65,6 +41,18 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineH0" />
 
     <ImageView
+        android:id="@+id/changeAvatarImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/home"
+        android:onClick="goBackToChoosePlayer"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH1"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH0"
+        app:srcCompat="@drawable/zz_change_avatar" />
+
+    <ImageView
         android:id="@+id/goBack"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -75,8 +63,9 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH3"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
+
 
     <TextView
         android:id="@+id/textDoor001"
@@ -166,7 +155,7 @@
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH3"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
         app:layout_constraintStart_toStartOf="@+id/guidelineV8"
         app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
@@ -190,7 +179,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH5"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH4" />
 
     <TextView
@@ -281,7 +270,7 @@
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH5"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
         app:layout_constraintStart_toStartOf="@+id/guidelineV8"
         app:layout_constraintTop_toTopOf="@+id/guidelineH4" />
 
@@ -305,7 +294,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH7"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH6" />
 
     <TextView
@@ -396,7 +385,7 @@
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH7"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
         app:layout_constraintStart_toStartOf="@+id/guidelineV8"
         app:layout_constraintTop_toTopOf="@+id/guidelineH6" />
 
@@ -420,7 +409,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH9"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH8" />
 
     <TextView
@@ -511,7 +500,7 @@
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH9"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
         app:layout_constraintStart_toStartOf="@+id/guidelineV8"
         app:layout_constraintTop_toTopOf="@+id/guidelineH8" />
 
@@ -535,7 +524,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH11"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH10" />
 
     <TextView
@@ -607,6 +596,237 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineV6"
         app:layout_constraintTop_toTopOf="@+id/guidelineH10" />
 
+    <TextView
+        android:id="@+id/textDoor024"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door024"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="24"
+        android:text="24"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH11"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH10" />
+
+    <TextView
+        android:id="@+id/textDoor025"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door025"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="25"
+        android:text="25"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH13"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH12" />
+
+    <TextView
+        android:id="@+id/textDoor026"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door026"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="26"
+        android:text="26"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH13"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV3"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH12" />
+
+    <TextView
+        android:id="@+id/textDoor027"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door027"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="27"
+        android:text="27"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH13"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV5"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV4"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH12" />
+
+    <TextView
+        android:id="@+id/textDoor028"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door028"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="28"
+        android:text="28"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH13"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV7"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV6"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH12" />
+
+    <TextView
+        android:id="@+id/textDoor029"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door029"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="29"
+        android:text="29"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH13"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH12" />
+
+    <TextView
+        android:id="@+id/textDoor030"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door030"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="30"
+        android:text="30"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH15"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH14" />
+
+    <TextView
+        android:id="@+id/textDoor031"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door031"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="31"
+        android:text="31"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH15"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV3"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH14" />
+
+    <TextView
+        android:id="@+id/textDoor032"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door032"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="32"
+        android:text="32"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH15"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV5"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV4"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH14" />
+
+    <TextView
+        android:id="@+id/textDoor033"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/zz_door"
+        android:contentDescription="@string/door033"
+        android:gravity="center"
+        android:maxLines="1"
+        android:onClick="goToDoor"
+        android:padding="4dp"
+        android:tag="33"
+        android:text="33"
+        android:textColor="#FFFFFF"
+        app:autoSizeMaxTextSize="40sp"
+        app:autoSizeMinTextSize="12sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH15"
+        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV7"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV6"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH14" />
+
+
     <ImageView
         android:id="@+id/goForward"
         android:layout_width="0dp"
@@ -615,27 +835,28 @@
         android:onClick="goForward"
         android:rotationY="0"
         android:src="@drawable/zz_forward_green"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH11"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH15"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
         app:layout_constraintStart_toStartOf="@+id/guidelineV8"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH10" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH14" />
 
     <ImageView
         android:id="@+id/pointsImage"
-        android:layout_width="70dp"
-        android:layout_height="73dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:contentDescription="@string/pointsImage"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/resourcePromo"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintEnd_toStartOf="@+id/bottomResourcesSpacer"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:srcCompat="@drawable/zz_pointsscored" />
 
     <TextView
         android:id="@+id/pointsTextView"
-        android:layout_width="56dp"
-        android:layout_height="59dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:gravity="center"
         android:maxLines="1"
         android:padding="7dp"
@@ -647,36 +868,226 @@
         app:autoSizeMinTextSize="5sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
         app:layout_constraintDimensionRatio="1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
+        app:layout_constraintStart_toStartOf="@+id/pointsImage"/>
+
+    <TextView
+        android:id="@+id/bottomResourcesSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
+
+    <ImageView
+        android:id="@+id/resourcePromo"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/resourcePromo"
+        android:onClick="goToResources"
+        android:src="@drawable/zz_resource_promo"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintEnd_toEndOf="@+id/bottomResourcesSpacer"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="@+id/bottomResourcesSpacer" />
+
+    <TextView
+        android:id="@+id/bottomInstructionsSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BIS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/bottomShareSpacer"
+        app:layout_constraintStart_toEndOf="@+id/bottomResourcesSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
-        android:layout_width="73dp"
-        android:layout_height="73dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:contentDescription="@string/playAgain"
         android:onClick="playAudioInstructionsEarth"
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/share"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintEnd_toEndOf="@+id/bottomInstructionsSpacer"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/resourcePromo"
+        app:layout_constraintStart_toStartOf="@+id/bottomInstructionsSpacer"
         app:srcCompat="@drawable/zz_instructions" />
+
+    <TextView
+        android:id="@+id/bottomShareSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BSS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/logoImage"
+        app:layout_constraintStart_toEndOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
+
+    <ImageView
+        android:id="@+id/share"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="goToShare"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintEnd_toEndOf="@+id/bottomShareSpacer"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="@+id/bottomShareSpacer"
+        app:srcCompat="@drawable/zz_share" />
 
     <ImageView
         android:id="@+id/logoImage"
-        android:layout_width="70dp"
-        android:layout_height="73dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:contentDescription="@string/clickLogoGoToAbout"
         android:onClick="goToAboutPage"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/share"
+        app:layout_constraintStart_toEndOf="@+id/bottomShareSpacer"
         app:srcCompat="@drawable/zz_alphatileslogosmall" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.11" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.13" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.23" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.24" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.34" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH6"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.35" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH7"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.45" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH8"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.46" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH9"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.56" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH10"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.57" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH11"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.67" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH12"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.68" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH13"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.78" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH14"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.79" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH15"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.89" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHSys1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.93" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHSys2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.99" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
@@ -735,126 +1146,10 @@
         app:layout_constraintGuide_percent="0.83" />
 
     <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH0"
+        android:id="@+id/guidelineV9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.02" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.12" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.17" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH3"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.27" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH4"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.29" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH5"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.39" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH6"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.41" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH7"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.51" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH8"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.53" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH9"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.63" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH10"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.65" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH11"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.75" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH12"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.785" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH13"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.885" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHSys1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHSys2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
+        android:orientation="vertical"
         app:layout_constraintGuide_percent="0.99" />
-
-    <ImageView
-        android:id="@+id/share"
-        android:layout_width="73dp"
-        android:layout_height="73dp"
-        android:onClick="goToShare"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/logoImage"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
-        app:srcCompat="@drawable/zz_share" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/ecuador.xml
+++ b/app/src/main/res/layout/ecuador.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Ecuador">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV3"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <TextView
         android:id="@+id/activeWordTextView"
@@ -161,7 +280,7 @@
         android:textColor="#000000"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintEnd_toStartOf="@+id/wordImage"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="25sp"
@@ -331,48 +450,26 @@
         tools:layout_editor_absoluteY="146dp" />
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -380,8 +477,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -391,14 +488,13 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
-        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV3"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:layout_constraintVertical_bias="0.0"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
         app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
@@ -413,21 +509,21 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.2" />
+        app:layout_constraintGuide_percent="0.18" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
@@ -476,14 +572,21 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
@@ -498,5 +601,12 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.95" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/ecuador.xml
+++ b/app/src/main/res/layout/ecuador.xml
@@ -465,7 +465,7 @@
         android:id="@+id/bottomMiddleSpacer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:tag="SR2"
+        android:tag="BMS"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toStartOf="@+id/repeatImage"
         app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"

--- a/app/src/main/res/layout/ecuador.xml
+++ b/app/src/main/res/layout/ecuador.xml
@@ -318,8 +318,7 @@
         app:autoSizeMinTextSize="12sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toTopOf="@+id/pointsImage"
-        app:layout_constraintTop_toBottomOf="@id/activeWordTextView" />
+        tools:layout_editor_absoluteY="146dp" />
 
     <TextView
         android:id="@+id/word02"
@@ -337,7 +336,6 @@
         app:autoSizeMinTextSize="12sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        tools:layout_editor_absoluteX="151dp"
         tools:layout_editor_absoluteY="146dp" />
 
     <TextView
@@ -374,7 +372,6 @@
         app:autoSizeMinTextSize="12sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        tools:layout_editor_absoluteX="151dp"
         tools:layout_editor_absoluteY="146dp" />
 
     <TextView

--- a/app/src/main/res/layout/georgia.xml
+++ b/app/src/main/res/layout/georgia.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Georgia">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV12"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/wordImage"
@@ -162,7 +281,7 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         android:contentDescription="@string/activeWordPicture"
-        app:srcCompat="@drawable/zz_alphatileslogosmall" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <TextView
         android:id="@+id/tile01"
@@ -579,48 +698,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -628,8 +725,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -641,8 +738,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV12"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -660,70 +757,70 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.09" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.53" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.53" />
+        app:layout_constraintGuide_percent="0.56" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.63" />
+        app:layout_constraintGuide_percent="0.67" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.68" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.76" />
+        app:layout_constraintGuide_percent="0.79" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.78" />
+        app:layout_constraintGuide_percent="0.80" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -737,21 +834,21 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.03" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.17" />
+        app:layout_constraintGuide_percent="0.165" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.19" />
+        app:layout_constraintGuide_percent="0.175" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
@@ -765,28 +862,28 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.35" />
+        app:layout_constraintGuide_percent="0.34" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.495" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.51" />
+        app:layout_constraintGuide_percent="0.505" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.66" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV9"
@@ -800,20 +897,20 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.81" />
+        app:layout_constraintGuide_percent="0.825" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.83" />
+        app:layout_constraintGuide_percent="0.835" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.97" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/georgia_syll.xml
+++ b/app/src/main/res/layout/georgia_syll.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Georgia">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/wordImage"
@@ -571,49 +690,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/pointsImage"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:layout_constraintVertical_bias="0.0"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -621,8 +717,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -634,8 +730,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -653,112 +749,112 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.35" />
+        app:layout_constraintGuide_percent="0.36" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.36" />
+        app:layout_constraintGuide_percent="0.38" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.431667" />
+        app:layout_constraintGuide_percent="0.46" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.451667" />
+        app:layout_constraintGuide_percent="0.47" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.52333" />
+        app:layout_constraintGuide_percent="0.55" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.54333" />
+        app:layout_constraintGuide_percent="0.56" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.615" />
+        app:layout_constraintGuide_percent="0.64" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.635" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.70667"/>
+        app:layout_constraintGuide_percent="0.73"/>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.72667"/>
+        app:layout_constraintGuide_percent="0.74"/>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.79833"/>
+        app:layout_constraintGuide_percent="0.82"/>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.81833"/>
+        app:layout_constraintGuide_percent="0.83"/>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH14"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89"/>
+        app:layout_constraintGuide_percent="0.91"/>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -772,7 +868,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.03" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
@@ -807,6 +903,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.97" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/italy.xml
+++ b/app/src/main/res/layout/italy.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Italy">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV5"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/referenceItem"
@@ -159,8 +278,8 @@
         android:padding="2dp"
         android:tag="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV5"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:layout_constraintVertical_bias="0.04"
         app:srcCompat="@drawable/zz_click_for_word_audio"/>
@@ -178,76 +297,6 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:layout_constraintVertical_bias="0.04"
         app:srcCompat="@drawable/zz_forward_green"/>
-
-    <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/pointsImage"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
-        android:id="@+id/gamesHomeImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playerAvatar"
-        android:onClick="goBackToEarth"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_games_home" />
-
-    <ImageView
-        android:id="@+id/instructions"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playAudioInstructions"
-        android:onClick="playAudioInstructions"
-        android:rotationY="0"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_instructions" />
-
-    <ImageView
-        android:id="@+id/repeatImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
-        android:onClick="repeatGame"
-        android:rotationY="0"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_forward_inactive" />
 
     <ImageView
         android:id="@+id/wordImage01"
@@ -844,6 +893,54 @@
         android:padding = "1dp"
         android:maxLines="1"/>
 
+    <ImageView
+        android:id="@+id/gamesHomeImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="goBackToEarth"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playerAvatar"
+        app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
+
+    <ImageView
+        android:id="@+id/instructions"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="playAudioInstructions"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
+        app:srcCompat="@drawable/zz_instructions" />
+
+    <ImageView
+        android:id="@+id/repeatImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="repeatGame"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV5"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
+        app:srcCompat="@drawable/zz_forward_inactive" />
+
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHneg1"
         android:layout_width="wrap_content"
@@ -856,91 +953,91 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.06" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.19" />
+        app:layout_constraintGuide_percent="0.21" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.2" />
+        app:layout_constraintGuide_percent="0.23" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3AndAHalf"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.32" />
+        app:layout_constraintGuide_percent="0.35" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.37" />
+        app:layout_constraintGuide_percent="0.4" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4AndAHalf"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.52" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.54" />
+        app:layout_constraintGuide_percent="0.57" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5AndAHalf"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.66" />
+        app:layout_constraintGuide_percent="0.69" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.71" />
+        app:layout_constraintGuide_percent="0.74" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6AndAHalf"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.83" />
+        app:layout_constraintGuide_percent="0.86" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.88" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -954,7 +1051,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.02" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
@@ -982,6 +1079,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/japan_12.xml
+++ b/app/src/main/res/layout/japan_12.xml
@@ -7,15 +7,81 @@
     android:layout_height="match_parent"
     tools:context=".Japan">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -28,6 +94,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -40,6 +107,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -52,6 +120,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -64,6 +133,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -76,6 +146,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -88,6 +159,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -100,6 +172,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -112,6 +185,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -124,6 +198,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -136,6 +211,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -145,115 +221,69 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
-    <ImageView
-        android:id="@+id/pointsImage"
+    <TextView
+        android:id="@+id/spacerRight1"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/pointsImage"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
 
     <TextView
         android:id="@+id/pointsTextView"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:background="#9C27B0"
         android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
+        android:tag="1"
         android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
         app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <ImageView
+        android:id="@+id/wordImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:contentDescription="@string/activeWordPicture"
+        android:onClick="onClickWord"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
-        android:id="@+id/gamesHomeImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playerAvatar"
-        android:onClick="goBackToEarth"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_games_home" />
-
-    <ImageView
-        android:id="@+id/instructions"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
-        android:onClick="playAudioInstructions"
-        android:rotationY="0"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_instructions" />
-
-    <ImageView
-        android:id="@+id/repeatImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
-        android:onClick="repeatGame"
-        android:rotationY="0"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_forward_inactive" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline8"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.45" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHneg1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.01" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH0"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHSys1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.82" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHSys2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.99" />
+        app:layout_constraintEnd_toStartOf="@+id/word"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH0"
+        app:layout_constraintVertical_bias="0.0"
+        app:srcCompat="@drawable/zz_sil" />
 
     <TextView
         android:id="@+id/word"
@@ -266,7 +296,7 @@
         app:autoSizeMinTextSize="20sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toTopOf="@+id/guideline8"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/wordImage"
         app:layout_constraintTop_toTopOf="@+id/guidelineH0"
@@ -289,8 +319,8 @@
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button1"
-        app:layout_constraintStart_toStartOf="@id/guidelineL"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -307,7 +337,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile02"
         app:layout_constraintStart_toEndOf="@id/tile01"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8" />
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile02"
@@ -326,7 +356,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button2"
         app:layout_constraintStart_toEndOf="@id/button1"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8"
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -343,7 +373,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile03"
         app:layout_constraintStart_toEndOf="@id/tile02"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8" />
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile03"
@@ -362,7 +392,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button3"
         app:layout_constraintStart_toEndOf="@id/button2"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8"
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -379,7 +409,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile04"
         app:layout_constraintStart_toEndOf="@id/tile03"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile04"
@@ -398,7 +428,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button4"
         app:layout_constraintStart_toEndOf="@id/button3"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -415,7 +445,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile05"
         app:layout_constraintStart_toEndOf="@id/tile04"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile05"
@@ -434,7 +464,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button5"
         app:layout_constraintStart_toEndOf="@id/button4"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -451,7 +481,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile06"
         app:layout_constraintStart_toEndOf="@+id/tile05"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile06"
@@ -470,7 +500,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button6"
         app:layout_constraintStart_toEndOf="@+id/button5"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -487,7 +517,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile07"
         app:layout_constraintStart_toEndOf="@+id/tile06"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile07"
@@ -506,7 +536,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button7"
         app:layout_constraintStart_toEndOf="@+id/button6"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -523,7 +553,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile08"
         app:layout_constraintStart_toEndOf="@+id/tile07"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile08"
@@ -542,7 +572,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button8"
         app:layout_constraintStart_toEndOf="@+id/button7"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -559,7 +589,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile09"
         app:layout_constraintStart_toEndOf="@+id/tile08"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile09"
@@ -578,7 +608,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button9"
         app:layout_constraintStart_toEndOf="@+id/button8"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -595,7 +625,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile10"
         app:layout_constraintStart_toEndOf="@+id/tile09"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile10"
@@ -614,7 +644,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button10"
         app:layout_constraintStart_toEndOf="@+id/button9"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -631,7 +661,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile11"
         app:layout_constraintStart_toEndOf="@+id/tile10"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile11"
@@ -650,7 +680,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button11"
         app:layout_constraintStart_toEndOf="@+id/button10"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -667,7 +697,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile12"
         app:layout_constraintStart_toEndOf="@+id/tile11"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile12"
@@ -684,40 +714,106 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineR"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toEndOf="@+id/button11"
-        app:layout_constraintTop_toTopOf="@+id/guideline8"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
+    <ImageView
+        android:id="@+id/gamesHomeImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="goBackToEarth"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playerAvatar"
+        app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
+
+    <ImageView
+        android:id="@+id/instructions"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="playAudioInstructions"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
+        app:srcCompat="@drawable/zz_instructions" />
+
+    <ImageView
+        android:id="@+id/repeatImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="repeatGame"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
+        app:srcCompat="@drawable/zz_forward_inactive" />
+    
     <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineL"
+        android:id="@+id/guidelineHneg1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.11" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.45" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHSys1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.89" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHSys2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.99" />
+    
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineR"
+        android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.99" />
-
-    <ImageView
-        android:id="@+id/wordImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginBottom="16dp"
-        android:contentDescription="@string/activeWordPicture"
-        android:onClick="onClickWord"
-        app:layout_constraintBottom_toTopOf="@+id/guideline8"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toStartOf="@+id/word"
-        app:layout_constraintStart_toStartOf="@+id/guidelineL"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH0"
-        app:layout_constraintVertical_bias="0.0"
-        app:srcCompat="@drawable/zz_alphatileslogosmall" />
-
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/japan_7.xml
+++ b/app/src/main/res/layout/japan_7.xml
@@ -7,15 +7,81 @@
     android:layout_height="match_parent"
     tools:context=".Japan">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -28,6 +94,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -40,6 +107,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -52,6 +120,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -64,6 +133,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -76,6 +146,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -88,6 +159,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -100,6 +172,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -112,6 +185,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -124,6 +198,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -136,6 +211,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -145,116 +221,31 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
-    <ImageView
-        android:id="@+id/pointsImage"
+    <TextView
+        android:id="@+id/spacerRight1"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
 
     <TextView
-        android:id="@+id/pointsTextView"
+        android:id="@+id/spacerRight2"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
-        android:id="@+id/gamesHomeImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="goBackToEarth"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playerAvatar"
-        app:srcCompat="@drawable/zz_games_home" />
-
-    <ImageView
-        android:id="@+id/instructions"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="playAudioInstructions"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_instructions" />
-
-    <ImageView
-        android:id="@+id/repeatImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
-        android:onClick="repeatGame"
-        android:rotationY="0"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:layout_constraintVertical_bias="0.0"
-        app:srcCompat="@drawable/zz_forward_inactive" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline8"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.45" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHneg1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.01" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH0"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHSys1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.82" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHSys2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.99" />
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
 
     <TextView
         android:id="@+id/word"
@@ -267,7 +258,7 @@
         app:autoSizeMinTextSize="20sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toTopOf="@+id/guideline8"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/wordImage"
         app:layout_constraintTop_toTopOf="@+id/guidelineH0"
@@ -290,8 +281,8 @@
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintEnd_toStartOf="@+id/button1"
-        app:layout_constraintStart_toStartOf="@id/guidelineL"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"/>
 
     <TextView
@@ -308,7 +299,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile02"
         app:layout_constraintStart_toEndOf="@id/tile01"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8" />
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile02"
@@ -328,7 +319,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/button2"
         app:layout_constraintStart_toEndOf="@id/button1"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8" />
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/button2"
@@ -344,7 +335,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile03"
         app:layout_constraintStart_toEndOf="@id/tile02"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8" />
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile03"
@@ -364,7 +355,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/button3"
         app:layout_constraintStart_toEndOf="@id/button2"
-        app:layout_constraintTop_toBottomOf="@+id/guideline8" />
+        app:layout_constraintTop_toBottomOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/button3"
@@ -380,7 +371,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile04"
         app:layout_constraintStart_toEndOf="@id/tile03"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile04"
@@ -400,7 +391,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/button4"
         app:layout_constraintStart_toEndOf="@id/button3"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/button4"
@@ -416,7 +407,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile05"
         app:layout_constraintStart_toEndOf="@id/tile04"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile05"
@@ -436,7 +427,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/button5"
         app:layout_constraintStart_toEndOf="@id/button4"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/button5"
@@ -452,7 +443,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile06"
         app:layout_constraintStart_toEndOf="@+id/tile05"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile06"
@@ -472,7 +463,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/button6"
         app:layout_constraintStart_toEndOf="@+id/button5"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/button6"
@@ -488,7 +479,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/tile07"
         app:layout_constraintStart_toEndOf="@+id/tile06"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <TextView
         android:id="@+id/tile07"
@@ -506,23 +497,9 @@
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys1"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineR"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toEndOf="@+id/button6"
-        app:layout_constraintTop_toTopOf="@+id/guideline8" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineL"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.01" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineR"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.99" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2" />
 
     <ImageView
         android:id="@+id/wordImage"
@@ -532,13 +509,131 @@
         android:layout_marginBottom="16dp"
         android:contentDescription="@string/activeWordPicture"
         android:onClick="onClickWord"
-        app:layout_constraintBottom_toTopOf="@+id/guideline8"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/word"
-        app:layout_constraintStart_toStartOf="@+id/guidelineL"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH0"
         app:layout_constraintVertical_bias="0.0"
         app:srcCompat="@drawable/zz_alphatileslogosmall" />
+    
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
+    <ImageView
+        android:id="@+id/gamesHomeImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="goBackToEarth"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playerAvatar"
+        app:srcCompat="@drawable/zz_games_home" />
 
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
+
+    <ImageView
+        android:id="@+id/instructions"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="playAudioInstructions"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
+        app:srcCompat="@drawable/zz_instructions" />
+
+    <ImageView
+        android:id="@+id/repeatImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="repeatGame"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
+        app:srcCompat="@drawable/zz_forward_inactive" />
+    
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHneg1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.11" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.45" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHSys1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.89" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHSys2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.99" />
+    
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
+    
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/malaysia.xml
+++ b/app/src/main/res/layout/malaysia.xml
@@ -514,15 +514,16 @@
         android:id="@+id/forwardArrowImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:contentDescription="@+id/forwardPageArrow"
         android:onClick="nextPageArrow"
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toEndOf="@id/guidelineV2"
         app:layout_constraintStart_toEndOf="@+id/bottomInstructionsSpacer"
-        android:contentDescription="@+id/forwardPageArrow"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintVertical_bias="0.0"
         app:srcCompat="@drawable/zz_forward" />
-    
+
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH0"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/malaysia.xml
+++ b/app/src/main/res/layout/malaysia.xml
@@ -14,49 +14,41 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="9dp"
-
         android:layout_marginTop="9dp"
         android:contentDescription="@string/activeWordPicture"
-
         android:onClick="clickPicHearAudio"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH1"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH0"
-        app:srcCompat="@drawable/zz_alphatileslogo"
-    />
-
-
+        app:srcCompat="@drawable/zz_alphatileslogo" />
 
     <TextView
         android:id="@+id/word01"
-        android:tag="1"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginStart="9dp"
+        android:layout_marginTop="9dp"
+        android:layout_marginEnd="9dp"
         android:background="#9C27B0"
         android:gravity="center"
+        android:maxLines="1"
         android:onClick="onWordClick"
+        android:padding="2dp"
+        android:tag="1"
         android:text="@string/word01"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
-        app:layout_constraintStart_toEndOf="@+id/wordImage01"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
-        app:layout_constraintTop_toTopOf="@+id/guidelineH0"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH1"
-        app:autoSizeTextType="uniform"
-        app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
+        app:autoSizeMinTextSize="5sp"
         app:autoSizeStepGranularity="2sp"
-        android:padding = "2dp"
-        android:maxLines="1"
-
-        android:layout_marginStart="9dp"
-        android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-    />
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH1"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/wordImage01"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH0"
+        app:layout_constraintVertical_bias="0.0" />
 
     <ImageView
         android:id="@+id/wordImage02"
@@ -64,20 +56,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word02"
@@ -87,14 +73,11 @@
         android:background="#006486"
         android:gravity="center"
         android:onClick="onWordClick"
-
         android:text="@string/word02"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage02"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:autoSizeTextType="uniform"
@@ -103,12 +86,9 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
-
+        android:layout_marginTop="9dp" />
 
     <ImageView
         android:id="@+id/wordImage03"
@@ -116,19 +96,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH3"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word03"
@@ -141,10 +116,8 @@
         android:text="@string/word03"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage03"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH2"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH3"
         app:autoSizeTextType="uniform"
@@ -153,11 +126,9 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <ImageView
         android:id="@+id/wordImage04"
@@ -165,19 +136,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word04"
@@ -190,10 +156,8 @@
         android:text="@string/word04"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage04"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
         app:autoSizeTextType="uniform"
@@ -202,11 +166,9 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <ImageView
         android:id="@+id/wordImage05"
@@ -214,19 +176,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH4"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH5"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word05"
@@ -236,14 +193,11 @@
         android:background="#0C27e0"
         android:gravity="center"
         android:onClick="onWordClick"
-
         android:text="@string/word05"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage05"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH4"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
@@ -252,11 +206,9 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <ImageView
         android:id="@+id/wordImage06"
@@ -264,19 +216,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word06"
@@ -286,14 +233,11 @@
         android:background="#f0c40a"
         android:gravity="center"
         android:onClick="onWordClick"
-
         android:text="@string/word06"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage06"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:autoSizeTextType="uniform"
@@ -302,11 +246,9 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
 
     <ImageView
@@ -315,19 +257,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH6"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH7"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word07"
@@ -340,10 +277,8 @@
         android:text="@string/word07"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage07"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH6"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
@@ -352,11 +287,9 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <ImageView
         android:id="@+id/wordImage08"
@@ -364,16 +297,12 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
         android:layout_marginTop="9dp"
         />
@@ -389,10 +318,8 @@
         android:text="@string/word08"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage08"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:autoSizeTextType="uniform"
@@ -401,31 +328,24 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
-
+        android:layout_marginTop="9dp" />
+    
     <ImageView
         android:id="@+id/wordImage09"
         android:tag="9"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH8"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH9"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word09"
@@ -438,10 +358,8 @@
         android:text="@string/word09"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage09"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH8"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
@@ -450,11 +368,9 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <ImageView
         android:id="@+id/wordImage10"
@@ -462,19 +378,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word10"
@@ -487,10 +398,8 @@
         android:text="@string/word10"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage10"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
         app:autoSizeTextType="uniform"
@@ -499,11 +408,9 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <ImageView
         android:id="@+id/wordImage11"
@@ -511,19 +418,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVStart"
-
-
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH10"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH11"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo"
-
         android:layout_marginStart="9dp"
-        android:layout_marginTop="9dp"
-        />
+        android:layout_marginTop="9dp" />
 
     <TextView
         android:id="@+id/word11"
@@ -533,14 +435,11 @@
         android:background="#f0e000"
         android:gravity="center"
         android:onClick="onWordClick"
-
         android:text="@string/word11"
         android:textColor="#FFFFFF"
         android:textSize="30sp"
-
         app:layout_constraintStart_toEndOf="@+id/wordImage11"
-        app:layout_constraintEnd_toStartOf="@+id/guidelineVEnd"
-
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintTop_toTopOf="@+id/guidelineH10"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH11"
         app:autoSizeTextType="uniform"
@@ -549,24 +448,32 @@
         app:autoSizeStepGranularity="2sp"
         android:padding = "2dp"
         android:maxLines="1"
-
         android:layout_marginStart="9dp"
         android:layout_marginEnd="9dp"
-        android:layout_marginTop="9dp"
-        />
-
+        android:layout_marginTop="9dp" />
 
     <ImageView
         android:id="@+id/backwardArrowImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:contentDescription="@+id/backwardPageArrow"
         android:onClick="prevPageArrow"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        android:contentDescription="@+id/backwardPageArrow"
+        app:layout_constraintEnd_toStartOf="@+id/bottomGamesHomeSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:layout_constraintVertical_bias="0.0"
         app:srcCompat="@drawable/zz_backward" />
+
+    <TextView
+        android:id="@+id/bottomGamesHomeSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BGHS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintStart_toEndOf="@+id/backwardArrowImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/gamesHomeImage"
@@ -574,11 +481,21 @@
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/backwardArrowImage"
+        app:layout_constraintStart_toStartOf="@+id/bottomGamesHomeSpacer"
+        app:layout_constraintEnd_toEndOf="@+id/bottomGamesHomeSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@+id/gamesHomeImage"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomInstructionsSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BIS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/forwardArrowImage"
+        app:layout_constraintStart_toEndOf="@+id/bottomGamesHomeSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -586,8 +503,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/forwardArrowImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomInstructionsSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@+id/playInstructionAudio"
         android:rotationY="0"
@@ -600,129 +517,122 @@
         android:onClick="nextPageArrow"
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/bottomInstructionsSpacer"
         android:contentDescription="@+id/forwardPageArrow"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         app:srcCompat="@drawable/zz_forward" />
-
-
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHSys1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
-    <!--This was set to 0.9, but since there is more room now, I moved it up.-->
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHSys2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_end="9dp" />
-
-
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineVStart"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.00" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineVEnd"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="1.00" />
-
-
-
+    
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH0"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.00" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.08" />
+        app:layout_constraintGuide_percent="0.09" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.16" />
+        app:layout_constraintGuide_percent="0.17" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.24" />
+        app:layout_constraintGuide_percent="0.25" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.32" />
+        app:layout_constraintGuide_percent="0.33" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.40" />
+        app:layout_constraintGuide_percent="0.41" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.48" />
+        app:layout_constraintGuide_percent="0.49" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.56" />
+        app:layout_constraintGuide_percent="0.57" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.64" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.72" />
+        app:layout_constraintGuide_percent="0.73" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.80" />
+        app:layout_constraintGuide_percent="0.81" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.88" />
+        app:layout_constraintGuide_percent="0.89" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHSys1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.93" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHSys2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.99" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/mexico.xml
+++ b/app/src/main/res/layout/mexico.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Mexico">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV7"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <TextView
         android:id="@+id/card01"
@@ -163,7 +282,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -222,7 +341,7 @@
         android:text="@string/memoryCard04"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV7"
         app:layout_constraintStart_toStartOf="@+id/guidelineV6"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:autoSizeTextType="uniform"
@@ -243,7 +362,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -302,7 +421,7 @@
         android:text="@string/memoryCard08"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV7"
         app:layout_constraintStart_toStartOf="@+id/guidelineV6"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:autoSizeTextType="uniform"
@@ -323,7 +442,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -382,7 +501,7 @@
         android:text="@string/memoryCard12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV7"
         app:layout_constraintStart_toStartOf="@+id/guidelineV6"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
@@ -403,7 +522,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -462,7 +581,7 @@
         android:text="@string/memoryCard16"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV7"
         app:layout_constraintStart_toStartOf="@+id/guidelineV6"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
@@ -483,7 +602,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -542,7 +661,7 @@
         android:text="@string/memoryCard20"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV7"
         app:layout_constraintStart_toStartOf="@+id/guidelineV6"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
@@ -552,47 +671,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -600,8 +698,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -613,8 +711,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV7"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -632,84 +730,84 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.06" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.22" />
+        app:layout_constraintGuide_percent="0.238" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.23" />
+        app:layout_constraintGuide_percent="0.248" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.39" />
+        app:layout_constraintGuide_percent="0.406" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.40" />
+        app:layout_constraintGuide_percent="0.416" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.56" />
+        app:layout_constraintGuide_percent="0.574" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.57" />
+        app:layout_constraintGuide_percent="0.584" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.73" />
+        app:layout_constraintGuide_percent="0.742" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.74" />
+        app:layout_constraintGuide_percent="0.752" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -719,45 +817,59 @@
         app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.235" />
+        app:layout_constraintGuide_percent="0.245" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.255" />
+        app:layout_constraintGuide_percent="0.2584" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.4934" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.51" />
+        app:layout_constraintGuide_percent="0.5066" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.745" />
+        app:layout_constraintGuide_percent="0.7416" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.765" />
+        app:layout_constraintGuide_percent="0.755" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV7"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/myanmar.xml
+++ b/app/src/main/res/layout/myanmar.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Myanmar">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="GNV"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="CLV"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/wordImage01"
@@ -161,7 +280,7 @@
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:srcCompat="@drawable/zz_alphatileslogo" />
 
@@ -245,7 +364,7 @@
         app:layout_constraintDimensionRatio="1"
         app:srcCompat="@drawable/zz_alphatileslogo"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1" />
 
@@ -259,9 +378,9 @@
         android:textColor="#000000"
         android:textSize="32sp"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:layout_constraintVertical_bias="0.0"
         app:autoSizeTextType="uniform"
@@ -288,7 +407,7 @@
         android:textStyle="normal"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -432,7 +551,7 @@
         android:textSize="26sp"
         android:textStyle="normal"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH6"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
@@ -457,7 +576,7 @@
         android:textStyle="normal"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -600,7 +719,7 @@
         android:textSize="26sp"
         android:textStyle="normal"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH8"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
@@ -625,7 +744,7 @@
         android:textStyle="normal"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -768,7 +887,7 @@
         android:textSize="26sp"
         android:textStyle="normal"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH10"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
@@ -793,7 +912,7 @@
         android:textStyle="normal"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH12"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -936,7 +1055,7 @@
         android:textSize="26sp"
         android:textStyle="normal"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH12"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11"
         app:autoSizeTextType="uniform"
@@ -961,7 +1080,7 @@
         android:textStyle="normal"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -1104,7 +1223,7 @@
         android:textSize="26sp"
         android:textStyle="normal"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH14"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
         app:autoSizeTextType="uniform"
@@ -1131,7 +1250,7 @@
         android:textStyle="normal"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH16"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH15"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -1275,7 +1394,7 @@
         android:textSize="26sp"
         android:textStyle="normal"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH16"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH15"
         app:autoSizeTextType="uniform"
@@ -1300,7 +1419,7 @@
         android:textStyle="normal"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH18"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH17"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -1443,7 +1562,7 @@
         android:textSize="26sp"
         android:textStyle="normal"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH18"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH17"
         app:autoSizeTextType="uniform"
@@ -1454,48 +1573,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -1503,8 +1600,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -1514,14 +1611,13 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
-        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV13"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:layout_constraintVertical_bias="0.0"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
         app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
@@ -1536,28 +1632,28 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.06" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.14" />
+        app:layout_constraintGuide_percent="0.16" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.15" />
+        app:layout_constraintGuide_percent="0.18" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
@@ -1571,105 +1667,105 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.28" />
+        app:layout_constraintGuide_percent="0.29" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.36" />
+        app:layout_constraintGuide_percent="0.37" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.37" />
+        app:layout_constraintGuide_percent="0.38" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.45" />
+        app:layout_constraintGuide_percent="0.46" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.46" />
+        app:layout_constraintGuide_percent="0.47" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.54" />
+        app:layout_constraintGuide_percent="0.55" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.55" />
+        app:layout_constraintGuide_percent="0.56" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.63" />
+        app:layout_constraintGuide_percent="0.64" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.64" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH14"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.72" />
+        app:layout_constraintGuide_percent="0.73" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH15"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.73" />
+        app:layout_constraintGuide_percent="0.74" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH16"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.81" />
+        app:layout_constraintGuide_percent="0.82" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH17"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.82" />
+        app:layout_constraintGuide_percent="0.83" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH18"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -1679,87 +1775,101 @@
         app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.136" />
+        app:layout_constraintGuide_percent="0.14142" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.144" />
+        app:layout_constraintGuide_percent="0.15143" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.28" />
+        app:layout_constraintGuide_percent="0.28285" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.288" />
+        app:layout_constraintGuide_percent="0.29286" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.424" />
+        app:layout_constraintGuide_percent="0.42428" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.432" />
+        app:layout_constraintGuide_percent="0.43429" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.568" />
+        app:layout_constraintGuide_percent="0.56571" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.576" />
+        app:layout_constraintGuide_percent="0.57572" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.712" />
+        app:layout_constraintGuide_percent="0.70714" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.72" />
+        app:layout_constraintGuide_percent="0.71715" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.856" />
+        app:layout_constraintGuide_percent="0.84857" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.864" />
+        app:layout_constraintGuide_percent="0.85858" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV13"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/peru.xml
+++ b/app/src/main/res/layout/peru.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Peru">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <ImageView
         android:id="@+id/wordImage"
@@ -253,48 +372,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -302,8 +399,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -315,8 +412,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -334,7 +431,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
@@ -362,56 +459,56 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.575" />
+        app:layout_constraintGuide_percent="0.58" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.585" />
+        app:layout_constraintGuide_percent="0.59" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.68" />
+        app:layout_constraintGuide_percent="0.69" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.69" />
+        app:layout_constraintGuide_percent="0.70" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.785" />
+        app:layout_constraintGuide_percent="0.80" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.795" />
+        app:layout_constraintGuide_percent="0.81" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -425,13 +522,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.02" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/peru.xml
+++ b/app/src/main/res/layout/peru.xml
@@ -281,7 +281,7 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         android:contentDescription="@string/activeWordPicture"
-        app:srcCompat="@drawable/zz_alphatileslogo" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <TextView
         android:id="@+id/word1"
@@ -387,7 +387,7 @@
         android:id="@+id/bottomMiddleSpacer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:tag="SR2"
+        android:tag="BMS"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toStartOf="@+id/repeatImage"
         app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"

--- a/app/src/main/res/layout/resources.xml
+++ b/app/src/main/res/layout/resources.xml
@@ -14,8 +14,8 @@
         android:layout_height="0dp"
         android:contentDescription="@string/resourcePromo"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:srcCompat="@drawable/zz_resource_promo" />
 
@@ -98,7 +98,7 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3" />
 
@@ -116,7 +116,7 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5" />
 
@@ -134,7 +134,7 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7" />
 
@@ -152,7 +152,7 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9" />
 
@@ -170,7 +170,7 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH12"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11" />
 
@@ -188,7 +188,7 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13" />
 
@@ -218,7 +218,6 @@
         app:layout_constraintTop_toTopOf="@+id/guidelineH14"
         app:srcCompat="@drawable/zz_forward" />
 
-
     <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
@@ -227,7 +226,7 @@
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH16"
         app:layout_constraintEnd_toStartOf="@id/instructions"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH15"
         app:srcCompat="@drawable/zz_games_home" />
 
@@ -239,7 +238,7 @@
         android:onClick="playAudioInstructionsResources"
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH16"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV6"
         app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
         app:layout_constraintTop_toTopOf="@+id/guidelineH15"
         app:srcCompat="@drawable/zz_instructions" />
@@ -249,7 +248,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.02" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
@@ -354,14 +353,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.02" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
@@ -396,6 +395,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/romania.xml
+++ b/app/src/main/res/layout/romania.xml
@@ -12,22 +12,19 @@
         android:id="@+id/tileBoxTextView"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:onClick="onRefClick"
         android:background="#9C27B0"
         android:gravity="center|center_vertical"
+        android:onClick="onRefClick"
         android:text="@string/gameTileInFocus"
         android:textColor="#FFFFFF"
         app:autoSizeMaxTextSize="120sp"
         app:autoSizeMinTextSize="20sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
-        app:layout_constraintDimensionRatio="1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH7"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV5"
-        app:layout_constraintHorizontal_bias="0.476"
         app:layout_constraintStart_toStartOf="@+id/guidelineV2"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
-        app:layout_constraintVertical_bias="1.0" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH0" />
 
     <ImageView
         android:id="@+id/backwardArrowImage"
@@ -35,12 +32,10 @@
         android:layout_height="0dp"
         android:layout_marginEnd="5dp"
         android:onClick="goToPreviousTile"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHMagTileTop"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintEnd_toStartOf="@+id/tileBoxTextView"
-        app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1andHalf"
-        app:layout_constraintVertical_bias="0.0"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         android:contentDescription="@string/goBackward"
         app:srcCompat="@drawable/zz_backward"
         android:layout_marginRight="5dp"
@@ -51,32 +46,30 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="5dp"
+        android:contentDescription="@string/goForward"
         android:onClick="goToNextTile"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHMagTileTop"
+        android:rotationY="0"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toEndOf="@+id/tileBoxTextView"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1andHalf"
-        app:srcCompat="@drawable/zz_forward"
-        android:contentDescription="@string/goForward"
-        android:layout_marginLeft="5dp"
-        android:rotationY="0"/>
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
+        app:srcCompat="@drawable/zz_forward" />
 
     <ImageView
         android:id="@+id/wordImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH9"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV5"
         app:layout_constraintStart_toStartOf="@+id/guidelineV2"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH8"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo" />
 
-
     <TextView
-        android:id="@+id/tileInMagnifyingGlass"
+        android:id="@+id/numberOfTotalText"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@drawable/zz_white_border"
@@ -88,10 +81,10 @@
         app:autoSizeMinTextSize="15sp"
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/guidelineHWhiteBorder"
-        app:layout_constraintEnd_toEndOf="@+id/tileBoxTextView"
-        app:layout_constraintStart_toStartOf="@+id/tileBoxTextView"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"/>
+        app:layout_constraintBottom_toBottomOf="@+id/guidelineH4"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV5"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH0"/>
 
     <TextView
         android:id="@+id/activeWordTextView"
@@ -101,10 +94,10 @@
         android:gravity="center"
         android:text="@string/activeWordText"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH11"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH10"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -117,103 +110,48 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="scrollBack"
-        app:layout_constraintBottom_toBottomOf="@+id/guidelineHScrollBottom"
+        android:rotationY="0"
+        app:layout_constraintBottom_toBottomOf="@+id/guidelineH3"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV3"
         app:layout_constraintStart_toStartOf="@+id/tileBoxTextView"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHMagTop"
-        app:srcCompat="@drawable/zz_backward_white"
-        android:rotationY="0"/>
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
+        app:srcCompat="@drawable/zz_backward_white" />
 
     <ImageView
         android:id="@+id/scrollForward"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="scrollForward"
+        android:rotationY="0"
+        app:layout_constraintBottom_toBottomOf="@+id/guidelineH3"
         app:layout_constraintDimensionRatio="1"
-        app:layout_constraintBottom_toBottomOf="@+id/guidelineHScrollBottom"
         app:layout_constraintEnd_toEndOf="@+id/tileBoxTextView"
         app:layout_constraintStart_toStartOf="@+id/guidelineV4"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHMagTop"
-        app:srcCompat="@drawable/zz_forward_white"
-        android:rotationY="0"/>
-
-    <ImageView
-        android:id="@+id/toggleInitialOnly"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="setToggleToInitialOnly"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
-        app:layout_constraintEnd_toStartOf="@+id/toggleInitialPlusGaps"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
-        android:contentDescription="toggleInitialOnly"
-        app:srcCompat="@drawable/zz_toggle_initial_only_off" />
-
-    <ImageView
-        android:id="@+id/toggleInitialPlusGaps"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="setToggleToInitialPlusGaps"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
-        app:layout_constraintEnd_toStartOf="@+id/toggleAllOfAll"
-        app:layout_constraintStart_toEndOf="@+id/toggleInitialOnly"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
-        android:contentDescription="toggleInitialPlusGaps"
-        app:srcCompat="@drawable/zz_toggle_initial_plus_gaps_off" />
-
-    <ImageView
-        android:id="@+id/toggleAllOfAll"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="setToggleToAllOfAll"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/toggleInitialPlusGaps"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
-        android:contentDescription="toggle_all_of_all"
-        app:srcCompat="@drawable/zz_toggle_all_of_all_off" />
-
-    <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/pointsImage"
-        android:visibility="invisible"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_pointsscored" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textSize="16sp"
-        android:textStyle="bold"
-        android:visibility="invisible"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
+        app:layout_constraintTop_toTopOf="@+id/guidelineH2"
+        app:srcCompat="@drawable/zz_forward_white" />
 
     <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playerAvatar"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:layout_constraintVertical_bias="0.0"
+        android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -221,117 +159,90 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
+        android:contentDescription="@string/playAudioInstructions"
         android:rotationY="0"
         app:srcCompat="@drawable/zz_instructions" />
 
-    <ImageView
-        android:id="@+id/repeatImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="repeatGame"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_forward_inactive" />
-
     <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH1"
+        android:id="@+id/guidelineH0"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.01" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHMagTop"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.03" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHScrollBottom"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHWhiteBorder"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.08" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH1andHalf"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.11" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHMagTileTop"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.30" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.34" />
+        app:layout_constraintGuide_percent="0.07" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.35" />
+        app:layout_constraintGuide_percent="0.11" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.68" />
+        app:layout_constraintGuide_percent="0.12" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.69" />
+        app:layout_constraintGuide_percent="0.135" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.82" />
+        app:layout_constraintGuide_percent="0.315" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.83" />
+        app:layout_constraintGuide_percent="0.38" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.88" />
+        app:layout_constraintGuide_percent="0.40" />
 
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH9"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.73" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH10"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.75" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH11"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.88" />
+    
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/romania.xml
+++ b/app/src/main/res/layout/romania.xml
@@ -246,7 +246,42 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.02" />
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHMagTop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.03" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHScrollBottom"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.07" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHWhiteBorder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.08" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH1andHalf"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.11" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineHMagTileTop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.30" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
@@ -302,14 +337,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
@@ -352,40 +387,5 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.99" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHMagTop"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.03" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHScrollBottom"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHWhiteBorder"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.08" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineHMagTileTop"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.30" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guidelineH1andHalf"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.11" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/set_player_name.xml
+++ b/app/src/main/res/layout/set_player_name.xml
@@ -15,9 +15,9 @@
         android:contentDescription="@string/playerAvatar"
         android:onClick="acceptName"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH1"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH0"
         app:srcCompat="@drawable/zz_games_home" />
 
     <ImageView
@@ -30,7 +30,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH1"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV11"
         app:layout_constraintStart_toEndOf="@+id/guidelineV10"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH0"
         app:srcCompat="@drawable/zz_instructions" />
 
     <ImageView
@@ -42,8 +42,10 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV11"
+        app:layout_constraintHorizontal_bias="0.504"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintVertical_bias="0.0"
         app:srcCompat="@drawable/zz_alphatileslogo" />
 
     <EditText
@@ -62,8 +64,8 @@
         app:autoSizeStepGranularity="2sp"
         app:autoSizeTextType="uniform"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH3" />
 
     <ImageView
@@ -73,7 +75,7 @@
         android:contentDescription="@string/backspace"
         android:onClick="acceptName"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV8"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:srcCompat="@drawable/zz_complete" />
@@ -87,7 +89,7 @@
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:srcCompat="@drawable/zz_deletetext" />
 
@@ -108,7 +110,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7" />
 
     <TextView
@@ -216,7 +218,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH8"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7" />
 
@@ -235,7 +237,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9" />
 
     <TextView
@@ -342,7 +344,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH10"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9" />
 
@@ -361,7 +363,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH12"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11" />
 
     <TextView
@@ -468,7 +470,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH12"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11" />
 
@@ -487,7 +489,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13" />
 
     <TextView
@@ -594,7 +596,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH14"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13" />
 
@@ -613,7 +615,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH16"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH15" />
 
     <TextView
@@ -720,23 +722,30 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH16"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH15" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.12" />
+        app:layout_constraintGuide_percent="0.13" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.24" />
+        app:layout_constraintGuide_percent="0.28" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
@@ -757,167 +766,188 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.41" />
+        app:layout_constraintGuide_percent="0.42" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.50" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.55" />
+        app:layout_constraintGuide_percent="0.52" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.63" />
+        app:layout_constraintGuide_percent="0.60" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.64" />
+        app:layout_constraintGuide_percent="0.61" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.72" />
+        app:layout_constraintGuide_percent="0.69" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.73" />
+        app:layout_constraintGuide_percent="0.70" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.81" />
+        app:layout_constraintGuide_percent="0.78" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.82" />
+        app:layout_constraintGuide_percent="0.79" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH14"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.87" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH15"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.91" />
+        app:layout_constraintGuide_percent="0.88" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH16"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.96" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineH17"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.99" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.136" />
+        app:layout_constraintGuide_percent="0.14142" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.144" />
+        app:layout_constraintGuide_percent="0.15143" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.28" />
+        app:layout_constraintGuide_percent="0.28285" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.288" />
+        app:layout_constraintGuide_percent="0.29286" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.424" />
+        app:layout_constraintGuide_percent="0.42428" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.432" />
+        app:layout_constraintGuide_percent="0.43429" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.568" />
+        app:layout_constraintGuide_percent="0.56571" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.576" />
+        app:layout_constraintGuide_percent="0.57572" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.712" />
+        app:layout_constraintGuide_percent="0.70714" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.72" />
+        app:layout_constraintGuide_percent="0.71715" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.856" />
+        app:layout_constraintGuide_percent="0.84857" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.864" />
+        app:layout_constraintGuide_percent="0.85858" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV13"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/share.xml
+++ b/app/src/main/res/layout/share.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/shareCL"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".Share">

--- a/app/src/main/res/layout/sudan.xml
+++ b/app/src/main/res/layout/sudan.xml
@@ -26,7 +26,7 @@
         app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
         app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:layout_constraintVertical_bias="0.0"
         app:autoSizeTextType="uniform"
@@ -171,7 +171,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH6"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
@@ -196,7 +196,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -339,7 +339,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH8"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
@@ -364,7 +364,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH10"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -507,7 +507,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH10"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH9"
         app:autoSizeTextType="uniform"
@@ -532,7 +532,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH12"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -675,7 +675,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH12"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH11"
         app:autoSizeTextType="uniform"
@@ -700,7 +700,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH14"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -843,7 +843,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH14"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH13"
         app:autoSizeTextType="uniform"
@@ -868,7 +868,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH16"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH15"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -1011,7 +1011,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH16"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH15"
         app:autoSizeTextType="uniform"
@@ -1036,7 +1036,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH18"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH17"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -1184,7 +1184,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH18"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH17"
         app:autoSizeTextType="uniform"
@@ -1209,7 +1209,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH20"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH19"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -1352,7 +1352,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH20"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH19"
         app:autoSizeTextType="uniform"
@@ -1377,7 +1377,7 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH22"
         app:layout_constraintEnd_toEndOf="@+id/guidelineV1"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineH21"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
@@ -1520,7 +1520,7 @@
         android:textSize="26sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@+id/guidelineH22"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
         app:layout_constraintStart_toStartOf="@+id/guidelineV12"
         app:layout_constraintTop_toTopOf="@+id/guidelineH21"
         app:autoSizeTextType="uniform"
@@ -1531,45 +1531,7 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/gamesHomeImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="goBackToEarth"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/repeatImage2"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playerAvatar"
-        app:srcCompat="@drawable/zz_games_home" />
-
-    <ImageView
-        android:id="@+id/instructions"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="playAudioInstructions"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_instructions" />
-
-    <ImageView
-        android:id="@+id/repeatImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
-        android:onClick="nextPageArrow"
-        android:rotationY="0"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_forward" />
-
-    <ImageView
-        android:id="@+id/repeatImage2"
+        android:id="@+id/previousSet"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/playAgain"
@@ -1577,142 +1539,190 @@
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         app:srcCompat="@drawable/zz_backward" />
+
+    <ImageView
+        android:id="@+id/gamesHomeImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="goBackToEarth"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintStart_toEndOf="@+id/previousSet"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playerAvatar"
+        app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomInstructionsSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BIS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/nextSet"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
+
+    <ImageView
+        android:id="@+id/instructions"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="playAudioInstructions"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintStart_toStartOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintEnd_toEndOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
+        app:srcCompat="@drawable/zz_instructions" />
+
+    <ImageView
+        android:id="@+id/nextSet"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/playAgain"
+        android:onClick="nextPageArrow"
+        android:rotationY="0"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV13"
+        app:layout_constraintStart_toEndOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:srcCompat="@drawable/zz_forward" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.01" />
+        app:layout_constraintGuide_percent="0.03" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.09" />
+        app:layout_constraintGuide_percent="0.11" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.11" />
+        app:layout_constraintGuide_percent="0.13" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.19" />
+        app:layout_constraintGuide_percent="0.21" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.21" />
+        app:layout_constraintGuide_percent="0.23" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.29" />
+        app:layout_constraintGuide_percent="0.31" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.31" />
+        app:layout_constraintGuide_percent="0.33" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.39" />
+        app:layout_constraintGuide_percent="0.41" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.41" />
+        app:layout_constraintGuide_percent="0.43" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH14"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.49" />
+        app:layout_constraintGuide_percent="0.51" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH15"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.51" />
+        app:layout_constraintGuide_percent="0.53" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH16"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.59" />
+        app:layout_constraintGuide_percent="0.61" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH17"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.61" />
+        app:layout_constraintGuide_percent="0.63" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH18"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.69" />
+        app:layout_constraintGuide_percent="0.71" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH19"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.71" />
+        app:layout_constraintGuide_percent="0.73" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH20"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.79" />
+        app:layout_constraintGuide_percent="0.81" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH21"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.81" />
+        app:layout_constraintGuide_percent="0.83" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH22"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -1722,87 +1732,101 @@
         app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
+
+    <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.136" />
+        app:layout_constraintGuide_percent="0.14142" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.144" />
+        app:layout_constraintGuide_percent="0.15143" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.28" />
+        app:layout_constraintGuide_percent="0.28285" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.288" />
+        app:layout_constraintGuide_percent="0.29286" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.424" />
+        app:layout_constraintGuide_percent="0.42428" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.432" />
+        app:layout_constraintGuide_percent="0.43429" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.568" />
+        app:layout_constraintGuide_percent="0.56571" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.576" />
+        app:layout_constraintGuide_percent="0.57572" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.712" />
+        app:layout_constraintGuide_percent="0.70714" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.72" />
+        app:layout_constraintGuide_percent="0.71715" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.856" />
+        app:layout_constraintGuide_percent="0.84857" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.864" />
+        app:layout_constraintGuide_percent="0.85858" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV13"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/sudan_syll.xml
+++ b/app/src/main/res/layout/sudan_syll.xml
@@ -851,58 +851,7 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/pointsImage"
-        android:visibility="invisible"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-
-    <ImageView
-        android:id="@+id/gamesHomeImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="goBackToEarth"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playerAvatar"
-        app:srcCompat="@drawable/zz_games_home" />
-
-    <ImageView
-        android:id="@+id/instructions"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:onClick="playAudioInstructions"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/playAgain"
-        android:rotationY="0"
-        app:srcCompat="@drawable/zz_instructions" />
-
-    <ImageView
-        android:id="@+id/repeatImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
-        android:onClick="nextPageArrow"
-        android:rotationY="0"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:srcCompat="@drawable/zz_forward" />
-
-    <ImageView
-        android:id="@+id/repeatImage2"
+        android:id="@+id/previousSet"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/playAgain"
@@ -910,9 +859,57 @@
         android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
         app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV0"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         app:srcCompat="@drawable/zz_backward" />
+
+    <ImageView
+        android:id="@+id/gamesHomeImage"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="goBackToEarth"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintStart_toEndOf="@+id/previousSet"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playerAvatar"
+        app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomInstructionsSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BIS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/nextSet"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
+
+    <ImageView
+        android:id="@+id/instructions"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:onClick="playAudioInstructions"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintStart_toStartOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintEnd_toEndOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
+        app:srcCompat="@drawable/zz_instructions" />
+
+    <ImageView
+        android:id="@+id/nextSet"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/playAgain"
+        android:onClick="nextPageArrow"
+        android:rotationY="0"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV9"
+        app:layout_constraintStart_toEndOf="@+id/bottomInstructionsSpacer"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
+        app:srcCompat="@drawable/zz_forward" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
@@ -926,98 +923,98 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.108671" />
+        app:layout_constraintGuide_percent="0.13" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.128671" />
+        app:layout_constraintGuide_percent="0.14" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.23724" />
+        app:layout_constraintGuide_percent="0.26" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.25724" />
+        app:layout_constraintGuide_percent="0.27" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.36581" />
+        app:layout_constraintGuide_percent="0.39" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH11"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.38581" />
+        app:layout_constraintGuide_percent="0.40" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH12"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.49438" />
+        app:layout_constraintGuide_percent="0.52" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.51438" />
+        app:layout_constraintGuide_percent="0.53" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH14"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.62295" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH15"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.64295" />
+        app:layout_constraintGuide_percent="0.66" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH16"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.75152" />
+        app:layout_constraintGuide_percent="0.78" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH17"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.77152" />
+        app:layout_constraintGuide_percent="0.79" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH18"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.88009" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.90" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -1025,6 +1022,13 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.99" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineV0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
@@ -1087,6 +1091,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="1.00" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/thailand.xml
+++ b/app/src/main/res/layout/thailand.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Thailand">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV4"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <TextView
         android:id="@+id/referenceItem"
@@ -266,48 +385,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -315,8 +412,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -326,14 +423,13 @@
         android:id="@+id/repeatImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:contentDescription="@string/playAgain"
         android:onClick="repeatGame"
-        android:rotationY="0"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV4"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        app:layout_constraintVertical_bias="1.0"
+        android:contentDescription="@string/playAgain"
+        android:rotationY="0"
         app:srcCompat="@drawable/zz_forward_inactive" />
 
     <androidx.constraintlayout.widget.Guideline
@@ -348,56 +444,56 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
+        app:layout_constraintGuide_percent="0.10" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.39" />
+        app:layout_constraintGuide_percent="0.42" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.41" />
+        app:layout_constraintGuide_percent="0.44" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.63" />
+        app:layout_constraintGuide_percent="0.66" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.65" />
+        app:layout_constraintGuide_percent="0.68" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.87" />
+        app:layout_constraintGuide_percent="0.90" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -411,7 +507,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.02" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
@@ -432,6 +528,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/thailand2.xml
+++ b/app/src/main/res/layout/thailand2.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".Thailand">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <TextView
         android:id="@+id/referenceItem"
@@ -262,48 +381,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -311,8 +408,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -324,8 +421,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV2"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -343,84 +440,84 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.45" />
+        app:layout_constraintGuide_percent="0.46" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.47" />
+        app:layout_constraintGuide_percent="0.48" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.565" />
+        app:layout_constraintGuide_percent="0.58" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.575" />
+        app:layout_constraintGuide_percent="0.59" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.67" />
+        app:layout_constraintGuide_percent="0.69" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.68" />
+        app:layout_constraintGuide_percent="0.70" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.775" />
+        app:layout_constraintGuide_percent="0.80" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.785" />
+        app:layout_constraintGuide_percent="0.81" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.88" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
@@ -434,13 +531,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.02" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/united_states_cl1.xml
+++ b/app/src/main/res/layout/united_states_cl1.xml
@@ -8,17 +8,82 @@
     android:background="#FFFFFF"
     tools:context=".UnitedStates">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
-        app:srcCompat="@drawable/zz_incomplete"
-        />
+        android:padding = "2dp"
+        app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
         android:id="@+id/tracker02"
@@ -30,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -42,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -54,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -66,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -78,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -90,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -102,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -114,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -126,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -138,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -147,32 +222,75 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV10"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <Button
         android:id="@+id/button01a"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="#9C27B0"
+        android:maxLines="1"
         android:onClick="onBtnClick"
+        android:padding="2dp"
         android:tag="1"
         android:text="@string/gameTile1a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeStepGranularity="2sp"
+        app:autoSizeTextType="uniform"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
-        app:autoSizeTextType="uniform"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeMaxTextSize="100sp"
-        app:autoSizeStepGranularity="2sp"
-        android:padding = "2dp"
-        android:maxLines="1"/>
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"/>
 
     <Button
         android:id="@+id/button01b"
@@ -184,11 +302,11 @@
         android:text="@string/gameTile1b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -206,11 +324,11 @@
         android:text="@string/gameTile2a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV4"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -228,11 +346,11 @@
         android:text="@string/gameTile2b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV4"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -250,11 +368,11 @@
         android:text="@string/gameTile3a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV5"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -272,11 +390,11 @@
         android:text="@string/gameTile3b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV5"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -294,11 +412,11 @@
         android:text="@string/gameTile4a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV8"
         app:layout_constraintStart_toStartOf="@+id/guidelineV7"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -316,11 +434,11 @@
         android:text="@string/gameTile4b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV8"
         app:layout_constraintStart_toStartOf="@+id/guidelineV7"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -339,11 +457,11 @@
         android:text="@string/gameTile5a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV10"
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -361,11 +479,11 @@
         android:text="@string/gameTile5b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV10"
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -377,13 +495,13 @@
         android:id="@+id/wordImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:contentDescription="@string/activeWordPicture"
         android:onClick="clickPicHearAudio"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV10"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
-        android:contentDescription="@string/activeWordPicture"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         app:srcCompat="@drawable/zz_sil" />
 
     <TextView
@@ -394,10 +512,10 @@
         android:text="@string/boxToBuildTargetWordIn"
         android:textColor="#000000"
         android:textSize="40sp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH7"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH4"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -406,48 +524,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -455,8 +551,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -468,8 +564,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV10"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -487,77 +583,77 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.06" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.19" />
+        app:layout_constraintGuide_percent="0.45" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.21" />
+        app:layout_constraintGuide_percent="0.47" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.34" />
+        app:layout_constraintGuide_percent="0.62" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.36" />
+        app:layout_constraintGuide_percent="0.64" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.46" />
+        app:layout_constraintGuide_percent="0.77" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.485" />
+        app:layout_constraintGuide_percent="0.78" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.885" />
+        app:layout_constraintGuide_percent="0.91" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"

--- a/app/src/main/res/layout/united_states_cl1.xml
+++ b/app/src/main/res/layout/united_states_cl1.xml
@@ -384,7 +384,7 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         android:contentDescription="@string/activeWordPicture"
-        app:srcCompat="@drawable/zz_alphatileslogo" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <TextView
         android:id="@+id/activeWordTextView"

--- a/app/src/main/res/layout/united_states_cl2.xml
+++ b/app/src/main/res/layout/united_states_cl2.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".UnitedStates">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,53 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV14"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
 
     <Button
         android:id="@+id/button01a"
@@ -161,11 +280,11 @@
         android:text="@string/gameTile1a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -183,11 +302,11 @@
         android:text="@string/gameTile1b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -205,11 +324,11 @@
         android:text="@string/gameTile2a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV4"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -227,11 +346,11 @@
         android:text="@string/gameTile2b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV4"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -249,11 +368,11 @@
         android:text="@string/gameTile3a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV5"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -271,11 +390,11 @@
         android:text="@string/gameTile3b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV5"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -293,11 +412,11 @@
         android:text="@string/gameTile4a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV8"
         app:layout_constraintStart_toStartOf="@+id/guidelineV7"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -315,11 +434,11 @@
         android:text="@string/gameTile4b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV8"
         app:layout_constraintStart_toStartOf="@+id/guidelineV7"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -337,11 +456,11 @@
         android:text="@string/gameTile5a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV10"
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -359,11 +478,11 @@
         android:text="@string/gameTile5b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV10"
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -381,11 +500,11 @@
         android:text="@string/gameTile6a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV12"
         app:layout_constraintStart_toStartOf="@+id/guidelineV11"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -403,11 +522,11 @@
         android:text="@string/gameTile6b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV12"
         app:layout_constraintStart_toStartOf="@+id/guidelineV11"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -425,11 +544,11 @@
         android:text="@string/gameTile7a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV14"
         app:layout_constraintStart_toStartOf="@+id/guidelineV13"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -447,11 +566,11 @@
         android:text="@string/gameTile7b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV14"
         app:layout_constraintStart_toStartOf="@+id/guidelineV13"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -464,11 +583,11 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV14"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_alphatileslogo" />
 
@@ -480,10 +599,10 @@
         android:text="@string/boxToBuildTargetWordIn"
         android:textColor="#000000"
         android:textSize="40sp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV14"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -492,48 +611,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -541,8 +638,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -554,8 +651,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV14"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -573,84 +670,84 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.07" />
+        app:layout_constraintGuide_percent="0.08" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.15" />
+        app:layout_constraintGuide_percent="0.48" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.19" />
+        app:layout_constraintGuide_percent="0.50" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.27" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.30" />
+        app:layout_constraintGuide_percent="0.67" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.46" />
+        app:layout_constraintGuide_percent="0.75" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.485" />
+        app:layout_constraintGuide_percent="0.77" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.885" />
+        app:layout_constraintGuide_percent="0.85" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.015" />
+        app:layout_constraintGuide_percent="0.01" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV2"
@@ -741,6 +838,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.985" />
+        app:layout_constraintGuide_percent="0.99" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/united_states_cl3.xml
+++ b/app/src/main/res/layout/united_states_cl3.xml
@@ -8,15 +8,81 @@
     android:background="#FFFFFF"
     tools:context=".UnitedStates">
 
+    <TextView
+        android:id="@+id/spacerLeft1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerLeft2"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerLeft2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SL2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toEndOf="@+id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/gameNumberView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/challengeLevelView"
+        app:layout_constraintStart_toStartOf="@id/spacerLeft1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
+    <TextView
+        android:id="@+id/challengeLevelView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FFD700"
+        android:gravity="center"
+        android:tag="1"
+        android:text="0"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:textSize="30sp"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/tracker01"
+        app:layout_constraintStart_toEndOf="@id/spacerLeft2"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <ImageView
         android:id="@+id/tracker01"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@string/tracker1of12"
+        android:tag="1"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
         app:layout_constraintEnd_toStartOf="@+id/tracker02"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/challengeLevelView"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -29,6 +95,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker03"
         app:layout_constraintStart_toEndOf="@+id/tracker01"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -41,6 +108,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker04"
         app:layout_constraintStart_toEndOf="@+id/tracker02"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -53,6 +121,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker05"
         app:layout_constraintStart_toEndOf="@+id/tracker03"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -65,6 +134,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker06"
         app:layout_constraintStart_toEndOf="@+id/tracker04"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -77,6 +147,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker07"
         app:layout_constraintStart_toEndOf="@+id/tracker05"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -89,6 +160,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker08"
         app:layout_constraintStart_toEndOf="@+id/tracker06"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -101,6 +173,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker09"
         app:layout_constraintStart_toEndOf="@+id/tracker07"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -113,6 +186,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker10"
         app:layout_constraintStart_toEndOf="@+id/tracker08"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -125,6 +199,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker11"
         app:layout_constraintStart_toEndOf="@+id/tracker09"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -137,6 +212,7 @@
         app:layout_constraintEnd_toStartOf="@+id/tracker12"
         app:layout_constraintStart_toEndOf="@+id/tracker10"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
 
     <ImageView
@@ -146,10 +222,54 @@
         android:contentDescription="@string/tracker12of12"
         android:tag="12"
         app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight1"
         app:layout_constraintStart_toEndOf="@+id/tracker11"
         app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        android:padding = "2dp"
         app:srcCompat="@drawable/zz_incomplete" />
+
+    <TextView
+        android:id="@+id/spacerRight1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR1"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toStartOf="@+id/spacerRight2"
+        app:layout_constraintStart_toEndOf="@+id/tracker12"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/spacerRight2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="SR2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV18"
+        app:layout_constraintStart_toEndOf="@+id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"/>
+
+    <TextView
+        android:id="@+id/pointsTextView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#9C27B0"
+        android:gravity="center"
+        android:tag="1"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:textSize="30sp"
+        android:text="@string/pointsScored"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH0"
+        app:layout_constraintEnd_toEndOf="@id/spacerRight2"
+        app:layout_constraintStart_toStartOf="@id/spacerRight1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHneg1"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="5sp"
+        app:autoSizeMaxTextSize="100sp"
+        app:autoSizeStepGranularity="2sp"
+        android:padding = "0dp"
+        android:maxLines="1"/>
+
     <Button
         android:id="@+id/button01a"
         android:layout_width="0dp"
@@ -160,11 +280,11 @@
         android:text="@string/gameTile1a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -182,11 +302,11 @@
         android:text="@string/gameTile1b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV2"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -204,11 +324,11 @@
         android:text="@string/gameTile2a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV4"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -226,11 +346,11 @@
         android:text="@string/gameTile2b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV4"
         app:layout_constraintStart_toStartOf="@+id/guidelineV3"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -248,11 +368,11 @@
         android:text="@string/gameTile3a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV5"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -270,11 +390,11 @@
         android:text="@string/gameTile3b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV6"
         app:layout_constraintStart_toStartOf="@+id/guidelineV5"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -292,11 +412,11 @@
         android:text="@string/gameTile4a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV8"
         app:layout_constraintStart_toStartOf="@+id/guidelineV7"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -314,11 +434,11 @@
         android:text="@string/gameTile4b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV8"
         app:layout_constraintStart_toStartOf="@+id/guidelineV7"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -336,11 +456,11 @@
         android:text="@string/gameTile5a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV10"
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -358,11 +478,11 @@
         android:text="@string/gameTile5b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV10"
         app:layout_constraintStart_toStartOf="@+id/guidelineV9"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -380,11 +500,11 @@
         android:text="@string/gameTile6a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV12"
         app:layout_constraintStart_toStartOf="@+id/guidelineV11"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -402,11 +522,11 @@
         android:text="@string/gameTile6b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV12"
         app:layout_constraintStart_toStartOf="@+id/guidelineV11"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -424,11 +544,11 @@
         android:text="@string/gameTile7a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV14"
         app:layout_constraintStart_toStartOf="@+id/guidelineV13"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -446,11 +566,11 @@
         android:text="@string/gameTile7b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV14"
         app:layout_constraintStart_toStartOf="@+id/guidelineV13"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -468,11 +588,11 @@
         android:text="@string/gameTile8a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV16"
         app:layout_constraintStart_toStartOf="@+id/guidelineV15"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -490,11 +610,11 @@
         android:text="@string/gameTile8b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV16"
         app:layout_constraintStart_toStartOf="@+id/guidelineV15"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -512,11 +632,11 @@
         android:text="@string/gameTile9a"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV18"
         app:layout_constraintStart_toStartOf="@+id/guidelineV17"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -534,11 +654,11 @@
         android:text="@string/gameTile9b"
         android:textAllCaps="false"
         android:textColor="#FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV18"
         app:layout_constraintStart_toStartOf="@+id/guidelineV17"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -551,11 +671,11 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="clickPicHearAudio"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH8"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH2"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@+id/guidelineV18"
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH7"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH1"
         android:contentDescription="@string/activeWordPicture"
         app:srcCompat="@drawable/zz_sil" />
 
@@ -567,10 +687,10 @@
         android:text="@string/boxToBuildTargetWordIn"
         android:textColor="#000000"
         android:textSize="40sp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineH6"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineH5"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineH4"
+        app:layout_constraintEnd_toEndOf="@+id/guidelineV18"
+        app:layout_constraintStart_toStartOf="@+id/guidelineV1"
+        app:layout_constraintTop_toTopOf="@+id/guidelineH3"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="5sp"
         app:autoSizeMaxTextSize="100sp"
@@ -579,48 +699,26 @@
         android:maxLines="1"/>
 
     <ImageView
-        android:id="@+id/pointsImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/gamesHomeImage"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
-        android:contentDescription="@string/pointsImage"
-        app:srcCompat="@drawable/zz_pointsscoredthisgame" />
-
-    <TextView
-        android:id="@+id/pointsTextView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:maxLines="1"
-        android:padding="7dp"
-        android:text="@string/pointsScored"
-        android:textAlignment="center"
-        android:textColor="#FFFFFF"
-        android:textStyle="bold"
-        app:autoSizeMaxTextSize="25sp"
-        app:autoSizeMinTextSize="5sp"
-        app:autoSizeStepGranularity="2sp"
-        app:autoSizeTextType="uniform"
-        app:layout_constraintBottom_toBottomOf="@+id/pointsImage"
-        app:layout_constraintDimensionRatio="1"
-        app:layout_constraintEnd_toEndOf="@+id/pointsImage"
-        app:layout_constraintStart_toStartOf="@+id/pointsImage"
-        app:layout_constraintTop_toTopOf="@+id/pointsImage" />
-
-    <ImageView
         android:id="@+id/gamesHomeImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:onClick="goBackToEarth"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toStartOf="@+id/instructions"
-        app:layout_constraintStart_toEndOf="@+id/pointsImage"
+        app:layout_constraintEnd_toStartOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playerAvatar"
         app:srcCompat="@drawable/zz_games_home" />
+
+    <TextView
+        android:id="@+id/bottomMiddleSpacer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:tag="BMS"
+        app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
+        app:layout_constraintEnd_toStartOf="@+id/repeatImage"
+        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"/>
 
     <ImageView
         android:id="@+id/instructions"
@@ -628,8 +726,8 @@
         android:layout_height="0dp"
         android:onClick="playAudioInstructions"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="@+id/repeatImage"
-        app:layout_constraintStart_toEndOf="@+id/gamesHomeImage"
+        app:layout_constraintEnd_toEndOf="@+id/bottomMiddleSpacer"
+        app:layout_constraintStart_toStartOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -641,8 +739,8 @@
         android:layout_height="0dp"
         android:onClick="repeatGame"
         app:layout_constraintBottom_toTopOf="@+id/guidelineHSys2"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/instructions"
+        app:layout_constraintEnd_toEndOf="@id/guidelineV18"
+        app:layout_constraintStart_toEndOf="@+id/bottomMiddleSpacer"
         app:layout_constraintTop_toTopOf="@+id/guidelineHSys1"
         android:contentDescription="@string/playAgain"
         android:rotationY="0"
@@ -660,7 +758,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.05" />
+        app:layout_constraintGuide_percent="0.06" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH1"
@@ -674,63 +772,63 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.14" />
+        app:layout_constraintGuide_percent="0.48" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.2" />
+        app:layout_constraintGuide_percent="0.50" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.26" />
+        app:layout_constraintGuide_percent="0.65" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.30" />
+        app:layout_constraintGuide_percent="0.67" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.46" />
+        app:layout_constraintGuide_percent="0.73" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.485" />
+        app:layout_constraintGuide_percent="0.77" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.885" />
+        app:layout_constraintGuide_percent="0.83" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.89" />
+        app:layout_constraintGuide_percent="0.93" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineHSys2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.98" />
+        app:layout_constraintGuide_percent="0.99" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineV1"

--- a/app/src/main/res/layout/united_states_cl3.xml
+++ b/app/src/main/res/layout/united_states_cl3.xml
@@ -557,7 +557,7 @@
         app:layout_constraintStart_toStartOf="@+id/guidelineV1"
         app:layout_constraintTop_toTopOf="@+id/guidelineH7"
         android:contentDescription="@string/activeWordPicture"
-        app:srcCompat="@drawable/zz_alphatileslogo" />
+        app:srcCompat="@drawable/zz_sil" />
 
     <TextView
         android:id="@+id/activeWordTextView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,16 @@
     <string name="door021">Door 021</string>
     <string name="door022">Door 022</string>
     <string name="door023">Door 023</string>
+    <string name="door024">Door 024</string>
+    <string name="door025">Door 025</string>
+    <string name="door026">Door 026</string>
+    <string name="door027">Door 027</string>
+    <string name="door028">Door 028</string>
+    <string name="door029">Door 029</string>
+    <string name="door030">Door 030</string>
+    <string name="door031">Door 031</string>
+    <string name="door032">Door 032</string>
+    <string name="door033">Door 033</string>
     <string name="avatarIcon01">Player 01 Avatar Icon</string>
     <string name="avatarIcon02">Player 02 Avatar Icon</string>
     <string name="avatarIcon03">Player 03 Avatar Icon</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,12 +1,14 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Base.Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="fontFamily">@font/charissil</item>
         <item name="android:textStyle">normal</item>
+<!--        <item name="android:statusBarColor">@android:color/transparent</item>-->
+<!--        <item name="android:navigationBarColor">@android:color/transparent</item>-->
     </style>
     <style name="AppTheme.Launcher" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->


### PR DESCRIPTION
All layouts have been updated. The title bar has been removed and the upper and lower sections have been redesigned so that the upper section is informational only and the lower section has only click-able buttons. The challenge level is now displayed as part of the upper section's information. This update was triggered by behavior on some API35 devices (e.g. Pixel 7a but not Pixel 8) where the title bar floated above information in the layout. This relates to Android's push for edge-to-edge layout design.