### PR TITLE
Fix Malaysia audio instructions bug for RTL.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 162
-        versionName "2.4.5"
+        versionCode 163
+        versionName "2.4.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -503,7 +503,7 @@ public abstract class GameActivity extends AppCompatActivity {
                 wordImage = findViewById(getWordImages()[i]);
                 wordImage.setClickable(false);
             }
-        if (!gameList.get(gameNumber-1).country.equals("Romania")&&!gameList.get(gameNumber-1).country.equals("Sudan")) {
+        if (!gameList.get(gameNumber-1).country.equals("Romania")&&!gameList.get(gameNumber-1).country.equals("Sudan")&&!gameList.get(gameNumber-1).country.equals("Malaysia")) {
             ImageView repeatImage = findViewById(R.id.repeatImage);
             repeatImage.setClickable(false);
         }
@@ -520,7 +520,7 @@ public abstract class GameActivity extends AppCompatActivity {
                 wordImage = findViewById(getWordImages()[i]);
                 wordImage.setClickable(true);
             }
-        if (!gameList.get(gameNumber-1).country.equals("Romania")&&!gameList.get(gameNumber-1).country.equals("Sudan")) {
+        if (!gameList.get(gameNumber-1).country.equals("Romania")&&!gameList.get(gameNumber-1).country.equals("Sudan")&&!gameList.get(gameNumber-1).country.equals("Malaysia")) {
             ImageView repeatImage = findViewById(R.id.repeatImage);
             repeatImage.setClickable(true);
         }


### PR DESCRIPTION
Added the third passive game (Malaysia) to two missing locations in GameActivity. This was causing the instruction audio button to crash in RTL versions of Malaysia (Dictionary View game).

At some point, we need a better solution, i.e. an array of passive games defined in Start that then we can refer to as needed in GameActivity (bypassing options row clickable/unclickable) and in Earth (forcing an always-circle door).