### PR TITLE
Arrow colors, Colombia syllable layout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 165
-        versionName "2.4.8"
+        versionCode 166
+        versionName "2.4.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -533,6 +533,9 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     protected void setAdvanceArrowToGray() {
+        if(!Start.changeArrowColor) {
+            return;
+        }
         ImageView repeatImage = findViewById(R.id.repeatImage);
         repeatImage.setBackgroundResource(0);
         repeatImage.setImageResource(R.drawable.zz_forward_inactive);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -16,6 +16,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
@@ -204,6 +205,12 @@ public abstract class GameActivity extends AppCompatActivity {
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         // testParsingAndCombining(); // Helpful runtime check for complex tile parsing
         super.onCreate(state);
+
+    }
+
+    @Override
+    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
         if(!Start.changeArrowColor) {
             setAdvanceArrowToBlue();
         }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -201,10 +201,12 @@ public abstract class GameActivity extends AppCompatActivity {
         } else {
             forceLTRIfSupported();
         }
-
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         // testParsingAndCombining(); // Helpful runtime check for complex tile parsing
         super.onCreate(state);
+        if(!Start.changeArrowColor) {
+            setAdvanceArrowToBlue();
+        }
     }
 
     public void goBackToEarth(View view) {
@@ -528,6 +530,9 @@ public abstract class GameActivity extends AppCompatActivity {
 
     protected void setAdvanceArrowToBlue() {
         ImageView repeatImage = findViewById(R.id.repeatImage);
+        if(repeatImage == null) {
+            return;
+        }
         repeatImage.setBackgroundResource(0);
         repeatImage.setImageResource(R.drawable.zz_forward);
     }
@@ -537,6 +542,9 @@ public abstract class GameActivity extends AppCompatActivity {
             return;
         }
         ImageView repeatImage = findViewById(R.id.repeatImage);
+        if(repeatImage == null) {
+            return;
+        }
         repeatImage.setBackgroundResource(0);
         repeatImage.setImageResource(R.drawable.zz_forward_inactive);
     }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -79,11 +79,11 @@ public class Italy extends GameActivity {
 
         ActivityLayouts.applyEdgeToEdge(this, gameID);
         ActivityLayouts.setStatusAndNavColors(this);
+        ImageView playNextWordImage = (ImageView) findViewById(R.id.playNextWord);
 
         if (scriptDirection.equals("RTL")) {
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
             ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
-            ImageView playNextWordImage = (ImageView) findViewById(R.id.playNextWord);
             ImageView referenceItemImage = (ImageView) findViewById(R.id.referenceItem);
 
             instructionsImage.setRotationY(180);
@@ -105,7 +105,9 @@ public class Italy extends GameActivity {
         if (getAudioInstructionsResID() == 0) {
             hideInstructionAudioImage();
         }
-
+        if(!Start.changeArrowColor) {
+            playNextWordImage.setImageResource(R.drawable.zz_forward_green);
+        }
         updatePointsAndTrackers(0);
         playAgain();
     }
@@ -114,7 +116,9 @@ public class Italy extends GameActivity {
         super.setAllGameButtonsUnclickable();
 
         ImageView nextWordArrow = findViewById(R.id.playNextWord);
-        nextWordArrow.setImageResource(R.drawable.zz_forward_inactive);
+        if(Start.changeArrowColor) {
+            nextWordArrow.setImageResource(R.drawable.zz_forward_inactive);
+        }
         nextWordArrow.setClickable(false);
 
         ImageView referenceItem = findViewById(R.id.referenceItem);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -431,13 +431,14 @@ public class Romania extends GameActivity {
 
         ImageView forwardArrow = findViewById(R.id.forwardArrowImage);
         forwardArrow.setClickable(false);
-        forwardArrow.setBackgroundResource(0);
-        forwardArrow.setImageResource(R.drawable.zz_forward_inactive);
+        setAdvanceArrowToGray();
 
         ImageView backwardArrow = findViewById(R.id.backwardArrowImage);
         backwardArrow.setClickable(false);
+        if(!Start.changeArrowColor) {
+            backwardArrow.setImageResource(R.drawable.zz_backward_inactive);
+        }
         backwardArrow.setBackgroundResource(0);
-        backwardArrow.setImageResource(R.drawable.zz_backward_inactive);
 
         TextView numberOfTotal = findViewById(R.id.numberOfTotalText);
         numberOfTotal.setClickable(false);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -89,9 +89,9 @@ public class Romania extends GameActivity {
         boldInitialFocusTiles = prefs.getBoolean("boldInitialFocusTiles_player" + playerString, boldInitialFocusTiles);
 
         scriptDirection = Start.langInfoList.find("Script direction (LTR or RTL)");
+        ImageView backwardArrowImage = (ImageView) findViewById(R.id.backwardArrowImage);
+        ImageView forwardArrowImage = (ImageView) findViewById(R.id.forwardArrowImage);
         if (scriptDirection.equals("RTL")) {
-            ImageView backwardArrowImage = (ImageView) findViewById(R.id.backwardArrowImage);
-            ImageView forwardArrowImage = (ImageView) findViewById(R.id.forwardArrowImage);
             ImageView scrollForwardImage = (ImageView) findViewById(R.id.scrollForward);
             ImageView scrollBackImage = (ImageView) findViewById(R.id.scrollBack);
             ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
@@ -102,7 +102,10 @@ public class Romania extends GameActivity {
             scrollBackImage.setRotationY(180);
             instructionsImage.setRotationY(180);
         }
-
+        if(!Start.changeArrowColor) {
+            backwardArrowImage.setImageResource(R.drawable.zz_backward);
+            forwardArrowImage.setImageResource(R.drawable.zz_forward);
+        }
         if (getAudioInstructionsResID() == 0) {
             hideInstructionAudioImage();
         }
@@ -431,11 +434,11 @@ public class Romania extends GameActivity {
 
         ImageView forwardArrow = findViewById(R.id.forwardArrowImage);
         forwardArrow.setClickable(false);
-        setAdvanceArrowToGray();
 
         ImageView backwardArrow = findViewById(R.id.backwardArrowImage);
         backwardArrow.setClickable(false);
-        if(!Start.changeArrowColor) {
+        if(Start.changeArrowColor) {
+            forwardArrow.setImageResource(R.drawable.zz_forward_inactive);
             backwardArrow.setImageResource(R.drawable.zz_backward_inactive);
         }
         backwardArrow.setBackgroundResource(0);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -73,6 +73,7 @@ public class Start extends AppCompatActivity {
     public static int numberOfAvatars = 12;
     public static String scriptType; // LM Can be "Thai", "Lao", "Khmer", or "Arabic" for special tile parsing. If nothing specified, tile parsing defaults to unidirectional.
     public static Boolean sendAnalytics;
+    public static boolean changeArrowColor;
     public static String placeholderCharacter; // LM Takes the place of a consonant for combining characters in complex scripts
     public static TileList CONSONANTS = new TileList();
     public static TileList PLACEHOLDER_CONSONANTS = new TileList();
@@ -90,7 +91,6 @@ public class Start extends AppCompatActivity {
     public static List<String> SYLLABLES = new ArrayList<>();
     public static List<String> SAD_STRINGS = new ArrayList<>();
     public static ArrayList<String> MULTITYPE_TILES = new ArrayList<>();
-
 
     private static final Logger LOGGER = Logger.getLogger( Start.class.getName() );
 
@@ -117,6 +117,7 @@ public class Start extends AppCompatActivity {
         //to make syllable audio optional
         hasSyllableAudio = getBooleanFromSettings("Has syllable audio", false);
         sendAnalytics = getBooleanFromSettings("Send analytics", false);
+        changeArrowColor = getBooleanFromSettings("Change arrow colors", true);
 
         String after12checkedTrackersSetting = settingsList.find("After 12 checked trackers");
         if (!after12checkedTrackersSetting.equals("")) {

--- a/app/src/main/res/layout/colombia_syllables.xml
+++ b/app/src/main/res/layout/colombia_syllables.xml
@@ -776,70 +776,70 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.31" />
+        app:layout_constraintGuide_percent="0.30" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.33" />
+        app:layout_constraintGuide_percent="0.32" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.43" />
+        app:layout_constraintGuide_percent="0.42" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline3.5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.45"/>
+        app:layout_constraintGuide_percent="0.44"/>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.52" />
+        app:layout_constraintGuide_percent="0.51" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.53" />
+        app:layout_constraintGuide_percent="0.52" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH6"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.60" />
+        app:layout_constraintGuide_percent="0.59" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH7"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.61" />
+        app:layout_constraintGuide_percent="0.60" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH8"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.68" />
+        app:layout_constraintGuide_percent="0.67" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH9"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.69" />
+        app:layout_constraintGuide_percent="0.68" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guidelineH10"


### PR DESCRIPTION
# 1
Add a Boolean to aa_settings.txt for "Change arrow colors" (default is true). When set to false, advance arrows do not change to gray while audio plays, and advance arrows do not change to gray when a round is incomplete (locked). This applies to the general advance arrows (bottom right of each screen) as well as the two pairs of Romania (Learn the Tiles) arrows and the next-audio button in Italy (Loteria).

# 2
Fix a minor in the syllables layout for Colombia (Spell From Memory). One button row had a vertical height of 0.06 instead of 0.07 like the rest.