### PR TITLE
Fix bug in Brazil (syllables, CL1) 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 161
-        versionName "2.4.4"
+        versionCode 162
+        versionName "2.4.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -374,6 +374,7 @@ public class Brazil extends GameActivity {
     }
 
     private void setUpSyllables() {
+        Collections.shuffle(SYLLABLES);
         boolean containsCorrectSyllable = false;
         Start.Syllable answer = syllableHashMap.find(correctSyllable.text); // Find corresponding syllable object for correct answer
 
@@ -394,7 +395,7 @@ public class Brazil extends GameActivity {
         for (int t = 0; t < visibleGameButtons; t++) {
             TextView gameTile = findViewById(GAME_BUTTONS[t]);
 
-            if (syllableList.get(t).text.equals(correctSyllable.text) && t < visibleGameButtons) {
+            if (SYLLABLES.get(t).equals(correctSyllable.text) && t < visibleGameButtons) {
                 containsCorrectSyllable = true;
             }
 
@@ -403,7 +404,7 @@ public class Brazil extends GameActivity {
 
             if (challengeLevel == 1) {
                 if (t < visibleGameButtons) {
-                    gameTile.setText(syllableList.get(t).text); // KP
+                    gameTile.setText(SYLLABLES.get(t));
                     gameTile.setBackgroundColor(tileColor);
                     gameTile.setTextColor(Color.parseColor("#FFFFFF")); // white
                     gameTile.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -209,7 +209,7 @@ public class Start extends AppCompatActivity {
         if (hasSyllableGames) {
             buildSyllableList();
             for (int d = 0; d < syllableList.size(); d++) {
-                SYLLABLES.add(syllableList.get(d).toString());
+                SYLLABLES.add(syllableList.get(d).text);
             }
             Collections.shuffle(SYLLABLES);
         }


### PR DESCRIPTION
Fix bug in Brazil (syllables, CL1) where distractors always came from first row of syllables table. Also sets up SYLLABLES in Start.java correctly, so that it can be used in Brazil.java along with all of the other arrays of C, V, CorV, Tone, AD and multitype.