### PR TITLE
Validator Updates 9 (seven changes)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 157
-        versionName "2.4.0"
+        versionCode 158
+        versionName "2.4.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -40,6 +40,11 @@ android {
     productFlavors {
         //Alpha Tiles internal team developers can find active product flavor definitions here:
         // https://docs.google.com/document/d/1a3satcmHFa5r6l7THrKLgxSWVCs-Mp2yOGyzk4oETsk/edit
+        gslGusiilaay {
+            dimension "language"
+            applicationIdSuffix ".blue.gslGusiilaay"
+            resValue "string", "app_name", 'fúraari nuliigen'
+        }
         tpxTeocuitlapa {
             dimension "language"
             applicationIdSuffix ".blue.tpxTeocuitlapa"

--- a/validator/src/main/java/org/alphatilesapps/validator/FilePresence.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/FilePresence.java
@@ -16,18 +16,18 @@ public class FilePresence {
     public ArrayList<Message> warnings = new ArrayList<>();
     public ArrayList<Message> recommendations = new ArrayList<>();
     /// Add a required file with subfolder and tag
-    public void add(String tag, String subfolder, String file, String mimeType, String reason, boolean optional) {
+    public void add(String tag, String subfolder, String file, String mimeType, String reason, boolean optional, long maxSize) {
         for(File other : files) {
             if(!file.isEmpty() && other.name.equals(file) && other.folderName.equals(subfolder))
                 return;
         }
         folders.add(subfolder);
-        files.add(new File(tag, subfolder, file, mimeType, reason, optional));
+        files.add(new File(tag, subfolder, file, mimeType, reason, optional, maxSize));
         tagData.putIfAbsent(tag, new TagData());
     }
-    public void addAll(String tag, String subfolder, ArrayList<String> files, String mimeType, String reason, boolean optional) {
+    public void addAll(String tag, String subfolder, ArrayList<String> files, String mimeType, String reason, boolean optional, long maxSize) {
         for(String file : files) {
-            add(tag, subfolder, file, mimeType, reason, optional);
+            add(tag, subfolder, file, mimeType, reason, optional, maxSize);
         }
     }
     /// Use the given Message.Tag for errors about the given file tag
@@ -42,6 +42,12 @@ public class FilePresence {
         for(String folderName : folders) {
             try {
                 Validator.GoogleDriveFolder folder = langPack.getFolderFromName(folderName);
+                HashMap<String, Integer> counts = new HashMap<>();
+                ArrayList<Validator.GoogleDriveItem> contents = folder.getFolderContents();
+                for(int i = 0; i < contents.size(); i++) {
+                    String key = contents.get(i).getName().split("\\.")[0];
+                    counts.merge(key, 1, Integer::sum);
+                }
                 for (int i = 0; i < folder.getFolderContents().size();) {
                     Validator.GoogleDriveItem item = folder.getFolderContents().get(i);
                     boolean excess = true;
@@ -59,13 +65,29 @@ public class FilePresence {
                         if (nameMatches && typeMatches) {
                             excess = false;
                             file.incorrect = false;
+                            if(item.getSize() > file.maxSize) {
+                                String human = file.maxSize + " B";
+                                if(file.maxSize > 1000_000) {
+                                    human = file.maxSize / 1000_000 + " MB";
+                                } else if(file.maxSize > 1000) {
+                                    human = file.maxSize / 1000 + " KB";
+                                }
+                                warnings.add(new Message(Message.Tag.Etc, "Item " + item.getName() + " in folder " + folderName + " is too large, should be smaller than " + human));
+                            } else if(item.getSize() == 0) {
+                                fatalErrors.add(new Message(Message.Tag.Etc, "Item " + item.getName() + " in folder " + folderName + " is zero sized"));
+                            }
                             break;
                         }
                     }
                     if (excess) {
                         Message.Tag tag = folderTags.getOrDefault(folderName, Message.Tag.FilePresence);
-                        if(showExcess)
-                            warnings.add(new Message(tag, "Item " + item.getName() + " in folder " + folderName + " is not used and will not be downloaded"));
+                        if(showExcess) {
+                            if(counts.get(stripped) <= 1) {
+                                warnings.add(new Message(tag, "Item " + item.getName() + " in folder " + folderName + " is not used and will not be downloaded"));
+                            } else {
+                                warnings.add(new Message(tag, "Item " + item.getName() + " in folder " + folderName + " is duplicated"));
+                            }
+                        }
                         excessFiles.add(new ExcessFile(folderName, stripped));
                         folder.getFolderContents().remove(i);
                     } else {
@@ -136,7 +158,8 @@ public class FilePresence {
         String folderName;
         String name;
         String reason;
-        File(String tag, String folderName, String name, String mimeTypes, String reason, boolean optional) {
+        long maxSize;
+        File(String tag, String folderName, String name, String mimeTypes, String reason, boolean optional, long maxSize) {
             this.tag = tag;
             this.name = name;
             if(name.isBlank()) {
@@ -150,6 +173,7 @@ public class FilePresence {
                 this.mimeTypes.add(type.strip());
             }
             this.reason = reason;
+            this.maxSize = maxSize;
         }
     }
     static class TagData {


### PR DESCRIPTION
# 1
Warn when audio and image file are too large. (Worked previously, then broke, now fixed.)

# 2
Warn when media file is of size 0 kb.

# 3
Fix typo ("tile" changed to "syllable"

# 4
Warn when duplicate files exist in Google Drive. (Google Drive allows cat.jpg and cat.jpg while Windows does not.)

# 5
Clarify wording in validator prompt to specify local Android Studio project path for Alpha Tiles.

# 6
Correctly downloads audio instruction files for non-game screens.

# 7
Now lists Unicode hex value along with decimal value.