### PR TITLE
Report fatal error for listing '0' in MixedDefs info

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 169
-        versionName "2.5.2"
+        versionCode 173
+        versionName "2.5.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -2214,15 +2214,23 @@ public class Validator {
         while (specMatcher.find()) {
             typeSpecsList.add(specMatcher.group());
         }
+
+        ArrayList<String> wordAsSimpleTileStringList = new ArrayList<>();
+        for (Tile tile : wordAsSimpleTileList) {
+            wordAsSimpleTileStringList.add(tile.text);
+        }
+
+        for(String typeSpec : typeSpecsList) {
+            if(typeSpec.startsWith("0")) {
+                fatalError(Message.Tag.Etc, "In wordlist, for the word " + word.wordInLOP + ", tiles are " + wordAsSimpleTileStringList + ", but the mixed types info, " + typeSpecsList + ", contains specification \"0\". Please replace \"0\" with the correct index (\"10\" is permitted)");
+            }
+        }
+
         if (typeSpecsList.size() == 1 && !typeSpecifications.equals("-")) {
             return parseAbbreviatedTypeSpecification(word);
         } else if (typeSpecifications.equals("-")) {  // No multi types info included. Build the full type specification out of index numbers
             typeSpecsList.clear();
         } else if (typeSpecsList.size() != wordAsSimpleTileList.size()) {
-            ArrayList<String> wordAsSimpleTileStringList = new ArrayList<>();
-            for (Tile tile : wordAsSimpleTileList) {
-                wordAsSimpleTileStringList.add(tile.text);
-            }
             fatalError(Message.Tag.Etc, "In wordlist, the word " + word.wordInLOP + " has " + wordAsSimpleTileList.size() +
                     " tiles, but the mixed types cell has " + typeSpecsList.size() + " specifications (its tiles are " + wordAsSimpleTileStringList + ")");
             throw new ValidatorException("In wordlist, the word " + word.wordInLOP + " has " + wordAsSimpleTileList.size() +


### PR DESCRIPTION
This pull request updates the validator. The validator can now report a fatal error if wordlist's 'Mixed-TypeSymbolsInfo' column contains any '0' indexes. ('10' is permitted.)