### PR TITLE
Fixing bug where texts were contextualized in stored objects

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -347,25 +347,6 @@ public class Thailand extends GameActivity {
             // challengeLevelThai 1 = pull random tiles for wrong choices
             // challengeLevelThai 2 = pull distractor tiles for wrong choices
             fourTileChoices = tileListNoSAD.returnFourTileChoices(refTile, challengeLevelThai, refTileType);
-            if(choiceType.equals("CONTEXTUAL")) { // In some Arabic script apps
-                switch(contextualTilePosition) { // specified by the 4th character of the challengeLevel number
-                    case "INITIAL":
-                        for(Tile t : fourTileChoices) {
-                            t.text = contextualizedForm_Initial(t.text);
-                        }
-                        break;
-                    case "FINAL":
-                        for(Tile t : fourTileChoices) {
-                            t.text = contextualizedForm_Final(t.text);
-                        }
-                        break;
-                    default: // MEDIAL
-                        for (Tile t : fourTileChoices) {
-                            t.text = contextualizedForm_Medial(t.text);
-                        }
-                        break;
-                }
-            }
         } else if (choiceType.matches("(WORD_TEXT|WORD_IMAGE)") && (!refType.contains("SYLLABLE"))) {
             fourWordChoices = wordList.returnFourWords(refWord, refTile, challengeLevelThai, refType);
             // challengeLevelThai 1 = pull words that begin with random tiles (not distractor, not same) for wrong choices
@@ -379,14 +360,47 @@ public class Thailand extends GameActivity {
 
         switch (choiceType) {
             case "TILE_LOWER":
-            case "CONTEXTUAL":
                 for (int t = 0; t < GAME_BUTTONS.length; t++) {
                     TextView choiceButton = findViewById(GAME_BUTTONS[t]);
                     String choiceColorStr = "#A9A9A9"; // dark gray
                     int choiceColorNo = Color.parseColor(choiceColorStr);
                     choiceButton.setBackgroundColor(choiceColorNo);
                     choiceButton.setTextColor(Color.parseColor("#000000")); // black
-                    choiceButton.setText(fourTileChoices.get(t).text); // Added contextualizingCharacter in prior if block for CONTEXTUAL choices; normal for TILE_LOWER
+                    choiceButton.setText(fourTileChoices.get(t).text);
+                }
+                break;
+            case "CONTEXTUAL":
+                switch(contextualTilePosition) { // Arabic script challengeLevel option; position specified by the 4th character of the challengeLevel number
+                    case "INITIAL":
+                        for (int t = 0; t < GAME_BUTTONS.length; t++) {
+                            TextView choiceButton = findViewById(GAME_BUTTONS[t]);
+                            String choiceColorStr = "#A9A9A9"; // dark gray
+                            int choiceColorNo = Color.parseColor(choiceColorStr);
+                            choiceButton.setBackgroundColor(choiceColorNo);
+                            choiceButton.setTextColor(Color.parseColor("#000000")); // black
+                            choiceButton.setText(contextualizedForm_Initial(fourTileChoices.get(t).text));
+                        }
+                        break;
+                    case "FINAL":
+                        for (int t = 0; t < GAME_BUTTONS.length; t++) {
+                            TextView choiceButton = findViewById(GAME_BUTTONS[t]);
+                            String choiceColorStr = "#A9A9A9"; // dark gray
+                            int choiceColorNo = Color.parseColor(choiceColorStr);
+                            choiceButton.setBackgroundColor(choiceColorNo);
+                            choiceButton.setTextColor(Color.parseColor("#000000")); // black
+                            choiceButton.setText(contextualizedForm_Final(fourTileChoices.get(t).text));
+                        }
+                        break;
+                    default: // MEDIAL
+                        for (int t = 0; t < GAME_BUTTONS.length; t++) {
+                            TextView choiceButton = findViewById(GAME_BUTTONS[t]);
+                            String choiceColorStr = "#A9A9A9"; // dark gray
+                            int choiceColorNo = Color.parseColor(choiceColorStr);
+                            choiceButton.setBackgroundColor(choiceColorNo);
+                            choiceButton.setTextColor(Color.parseColor("#000000")); // black
+                            choiceButton.setText(contextualizedForm_Medial(fourTileChoices.get(t).text));
+                        }
+                        break;
                 }
                 break;
             case "TILE_UPPER":


### PR DESCRIPTION
This is a pull request to the **contextual-forms** branch.

My code in contextual-forms has had a bug. In Thailand.java, I accidentally contextualized Tile objects' text fields, rather than getting those texts separately before contextualizing them. Those same Tile objects showed up subsequently with contextual forms, when they should have had the main, isolate form. This PR fixes that.

I have tested some but would love a second tester before merging.

**Instructions for testing**

1. Play a challenge level with contextual answer choices of Basic Matching (Thailand). The answer choices should be in contextual form (initial, medial, or final as specified in the challenge level). 
2. Then go to Tap To Hear (Sudan). This is a good place to test, since you can see all the tiles at once. You should not see any tiles in the tile list for Tap To Hear appearing in contextual form. They should all be in isolate form: matching the first column of gametiles.
3. As you continue to play contextual choice Thailand games, you should also **not** see the connected part getting longer and longer (previously, stored forms were being contextualized over and over again). All answer choices should have the same length connecter (just whatever the contextualizing character is, added on one time).