### PR TITLE
Fix backspacing composite key texts in Colombia

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 173
-        versionName "2.5.6"
+        versionCode 175
+        versionName "2.5.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -452,17 +452,20 @@ public class Colombia extends GameActivity {
 
     public void deleteLastKeyed(View view) {
 
+        if (clickedKeys.isEmpty()) {
+            return;
+        }
+
         TextView wordToBuild = (TextView) findViewById(R.id.activeWordTextView);
 
         String typedLettersSoFar = wordToBuild.getText().toString();
         String nowWithOneLessWordPiece = "";
 
         if (typedLettersSoFar.length() > 0) {
-            if (syllableGame.equals("S")) {
+            if (syllableGame.equals("S")
+                    || (syllableGame.equals("T") && challengeLevel == 3)) { // Using keyboard keys, not tile texts
                 nowWithOneLessWordPiece = typedLettersSoFar.substring(0, typedLettersSoFar.length() - clickedKeys.get(clickedKeys.size()-1).text.length());
-            } else if (syllableGame.equals("T") && challengeLevel == 3) { // Using keyboard keys, not tiles
-                nowWithOneLessWordPiece = typedLettersSoFar.substring(0, typedLettersSoFar.length() - 1);
-            } else if (syllableGame.equals("T")) {
+            } else if (syllableGame.equals("T")) { // Using tile texts
                 tilesInBuiltWord.remove(tilesInBuiltWord.size() - 1);
                 nowWithOneLessWordPiece = combineTilesToMakeWord(tilesInBuiltWord, refWord, -1);
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -902,6 +902,10 @@ public abstract class GameActivity extends AppCompatActivity {
     wordInLOP: The target word string, in the language of play
      */
     public static String combineTilesToMakeWord(List<Start.Tile> tilesInThisWordOption, Start.Word wordListWord, int indexOfReplacedTile) {
+        if (tilesInThisWordOption.isEmpty()) {
+            return "";
+        }
+
         ArrayList<Start.Tile> tilesInWordListWord = tileList.parseWordIntoTiles(wordListWord.wordInLOP, wordListWord);
         StringBuilder builder = new StringBuilder();
         String previousConsonant = "";


### PR DESCRIPTION
This fixes the following bug in challenge level 3 of Colombia (Build Word From Keyboard):
When backspacing a composite character, the app was crashing. It was deleting just the very last character, rather than the whole key text.