### PR TITLE
Create contextual game modes and the contextualized word frame setting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.google.gms.google-services'
+// apply plugin: 'com.google.gms.google-services'
 
 android {
     compileSdk 36

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.application'
-// apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.gms.google-services'
 
 android {
     compileSdk 36

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -111,7 +111,7 @@ public class Brazil extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
-        if (challengeLevel < 4 && !syllableGame.equals("S")) {
+        if (challengeLevel < 4 && !gameMode.contains("S")) {
 
             if (VOWELS.isEmpty()) {  // Makes sure VOWELS is populated only once when the app is running
                 for (int d = 0; d < tileList.size(); d++) {
@@ -122,7 +122,7 @@ public class Brazil extends GameActivity {
             }
             Collections.shuffle(VOWELS); // AH
 
-        } else if (syllableGame.equals("S")) {
+        } else if (gameMode.contains("S")) {
             if (SYLLABLES.isEmpty()) {
                 for (int d = 0; d < syllableList.size(); d++) {
                     SYLLABLES.add(syllableList.get(d).toString());
@@ -153,7 +153,7 @@ public class Brazil extends GameActivity {
 
         Collections.shuffle(MULTITYPE_TILES);
 
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             visibleGameButtons = 4;
         } else {
             switch (challengeLevel) {
@@ -211,7 +211,7 @@ public class Brazil extends GameActivity {
         removeTile();
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             setUpSyllables();
         } else {
             setUpTiles();
@@ -238,7 +238,7 @@ public class Brazil extends GameActivity {
         int resID = getResources().getIdentifier(refWord.wordInLWC, "drawable", getPackageName());
         image.setImageResource(resID);
 
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             parsedRefWordSyllableArray = syllableList.parseWordIntoSyllables(refWord);
             parsedRefWordSyllableArrayStrings = new ArrayList<String>();
             for(Syllable s: parsedRefWordSyllableArray) {
@@ -256,7 +256,7 @@ public class Brazil extends GameActivity {
         Tile nextTile;
 
         // JP: this section is not relevant to syllable games, right?
-        if (!syllableGame.equals("S")) {
+        if (!gameMode.contains("S")) {
             switch (challengeLevel) {
                 case 4:
                 case 5:
@@ -305,7 +305,7 @@ public class Brazil extends GameActivity {
 
         boolean repeat = true;
 
-        if (!syllableGame.equals("S")) {
+        if (!gameMode.contains("S")) {
             ArrayList<Integer> possibleIndices = new ArrayList<>();
             for (int i = 0; i < parsedRefWordTileArray.size(); i++) {
                 possibleIndices.add(i);
@@ -356,7 +356,7 @@ public class Brazil extends GameActivity {
         TextView constructedWord = findViewById(R.id.activeWordTextView);
         StringBuilder wordBuilder = new StringBuilder();
         String word;
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             Start.Syllable blankSyllable = new Start.Syllable("__", new ArrayList<>(),"X", 0, correctSyllable.color);
             parsedRefWordSyllableArray.set(index_to_remove, blankSyllable);
             for (Syllable s : parsedRefWordSyllableArray) {
@@ -381,7 +381,7 @@ public class Brazil extends GameActivity {
                 blankTile.text = placeholderCharacter;
                 parsedRefWordTileArray.set(index_to_remove, blankTile);
             }
-            if (useContextualFormsFITB) { // Setting used by some Arabic script apps to make tiles appear in contextual forms in answer choices and around blanks
+            if (contextualizeWordFramesInFITB) { // Game mode included in some Arabic script apps to make tiles appear in contextual forms in answer choices
                 blankTile.text = contextualizedWordPieceString(blankTile.text, index_to_remove, parsedRefWordTileArrayStrings);
             }
 
@@ -467,7 +467,7 @@ public class Brazil extends GameActivity {
             gameTile.setText(correctSyllable.text);
         }
 
-        if (useContextualFormsFITB) { // Setting used by some Arabic script apps
+        if (gameMode.equals("CS")) { // Game mode included in some Arabic-based-script apps to make syllable answer choices appear in contextual form
             produceContextualSyllableAnswerChoices();
         }
 
@@ -617,7 +617,7 @@ public class Brazil extends GameActivity {
 
         }
 
-        if (useContextualFormsFITB) { // Setting used by some Arabic script apps
+        if (gameMode.equals("CT")) { // Game mode included in some Arabic-based-script games to make tile answer choices appear in contextual form
             produceContextualTileAnswerChoices();
         }
     }
@@ -668,7 +668,7 @@ public class Brazil extends GameActivity {
 
             // report time and number of incorrect guesses
             if (sendAnalytics) {
-                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
+                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + gameMode;
                 Properties info = new Properties().putValue("Time Taken", System.currentTimeMillis() - levelBegunTime)
                         .putValue("Number Incorrect", incorrectOnLevel)
                         .putValue("Correct Answer", correctString)

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -357,7 +357,7 @@ public class Brazil extends GameActivity {
         StringBuilder wordBuilder = new StringBuilder();
         String word;
         if (gameMode.contains("S")) {
-            Start.Syllable blankSyllable = new Start.Syllable("__", new ArrayList<>(),"X", 0, correctSyllable.color);
+            Start.Syllable blankSyllable = new Start.Syllable(blankForMissingWordPiece, new ArrayList<>(),"X", 0, correctSyllable.color);
             parsedRefWordSyllableArray.set(index_to_remove, blankSyllable);
             for (Syllable s : parsedRefWordSyllableArray) {
                 if (s != null) {
@@ -366,7 +366,7 @@ public class Brazil extends GameActivity {
             }
             word = wordBuilder.toString();
         } else { // Tile game
-            Start.Tile blankTile = new Start.Tile("__", new ArrayList<>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, correctTile.typeOfThisTileInstance, 1, "");
+            Start.Tile blankTile = new Start.Tile(blankForMissingWordPiece, new ArrayList<>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, correctTile.typeOfThisTileInstance, 1, "");
             parsedRefWordTileArray.set(index_to_remove, blankTile);
             if (scriptType.equals("Khmer") && correctTile.typeOfThisTileInstance.equals("C")){
                 if(index_to_remove < parsedRefWordTileArray.size()-1 && parsedRefWordTileArray.get(index_to_remove + 1).typeOfThisTileInstance.matches("(V|AV|BV|D)")) {
@@ -381,7 +381,7 @@ public class Brazil extends GameActivity {
                 blankTile.text = placeholderCharacter;
                 parsedRefWordTileArray.set(index_to_remove, blankTile);
             }
-            if (contextualizeWordFramesInFITB) { // Game mode included in some Arabic script apps to make tiles appear in contextual forms in answer choices
+            if (contextualizeWordFrames) { // Setting for some Arabic script apps, to produce contextual forms around blanks
                 blankTile.text = contextualizedWordPieceString(blankTile.text, index_to_remove, parsedRefWordTileArrayStrings);
             }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -72,7 +72,7 @@ public class Colombia extends GameActivity {
         super.onCreate(savedInstanceState);
         context = this;
         int gameID = 0;
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             setContentView(R.layout.colombia_syllables);
             gameID = R.id.colombiaCL_syll;
         } else {
@@ -140,7 +140,7 @@ public class Colombia extends GameActivity {
         int resID = getResources().getIdentifier(refWord.wordInLWC, "drawable", getPackageName());
         image.setImageResource(resID);
 
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             parsedRefWordSyllableArray = Start.syllableList.parseWordIntoSyllables(refWord); // KP
         } else {
             parsedRefWordTileArray = Start.tileList.parseWordIntoTiles(refWord.wordInLOP, refWord); // KP
@@ -160,7 +160,7 @@ public class Colombia extends GameActivity {
                 // Will list <a> twice if <a> is needed twice
                 // The limited set keyboard is built with GAME TILES not with KEYS
 
-                if (syllableGame.equals("S")) {
+                if (gameMode.contains("S")) {
                     syllableKeysList = new ArrayList<>(parsedRefWordSyllableArray);
                     Collections.shuffle(syllableKeysList);
                     visibleGameButtons = syllableKeysList.size();
@@ -195,7 +195,7 @@ public class Colombia extends GameActivity {
                 // Build an array of the required tiles plus a corresponding tile from the distractor trio for each tile
                 // So, for a five tile word, there will be 10 tiles
                 // The limited-set keyboard is built with GAME TILES not with KEYS
-                if (syllableGame.equals("S")) {
+                if (gameMode.contains("S")) {
                     syllableKeysList = new ArrayList<>(parsedRefWordSyllableArray);
                     int numberOfCorrectKeys = parsedRefWordSyllableArray.size();
                     for (int n=0; n<numberOfCorrectKeys; n++) {
@@ -246,7 +246,7 @@ public class Colombia extends GameActivity {
                 }
                 break;
             case 3:
-                if (syllableGame.equals("S")) { // 18 tiles; distractors for the wrong answers
+                if (gameMode.contains("S")) { // 18 tiles; distractors for the wrong answers
                     syllableKeysList = new ArrayList<>(parsedRefWordSyllableArray);
                     for (int n=0; n<(18-parsedRefWordSyllableArray.size()); n++) {
                         Start.Syllable syllableInTheList = syllableKeysList.get(n);
@@ -317,7 +317,7 @@ public class Colombia extends GameActivity {
             default:
         }
 
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             for (int k = 0; k < syllablesPerPage; k++) {
                 TextView key = findViewById(GAME_BUTTONS[k]);
                 if (k < visibleGameButtons) {
@@ -348,7 +348,7 @@ public class Colombia extends GameActivity {
         Tile typedTile;
         String currentWord = "";
         TextView wordToBuild = (TextView) findViewById(R.id.activeWordTextView);
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             clickedKey = syllableKeysList.get(justClickedIndex);
             clickedKeys.add(clickedKey);
             for(WordPiece key : clickedKeys) {
@@ -379,7 +379,7 @@ public class Colombia extends GameActivity {
 
         String correctString = wordInLOPWithStandardizedSequenceOfCharacters(refWord);
         String currentAttempt;
-        if (syllableGame.equals("S") || (syllableGame.equals("T") && challengeLevel == 3)) {
+        if (gameMode.contains("S") || (gameMode.contains("T") && challengeLevel == 3)) {
             currentAttempt = wordToBuild.getText().toString();
         } else {
             currentAttempt = combineTilesToMakeWord(tilesInBuiltWord, refWord, -1);
@@ -406,7 +406,7 @@ public class Colombia extends GameActivity {
             if (correctString.length() > currentAttempt.length()) {
                 ArrayList<WordPiece> firstNCorrectTiles = new ArrayList<>();
                 for (int t=0; t<clickedKeys.size(); t++) {
-                    if (syllableGame.equals("S")) {
+                    if (gameMode.contains("S")) {
                         if (t<parsedRefWordSyllableArray.size()){
                             firstNCorrectTiles.add(parsedRefWordSyllableArray.get(t));
                         }
@@ -419,10 +419,10 @@ public class Colombia extends GameActivity {
                 if (currentAttempt.equals(correctString.substring(0, currentAttempt.length()))
                 || clickedKeys.equals(firstNCorrectTiles)) { // Word is incomplete but spelled correctly so far
                     // orange=true if there is no key option that would allow the player to continue correctly
-                    if (challengeLevel == 1 || challengeLevel == 2 || syllableGame.equals("S")) {
+                    if (challengeLevel == 1 || challengeLevel == 2 || gameMode.contains("S")) {
                         boolean orange = false;
                         for (int i = 0; i < clickedKeys.size(); i++) {
-                            if (syllableGame.equals("S")) {
+                            if (gameMode.contains("S")) {
                                 if (!clickedKeys.get(i).text.equals(parsedRefWordSyllableArray.get(i).text)) {
                                     orange = true;
                                     break;
@@ -462,10 +462,10 @@ public class Colombia extends GameActivity {
         String nowWithOneLessWordPiece = "";
 
         if (typedLettersSoFar.length() > 0) {
-            if (syllableGame.equals("S")
-            || (syllableGame.equals("T") && challengeLevel == 3)) { // Using keyboard keys, not tile texts
+            if (gameMode.contains("S")
+            || (gameMode.contains("T") && challengeLevel == 3)) { // Using keyboard keys, not tile texts
                 nowWithOneLessWordPiece = typedLettersSoFar.substring(0, typedLettersSoFar.length() - clickedKeys.get(clickedKeys.size()-1).text.length());
-            } else if (syllableGame.equals("T")) { // Using tile texts
+            } else if (gameMode.contains("T")) { // Using tile texts
                 tilesInBuiltWord.remove(tilesInBuiltWord.size() - 1);
                 nowWithOneLessWordPiece = combineTilesToMakeWord(tilesInBuiltWord, refWord, -1);
             }
@@ -481,7 +481,7 @@ public class Colombia extends GameActivity {
 
         int justClickedKey = Integer.parseInt((String) view.getTag());
         // Next line says ... if a basic keyboard (which all fits on one screen) or (even when on a complex keyboard) if something other than the last two buttons (the two arrows) are tapped...
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             if (keysInUse <= syllablesPerPage || justClickedKey <= (syllablesPerPage - 2)) {
                 int keyIndex = (33 * (keyboardScreenNo - 1)) + justClickedKey - 1;
                 respondToKeySelection(keyIndex);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
@@ -156,14 +156,14 @@ public class Earth extends AppCompatActivity {
                         String project = "org.alphatilesapps.alphatiles.";
                         String country = Start.gameList.get((pageNumber * doorsPerPage) + doorIndex).country;
                         String challengeLevel = Start.gameList.get((pageNumber * doorsPerPage) + doorIndex).level;
-                        String syllableGame = gameList.get((pageNumber * doorsPerPage) + doorIndex).mode;
+                        String gameMode = gameList.get((pageNumber * doorsPerPage) + doorIndex).mode;
                         String stage;
                         if (gameList.get((pageNumber * doorsPerPage) + doorIndex).stage.equals("-")) {
                             stage = "1";
                         } else {
                             stage = gameList.get((pageNumber * doorsPerPage) + doorIndex).stage;
                         }
-                        String uniqueGameLevelPlayerModeStageID = project + country + challengeLevel + playerString + syllableGame + stage;
+                        String uniqueGameLevelPlayerModeStageID = project + country + challengeLevel + playerString + gameMode + stage;
 
                         trackerCount = prefs.getInt(uniqueGameLevelPlayerModeStageID + "_trackerCount", 0);
 
@@ -272,7 +272,7 @@ public class Earth extends AppCompatActivity {
 
         int challengeLevel = Integer.parseInt(Start.gameList.get((pageNumber * doorsPerPage) + doorIndex).level);
         int gameNumber = (pageNumber * doorsPerPage) + doorIndex + 1;
-        String syllableGame = gameList.get((pageNumber * doorsPerPage) + doorIndex).mode;
+        String gameMode = gameList.get((pageNumber * doorsPerPage) + doorIndex).mode;
         int stage;
         if (gameList.get((pageNumber * doorsPerPage) + doorIndex).stage.equals("-")) {
             stage = 1;
@@ -291,7 +291,7 @@ public class Earth extends AppCompatActivity {
         intent.putExtra("gameNumber", gameNumber);
         intent.putExtra("pageNumber", pageNumber);
         intent.putExtra("country", country);
-        intent.putExtra("syllableGame", syllableGame);
+        intent.putExtra("gameMode", gameMode);
         intent.putExtra("stage", stage);
         intent.putExtra("studentGrade", grade);
         startActivity(intent);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
@@ -446,7 +446,7 @@ public class Ecuador extends GameActivity {
 
             if (sendAnalytics) {
                 // report time and number of incorrect guesses
-                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
+                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + gameMode;
                 Properties info = new Properties().putValue("Time Taken", System.currentTimeMillis() - levelBegunTime)
                         .putValue("Number Incorrect", incorrectOnLevel)
                         .putValue("Correct Answer", chosenWordText)

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -33,7 +33,6 @@ import java.util.TimerTask;
 import java.util.logging.Logger;
 
 import static org.alphatilesapps.alphatiles.Start.MULTITYPE_TILES;
-import static org.alphatilesapps.alphatiles.Start.NON_SPACERS_ARABIC;
 import static org.alphatilesapps.alphatiles.Start.SILENT_PRELIMINARY_TILES;
 import static org.alphatilesapps.alphatiles.Start.colorList;
 import static org.alphatilesapps.alphatiles.Start.differentiatesTileTypes;
@@ -74,7 +73,7 @@ public abstract class GameActivity extends AppCompatActivity {
     String playerString;
     int challengeLevel = -1;
     int stage = 7;
-    String syllableGame;
+    String gameMode;
 
     SharedPreferences prefs;
     String uniqueGameLevelPlayerModeStageID;
@@ -168,7 +167,7 @@ public abstract class GameActivity extends AppCompatActivity {
         playerNumber = getIntent().getIntExtra("playerNumber", -1);
         challengeLevel = getIntent().getIntExtra("challengeLevel", -1);
         stage = getIntent().getIntExtra("stage", 7);
-        syllableGame = getIntent().getStringExtra("syllableGame");
+        gameMode = getIntent().getStringExtra("gameMode");
         gameNumber = getIntent().getIntExtra("gameNumber", 0);
         country = getIntent().getStringExtra("country");
         playerString = Util.returnPlayerStringToAppend(playerNumber);
@@ -177,7 +176,7 @@ public abstract class GameActivity extends AppCompatActivity {
 
         prefs = getSharedPreferences(ChoosePlayer.SHARED_PREFS, MODE_PRIVATE);
         className = getClass().getName();
-        uniqueGameLevelPlayerModeStageID = className + challengeLevel + playerString + syllableGame + stage;
+        uniqueGameLevelPlayerModeStageID = className + challengeLevel + playerString + gameMode + stage;
         trackerCount = prefs.getInt(uniqueGameLevelPlayerModeStageID + "_trackerCount", 0);
         hasChecked12Trackers = prefs.getBoolean(uniqueGameLevelPlayerModeStageID + "_hasChecked12Trackers", false);
         points = prefs.getInt(uniqueGameLevelPlayerModeStageID + "_points", 0);
@@ -368,7 +367,7 @@ public abstract class GameActivity extends AppCompatActivity {
                                 } else {
                                     stage = Integer.parseInt(gameList.get(gameNumber - 1).stage);
                                 }
-                                syllableGame = gameList.get(gameNumber - 1).mode;
+                                gameMode = gameList.get(gameNumber - 1).mode;
                                 country = gameList.get(gameNumber - 1).country;
                             } else {
                                 gameNumber = 1;
@@ -378,7 +377,7 @@ public abstract class GameActivity extends AppCompatActivity {
                                 } else {
                                     stage = Integer.parseInt(gameList.get(0).stage);
                                 }
-                                syllableGame = gameList.get(0).mode;
+                                gameMode = gameList.get(0).mode;
                                 country = gameList.get(0).country;
                             }
                             String activityClass = project + country;
@@ -388,14 +387,14 @@ public abstract class GameActivity extends AppCompatActivity {
                             } catch (ClassNotFoundException e) {
                                 e.printStackTrace();
                             }
-                            String nextUniqueGameLevelPlayerModeStageID = activityClass + challengeLevel + playerString + syllableGame + stage;
+                            String nextUniqueGameLevelPlayerModeStageID = activityClass + challengeLevel + playerString + gameMode + stage;
                             hasChecked12Trackers = prefs.getBoolean(nextUniqueGameLevelPlayerModeStageID + "_hasChecked12Trackers", false);
 
                             if (!hasChecked12Trackers) {
                                 foundNextUncompletedGame = true;
                                 intent.putExtra("challengeLevel", challengeLevel);
                                 intent.putExtra("stage", stage);
-                                intent.putExtra("syllableGame", syllableGame);
+                                intent.putExtra("gameMode", gameMode);
                                 intent.putExtra("globalPoints", globalPoints);
                                 intent.putExtra("gameNumber", gameNumber);
                                 intent.putExtra("country", country);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -18,7 +18,6 @@ import static org.alphatilesapps.alphatiles.Start.contextualizingCharacter;
 import static org.alphatilesapps.alphatiles.Start.sendAnalytics;
 import static org.alphatilesapps.alphatiles.Start.colorList;
 import static org.alphatilesapps.alphatiles.Start.CorV;
-import static org.alphatilesapps.alphatiles.Start.useContextualFormsITI;
 
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;
@@ -94,7 +93,7 @@ public class Georgia extends GameActivity {
         super.onCreate(savedInstanceState);
         context = this;
         int gameID = 0;
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             setContentView(R.layout.georgia_syll);
             gameID = R.id.georgiaCL_syll;
         } else {
@@ -132,7 +131,7 @@ public class Georgia extends GameActivity {
                 visibleGameButtons = 6;
         }
 
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             syllableListCopy = (Start.SyllableList) Start.syllableList.clone();
         }
 
@@ -164,14 +163,14 @@ public class Georgia extends GameActivity {
 
         repeatLocked = true;
         setAdvanceArrowToGray();
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             Collections.shuffle(syllableListCopy); //JP
         }
 
         setWord();
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             setUpSyllables();
         } else {
             setUpTiles();
@@ -194,7 +193,7 @@ public class Georgia extends GameActivity {
 
     private void setWord() {
         chooseWord();
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             parsedRefWordSyllableArray = Start.syllableList.parseWordIntoSyllables(refWord); // JP
             initialSyllable = parsedRefWordSyllableArray.get(0);
         } else {
@@ -276,7 +275,7 @@ public class Georgia extends GameActivity {
 
         // Make the gameButtons contain contextual forms for some Arabic script apps
         Set<String> contextualizedChallengingChoices = new HashSet<String>();
-        if(useContextualFormsITI){
+        if(gameMode.equals("CS")){
             for (String answerChoiceString : challengingAnswerChoices) {
                 contextualizedChallengingChoices.add(contextualizedForm_Initial(answerChoiceString));
             }
@@ -303,7 +302,7 @@ public class Georgia extends GameActivity {
                         randomNum = rand.nextInt(syllableListCopy.size());
                         syllableOptionText = syllableListCopy.get(randomNum).text;
                     }
-                    if (useContextualFormsITI) { // For some Arabic script apps
+                    if (gameMode.equals("CS")) { // Contextualized syllable texts, for some Arabic script apps
                         gameTile.setText(contextualizedForm_Initial(syllableOptionText));
                     } else {
                         gameTile.setText(syllableOptionText);
@@ -473,7 +472,7 @@ public class Georgia extends GameActivity {
             rand = new Random();
             randomNum = rand.nextInt(visibleGameButtons - 1);
             TextView gameTile = findViewById(GAME_BUTTONS[randomNum]);
-            if(useContextualFormsITI) {
+            if(gameMode.equals("CT")) { // Contextualized tile string options. Included in some Arabic-based-script apps.
                 gameTile.setText(contextualizedForm_Initial(initialTile.text));
             } else {
                 gameTile.setText(initialTile.text);
@@ -492,7 +491,7 @@ public class Georgia extends GameActivity {
         setOptionsRowUnclickable();
 
         String correctString = "";
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             correctString = initialSyllable.text;
         } else {
             correctString = initialTile.text;
@@ -509,7 +508,7 @@ public class Georgia extends GameActivity {
 
             if (sendAnalytics) {
                 // report time and number of incorrect guesses
-                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
+                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + gameMode;
                 Properties info = new Properties().putValue("Time Taken", System.currentTimeMillis() - levelBegunTime)
                         .putValue("Number Incorrect", incorrectOnLevel)
                         .putValue("Correct Answer", correctString)

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import static org.alphatilesapps.alphatiles.Start.contextualizingCharacter;
 import static org.alphatilesapps.alphatiles.Start.sendAnalytics;
 import static org.alphatilesapps.alphatiles.Start.colorList;
 import static org.alphatilesapps.alphatiles.Start.CorV;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -400,7 +400,7 @@ public class Georgia extends GameActivity {
 
         // Make the gameButtons contain contextual forms for some Arabic script apps
         Set<String> contextualizedChallengingChoices = new HashSet<String>();
-        if(useContextualFormsITI) { // For some Arabic script apps
+        if(gameMode.contains("C")) { // For some Arabic script apps; answer choices in contextual form
             for (String answerChoiceString : challengingAnswerChoices) {
                 contextualizedChallengingChoices.add(contextualizedForm_Initial(answerChoiceString));
             }
@@ -430,7 +430,7 @@ public class Georgia extends GameActivity {
                         randomNum = rand.nextInt(CorV.size());
                         tileOptionText = CorV.get(randomNum).text;
                     }
-                    if (useContextualFormsITI) { // For some Arabic script apps
+                    if (gameMode.contains("C")) { // For some Arabic script apps; answer choices in contextual form
                         gameTile.setText(contextualizedForm_Initial(tileOptionText));
                     } else {
                         gameTile.setText(tileOptionText);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import static org.alphatilesapps.alphatiles.Start.contextualizingCharacter;
 import static org.alphatilesapps.alphatiles.Start.sendAnalytics;
 import static org.alphatilesapps.alphatiles.Start.colorList;
 import static org.alphatilesapps.alphatiles.Start.CorV;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -100,7 +100,7 @@ public class Italy extends GameActivity {
             fixConstraintsRTL(gameID);
         }
 
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             sortableSyllArray = (Start.SyllableList) syllableList.clone();
             Collections.shuffle(sortableSyllArray);
         } else {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
@@ -258,7 +258,7 @@ public class Peru extends GameActivity {
 
             if (sendAnalytics) {
                 // report time and number of incorrect guesses
-                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
+                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + gameMode;
                 Properties info = new Properties().putValue("Time Taken", System.currentTimeMillis() - levelBegunTime)
                         .putValue("Number Incorrect", incorrectOnLevel)
                         .putValue("Correct Answer", chosenWordText)

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -80,9 +80,10 @@ public class Start extends AppCompatActivity {
     public static String scriptType; // LM Can be "Thai", "Lao", "Khmer", or "Arabic" for special tile parsing. If nothing specified, tile parsing defaults to unidirectional.
     public static Boolean sendAnalytics;
     public static boolean changeArrowColor;
+    public static String blankForMissingWordPiece = "__"; // LM for FITB and BWFP
     public static String placeholderCharacter; // LM Takes the place of a consonant for combining characters in complex scripts
-    public static String contextualizingCharacter; // LM for displaying various contextual forms of Arabic characters
-    public static Boolean contextualizeWordFramesInFITB; // LM Make Arabic letters contextual around blanks in FITB
+    public static String contextualizer; // LM for displaying various contextual forms of Arabic characters
+    public static Boolean contextualizeWordFrames; // LM Make Arabic letters contextual around blanks in FITB and BWFP
     public static TileList CONSONANTS = new TileList();
     public static TileList PLACEHOLDER_CONSONANTS = new TileList();
     public static TileList SILENT_PRELIMINARY_TILES = new TileList();
@@ -141,7 +142,7 @@ public class Start extends AppCompatActivity {
 
         differentiatesTileTypes = getBooleanFromSettings("Differentiates types of multitype symbols", false);
 
-        contextualizeWordFramesInFITB = getBooleanFromSettings("Contextualize word frames in Fill In The Blank", false);
+        contextualizeWordFrames = getBooleanFromSettings("Contextualize word frames", false);
 
         sendAnalytics = getBooleanFromSettings("Send analytics", false);
         changeArrowColor = getBooleanFromSettings("Change arrow colors", true);
@@ -785,9 +786,9 @@ public class Start extends AppCompatActivity {
         if (placeholderCharacter.isEmpty()) {
             placeholderCharacter = "XYZXYZ"; // No placeholders in tiles; this variable shouldn't be matched to anything in words
         }
-        contextualizingCharacter = settingsList.find("Contextualizing character");
-        if (contextualizingCharacter.isEmpty()) {
-            contextualizingCharacter = "XYZXYZ"; // No contextualizing characters in tiles; this variable shouldn't be matched to anything in words
+        contextualizer = settingsList.find("Contextualizing character");
+        if (contextualizer.isEmpty()) {
+            contextualizer = "XYZXYZ"; // No contextualizing characters in tiles; this variable shouldn't be matched to anything in words
         }
 
     }
@@ -860,7 +861,7 @@ public class Start extends AppCompatActivity {
         tileHashMapWithoutPlaceHoldersOrContextualizers = new TileHashMap();
         tileHashMapNoSADWithoutPlaceholdersOrContextualizers = new TileHashMap();
         for (int i = 0; i < tileList.size(); i++) {
-            String strippedTileText = tileList.get(i).text.replace(placeholderCharacter, "").replace(contextualizingCharacter, "");
+            String strippedTileText = tileList.get(i).text.replace(placeholderCharacter, "").replace(contextualizer, "");
             tileHashMapWithoutPlaceHoldersOrContextualizers.put(strippedTileText, tileList.get(i));
             if (!tileList.get(i).tileType.equals("SAD")) {
                 tileHashMapNoSADWithoutPlaceholdersOrContextualizers.put(strippedTileText, tileList.get(i));

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -82,10 +82,7 @@ public class Start extends AppCompatActivity {
     public static boolean changeArrowColor;
     public static String placeholderCharacter; // LM Takes the place of a consonant for combining characters in complex scripts
     public static String contextualizingCharacter; // LM for displaying various contextual forms of Arabic characters
-    public static Boolean useContextualFormsFITB;
-    public static Boolean useContextualFormsBWFP;
-    public static Boolean useContextualFormsITI;
-
+    public static Boolean contextualizeWordFramesInFITB; // LM Make Arabic letters contextual around blanks in FITB
     public static TileList CONSONANTS = new TileList();
     public static TileList PLACEHOLDER_CONSONANTS = new TileList();
     public static TileList SILENT_PRELIMINARY_TILES = new TileList();
@@ -144,9 +141,7 @@ public class Start extends AppCompatActivity {
 
         differentiatesTileTypes = getBooleanFromSettings("Differentiates types of multitype symbols", false);
 
-        useContextualFormsFITB = getBooleanFromSettings("Use contextual forms for Fill In The Blank", false);
-        useContextualFormsBWFP = getBooleanFromSettings("Use contextual forms for Build Word From Pairs", false);
-        useContextualFormsITI = getBooleanFromSettings("Use contextual forms for Identify The Initial", false);
+        contextualizeWordFramesInFITB = getBooleanFromSettings("Contextualize word frames in Fill In The Blank", false);
 
         sendAnalytics = getBooleanFromSettings("Send analytics", false);
         changeArrowColor = getBooleanFromSettings("Change arrow colors", true);
@@ -760,7 +755,7 @@ public class Start extends AppCompatActivity {
                 if (!game.hasNull()) {
                     gameList.add(game);
                 }
-                if (thisLineArray[6].equals("S")) { //JP
+                if (thisLineArray[6].contains("S")) { //JP
                     hasSyllableGames = true;
                 }
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Sudan.java
@@ -75,7 +75,7 @@ public class Sudan extends GameActivity {
         int gameID = 0;
         determineNumPages(); // JP
 
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             setContentView(R.layout.sudan_syll);
             gameID = R.id.sudansyllCL;
             splitSyllablesListAcrossPages();
@@ -126,7 +126,7 @@ public class Sudan extends GameActivity {
 
         tilePagesLists.add(tilePage);
         syllablePagesLists.add(syllablePage);
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             int total = syllableList.size() - syllablesPerPage; // 1 page is accounted for in numPages init
             while (total >= 0) {
                 numPages++;
@@ -261,7 +261,7 @@ public class Sudan extends GameActivity {
     public void nextPageArrow(View view) {
         if (currentPageNumber < numPages) {
             currentPageNumber++;
-            if (syllableGame.equals("S")) {
+            if (gameMode.contains("S")) {
                 showCorrectNumSyllables(currentPageNumber);
             } else {
                 showCorrectNumTiles(currentPageNumber);
@@ -273,7 +273,7 @@ public class Sudan extends GameActivity {
     public void prevPageArrow(View view) {
         if (currentPageNumber > 0) {
             currentPageNumber--;
-            if (syllableGame.equals("S")) {
+            if (gameMode.contains("S")) {
                 showCorrectNumSyllables(currentPageNumber);
             } else {
                 showCorrectNumTiles(currentPageNumber);
@@ -303,7 +303,7 @@ public class Sudan extends GameActivity {
 
         int audioId;
         int duration;
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             Start.Syllable thisSyllable = syllablePagesLists.get(currentPageNumber).get(Integer.parseInt((String) view.getTag())-1);
             audioId = syllableAudioIDs.get(thisSyllable.audioName);
             duration = thisSyllable.duration;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -617,7 +617,7 @@ public class Thailand extends GameActivity {
 
             if (sendAnalytics) {
                 // report time and number of incorrect guesses
-                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + syllableGame;
+                String gameUniqueID = country.toLowerCase().substring(0, 2) + challengeLevel + gameMode;
                 Properties info = new Properties().putValue("Time Taken", System.currentTimeMillis() - levelBegunTime)
                         .putValue("Number Incorrect", incorrectOnLevel)
                         .putValue("Correct Answer", refTile)

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -261,11 +261,11 @@ public class Thailand extends GameActivity {
                     refTile = tileListNoSAD.get(randomTileIndex);
                     refTileType = refTile.typeOfThisTileInstance;
                     boolean choicesContainContextualizersOrPlaceholders = false;
-                    if (refTile.text.contains(contextualizingCharacter) || refTile.text.contains(placeholderCharacter)) {
+                    if (refTile.text.contains(contextualizer) || refTile.text.contains(placeholderCharacter)) {
                         choicesContainContextualizersOrPlaceholders = true;
                     } else {
                         for (String t : refTile.distractors) {
-                            if (t.contains(contextualizingCharacter) || t.contains(placeholderCharacter)) {
+                            if (t.contains(contextualizer) || t.contains(placeholderCharacter)) {
                                 choicesContainContextualizersOrPlaceholders = true;
                                 break;
                             }
@@ -646,7 +646,6 @@ public class Thailand extends GameActivity {
                 }
             }
 
-            //JP: Added switch statement to determine which method to call: tile or word
             switch (refType) {
                 case "SYLLABLE_TEXT":
                 case "SYLLABLE_AUDIO":

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -659,6 +659,12 @@ public class Thailand extends GameActivity {
                 case "TILE_AUDIO":
                 case "CONTEXTUAL":
                     playCorrectSoundThenActiveTileClip(false);
+                case "CONTEXTUAL":
+                    if (hasTileAudio) {
+                        playCorrectSoundThenActiveTileClip(false);
+                    } else {
+                        playCorrectSound();
+                    }
                     break;
                 case "TILE_LOWER":
                 case "TILE_UPPER":

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -360,13 +360,14 @@ public class Thailand extends GameActivity {
 
         switch (choiceType) {
             case "TILE_LOWER":
+            case "CONTEXTUAL":
                 for (int t = 0; t < GAME_BUTTONS.length; t++) {
                     TextView choiceButton = findViewById(GAME_BUTTONS[t]);
                     String choiceColorStr = "#A9A9A9"; // dark gray
                     int choiceColorNo = Color.parseColor(choiceColorStr);
                     choiceButton.setBackgroundColor(choiceColorNo);
                     choiceButton.setTextColor(Color.parseColor("#000000")); // black
-                    choiceButton.setText(fourTileChoices.get(t).text);
+                    choiceButton.setText(fourTileChoices.get(t).text); // Added ZWJ in prior if block for CONTEXTUAL; normal for TILE_LOWER
                 }
                 break;
             case "CONTEXTUAL":
@@ -656,6 +657,7 @@ public class Thailand extends GameActivity {
                     }
                     break;
                 case "TILE_AUDIO":
+                case "CONTEXTUAL":
                     playCorrectSoundThenActiveTileClip(false);
                     break;
                 case "TILE_LOWER":

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -361,16 +361,6 @@ public class Thailand extends GameActivity {
         switch (choiceType) {
             case "TILE_LOWER":
             case "CONTEXTUAL":
-                for (int t = 0; t < GAME_BUTTONS.length; t++) {
-                    TextView choiceButton = findViewById(GAME_BUTTONS[t]);
-                    String choiceColorStr = "#A9A9A9"; // dark gray
-                    int choiceColorNo = Color.parseColor(choiceColorStr);
-                    choiceButton.setBackgroundColor(choiceColorNo);
-                    choiceButton.setTextColor(Color.parseColor("#000000")); // black
-                    choiceButton.setText(fourTileChoices.get(t).text); // Added ZWJ in prior if block for CONTEXTUAL; normal for TILE_LOWER
-                }
-                break;
-            case "CONTEXTUAL":
                 switch(contextualTilePosition) { // Arabic script challengeLevel option; position specified by the 4th character of the challengeLevel number
                     case "INITIAL":
                         for (int t = 0; t < GAME_BUTTONS.length; t++) {
@@ -656,15 +646,6 @@ public class Thailand extends GameActivity {
                     }
                     break;
                 case "TILE_AUDIO":
-                case "CONTEXTUAL":
-                    playCorrectSoundThenActiveTileClip(false);
-                case "CONTEXTUAL":
-                    if (hasTileAudio) {
-                        playCorrectSoundThenActiveTileClip(false);
-                    } else {
-                        playCorrectSound();
-                    }
-                    break;
                 case "TILE_LOWER":
                 case "TILE_UPPER":
                 case "CONTEXTUAL":

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -142,7 +142,7 @@ public class UnitedStates extends GameActivity {
         }
 
         // Set up additional structures
-        if (syllableGame.equals("S")) {
+        if (gameMode.contains("S")) {
             parsedRefWordSyllableArray = syllableList.parseWordIntoSyllables(refWord);
             parsedLengthOfRefWord = parsedRefWordSyllableArray.size();
             parsedRefWordSyllableArrayStrings = new ArrayList<String>();
@@ -201,7 +201,7 @@ public class UnitedStates extends GameActivity {
                 int randomlyCorrectStringGoesBelow = rand.nextInt(2); // Choose whether correct tile goes above ( =0 ) or below ( =1 )
                 int randomDistractor = rand.nextInt(Start.ALT_COUNT); // KP // Choose which distractor will be the alternative
                 if (randomlyCorrectStringGoesBelow == 0) { // Correct string goes above
-                    if (syllableGame.equals("S") && !SAD_STRINGS.contains(parsedRefWordSyllableArray.get(parseIndex).text)) {
+                    if (gameMode.contains("S") && !SAD_STRINGS.contains(parsedRefWordSyllableArray.get(parseIndex).text)) {
                         gameButtonA.setText(parsedRefWordSyllableArray.get(parseIndex).text);
                         gameButtonB.setText(parsedRefWordSyllableArray.get(parseIndex).distractors.get(randomDistractor));
                     } else {
@@ -211,7 +211,7 @@ public class UnitedStates extends GameActivity {
                         tileOptions.add(tileHashMap.find(parsedRefWordTileArray.get(parseIndex).distractors.get(randomDistractor)));
                     }
                 } else { // Correct string goes below
-                    if (syllableGame.equals("S") && !SAD_STRINGS.contains(parsedRefWordSyllableArray.get(parseIndex).text)) {
+                    if (gameMode.contains("S") && !SAD_STRINGS.contains(parsedRefWordSyllableArray.get(parseIndex).text)) {
                         gameButtonB.setText(parsedRefWordSyllableArray.get(parseIndex).text);
                         gameButtonA.setText(parsedRefWordSyllableArray.get(parseIndex).distractors.get(randomDistractor));
                     } else {
@@ -241,13 +241,13 @@ public class UnitedStates extends GameActivity {
         constructedWord.setText(initialDisplay);
 
 
-        if (useContextualFormsBWFP) { // Option for Arabic scripts
-            if(syllableGame.equals("S")) {
-                contextualizeSyllableForms();
-            } else {
-                contextualizeTileForms();
-            }
+       // Game modes included in some Arabic-based-script apps to make word piece strings appear in contextual form
+        if(gameMode.equals("CS")) {
+            contextualizeSyllableForms();
+        } else if (gameMode.equals("CT")){
+            contextualizeTileForms();
         }
+
 
         setAllGameButtonsClickable();
     }
@@ -300,7 +300,7 @@ public class UnitedStates extends GameActivity {
         }
 
         String displayedWord;
-        if (syllableGame.equals("S")){
+        if (gameMode.contains("S")){
             StringBuilder stringBuilder = new StringBuilder();
 
             for (int i = 0; i < numberOfPairs; i++) {
@@ -357,7 +357,7 @@ public class UnitedStates extends GameActivity {
         Button otherGameButton = findViewById(GAME_BUTTONS[otherOptionIndex]);
         selections[selectionIndex] = gameButton.getText().toString();
         selections[otherOptionIndex] = "";
-        if(syllableGame.equals("T")) {
+        if(gameMode.contains("T")) {
             tileSelections[selectionIndex/2] = tileOptions.get(selectionIndex);
         }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -150,9 +150,12 @@ public class UnitedStates extends GameActivity {
                 parsedRefWordSyllableArrayStrings.add(s.text);
             }
         } else {
-            Tile emptyTile = new Tile("__", new ArrayList<String>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, "", 0, "");
+            Tile emptyTile = new Tile(blankForMissingWordPiece, new ArrayList<String>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, "", 0, "");
             tileSelections = new Tile[parsedLengthOfRefWord];
             for (int t = 0; t<parsedLengthOfRefWord; t++) {
+                if (contextualizeWordFrames){ // For some Arabic Script apps, to make edges of pieces in the word draft appear contextually
+                    emptyTile.text = contextualizedWordPieceString(blankForMissingWordPiece, t, parsedRefWordTileArrayStrings);
+                }
                 tileSelections[t] = new Tile(emptyTile);
             }
             tileOptions.clear();
@@ -237,8 +240,9 @@ public class UnitedStates extends GameActivity {
         TextView constructedWord = findViewById(R.id.activeWordTextView);
         String initialDisplay = "";
         for (int i = 0; i < numberOfPairs; i++)
-            initialDisplay += "__";
+            initialDisplay += blankForMissingWordPiece;
         constructedWord.setText(initialDisplay);
+        constructedWord.setTextColor(Color.BLACK);
 
 
        // Game modes included in some Arabic-based-script apps to make word piece strings appear in contextual form
@@ -253,7 +257,7 @@ public class UnitedStates extends GameActivity {
     }
 
     /**
-     * For Arabic script apps with useContextualFormsBWFP = true (BWFP = Build Word From Pairs)
+     * For Arabic script apps with a game in CT mode (Contextualized Tile answer choices)
      */
     private void contextualizeTileForms() {
 
@@ -270,7 +274,7 @@ public class UnitedStates extends GameActivity {
     }
 
     /**
-     * For Arabic script apps with useContextualFormsBWFP = true (BWFP = Build Word From Pairs)
+     * For Arabic script apps with games in CS mode (Contextualized Syllable answer choices)
      */
     private void contextualizeSyllableForms() {
 
@@ -308,7 +312,11 @@ public class UnitedStates extends GameActivity {
                     stringBuilder.append(selections[2 * i]);
                     stringBuilder.append(selections[2 * i + 1]);
                 } else {
-                    stringBuilder.append(contextualizedWordPieceString("__", i, parsedRefWordSyllableArrayStrings));
+                    if (contextualizeWordFrames) {
+                        stringBuilder.append(contextualizedWordPieceString(blankForMissingWordPiece, i, parsedRefWordSyllableArrayStrings));
+                    } else {
+                        stringBuilder.append(blankForMissingWordPiece);
+                    }
                 }
             }
 

--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -513,6 +513,18 @@ public class Validator {
             try {
                 Tab langInfo = langPackGoogleSheet.getTabFromName("langinfo");
                 scriptType = langInfo.getRowFromFirstCell("Script type").get(1); // sets global variable used to determine simple/complex parse
+                if (scriptType.equals("Arabic")) {
+                    try {
+                        Tab settings = langPackGoogleSheet.getTabFromName("settings");
+                        if (!settings.getRowFromFirstCell("Contextualize word frames").get(1).matches("(TRUE|FALSE)")) {
+                            fatalError(Message.Tag.Etc, "In settings \"Contextualize word frames\" must be either \"TRUE\" or \"FALSE\"");
+                        }
+                    } catch (ValidatorException e) {
+                        recommend(Message.Tag.Etc, "For Arabic script apps: If you would like word frames to have contextual forms around blanks, set \"Contextualize word frames\" to \"TRUE\" in settings.");
+                    }
+
+
+                }
             } catch (ValidatorException e) {
                 fatalError(Message.Tag.Etc, "In langinfo \"Script type\" must be either \"Arabic,\" \"Devanagari,\" \"Khmer,\" \"Lao,\" \"Roman,\"or \"Thai\". Please add a valid script type.");
             }

--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -1172,7 +1172,7 @@ public class Validator {
             Tab gamesTab = langPackGoogleSheet.getTabFromName("games");
             boolean hasSudanForTiles = false;
             for (int i = 0; i < gamesTab.size(); i++) {
-                if (gamesTab.get(i).get(1).equals("Sudan") && gamesTab.get(i).get(6).equals("T")) {
+                if (gamesTab.get(i).get(1).equals("Sudan") && gamesTab.get(i).get(6).contains("T")) {
                     hasSudanForTiles = true;
                     break;
                 }
@@ -1190,7 +1190,7 @@ public class Validator {
             Tab gamesTab = langPackGoogleSheet.getTabFromName("games");
             boolean hasSudanForSyllables = false;
             for (int i = 1; i < gamesTab.size(); i++) {
-                if (gamesTab.get(i).get(1).equals("Sudan") && gamesTab.get(i).get(6).equals("S")) {
+                if (gamesTab.get(i).get(1).equals("Sudan") && gamesTab.get(i).get(6).contains("S")) {
                     hasSudanForSyllables = true;
                     break;
                 }
@@ -1200,6 +1200,22 @@ public class Validator {
                 recommend(Message.Tag.Etc, "It is recommended you add Sudan for syllables to the games tab if you have syllable audio");
             } else if (!hasSyllableAudio && hasSudanForSyllables) {
                 fatalError(Message.Tag.Etc, "You cannot have Sudan for syllables in the games tab if you do not have syllable audio");
+            }
+        } catch (ValidatorException e) {
+            warn(Message.Tag.Etc, FAILED_CHECK_WARNING + "the games tab");
+        }
+
+        try {
+            Tab gamesTab = langPackGoogleSheet.getTabFromName("games");
+            for (int i = 0; i < gamesTab.size(); i++) {
+                if (!(gamesTab.get(i).get(1).matches("(Georgia|Brazil|UnitedStates|Thailand)")) && gamesTab.get(i).get(6).contains("C")) {
+                    fatalError(Message.Tag.Etc, gamesTab.get(i).get(1) + " games do not have separate contextual forms modes. Change \"" + gamesTab.get(i).get(6) + "\" in games column SyllOrTile to \"" + gamesTab.get(i).get(6).replace("C", "") + "\" for game " + gamesTab.get(i).get(0));
+                }
+                if (gamesTab.get(i).get(1).equals("Thailand") && gamesTab.get(i).get(6).contains("C") && !(gamesTab.get(i).get(2).contains("9"))) {
+                    fatalError(Message.Tag.Etc, "Except in challenge levels with contextual mapping types (type 9), Thailand levels use isolate, not contextual forms. Change \"" + gamesTab.get(i).get(6) + "\" in games column SyllOrTile for game to \"" + gamesTab.get(i).get(6).replace("C", "") + "\" for game " + gamesTab.get(i).get(0));
+                } else if (gamesTab.get(i).get(1).equals("Thailand") && gamesTab.get(i).get(6).contains("C") && gamesTab.get(i).get(2).contains("9")) {
+                    fatalError(Message.Tag.Etc, "Although its mode is marked " + gamesTab.get(i).get(6) + ", game " + gamesTab.get(i).get(0) + "'s referent and options will be contextual or not based on the challenge level. Change \"" + gamesTab.get(i).get(6) + "\" in games column SyllOrTile  to \"" + gamesTab.get(i).get(6).replace("C", "") + "\" for game " + gamesTab.get(i).get(0));
+                }
             }
         } catch (ValidatorException e) {
             warn(Message.Tag.Etc, FAILED_CHECK_WARNING + "the games tab");


### PR DESCRIPTION
This PR would add the following two features to the **contextual-forms** branch. contextual-forms expands options regarding contextual forms for Arabic-based script language packs.

1.  **Contextual Tile and Contextual Syllable game modes**. If desired, teams can add the same game (either Fill In The Blank-Brazil, Identify The Initial-Georgia, and Build Word From Pairs-United States) twice in the same app: once with answer choices in contextual form and once with answer choices in default (isolate) form. In the games tab, values in the "SyllOrTile" column for each game can now be set as either (default, non-contextualized) S (syllable), T (tile), or new options: CT (contextual tile) and CS (contextual syllable). Teams can have the same Country and same ChallengeLevel, but different "SyllOrTile" ( = mode, including contextual or not).

The **validator has been updated** to send a warning if CT or CS is marked for any game besides Fill In The Blank, Identify The Initial, or Build Word From Pairs, since those are the only games with the possibility of contextualized answer choices.

3. **Contextualized word frames.** While contextual game modes (above) specify how answer choices look, this setting specifies how word frames look (contextual form or not). For Fill in the Blank and Build Word From Pairs, if setting "Contextualize word frames" is set to TRUE in the settings tab, the word pieces around blanks will have contextual forms. They will look like they are about to connect to whatever goes in the adjacent blank. If this setting is left off, or set to FALSE, word pieces around blanks will not appear to join to what is in the blank. 

The **validator has been updated** to send a recommendation to language packs that have Arabic script (in langinfo) to add this setting if they would like to contextualize word frames.

TODO along with/after testing: add these new game modes and this new setting to instructions for language pack creation.

**Instructions for testing**

- [ ] Duplicate some games (FITB, ITI, and BWFP) from a language pack with a contextualizer specified; Make some instances of those games have SyllOrTile value "T" and some have SyllOrTile value "CT".
- [ ] Check that in the "T" games, answer choices are isolate.
- [ ] Check that in the "CT" games, answer choices are in contextual form.
- [ ] Add "CT" for a different game; maybe WordSearch. 
- [ ] Run the validator. 
- [ ] Check to see if an error is reported that the WordSearch (Myanmar) game does not have a version with contextual answer choices, so to change it to "T".
- [ ] Remove any previous settings about "Use contextual forms..." as those have now been replaced with contextual game modes (syllOrTile values).
- [ ] Add the setting "Contextualize word frames" and set it to "TRUE".
- [ ] Check that word pieces around blanks in Fill in the Blank appear in contextual form, as if connected to what's in the blank.
- [ ] Check that word pieces in the draft word of Build Word From Pairs appear in contextual form, as if connected to what's in the blanks next to them.
- [ ] Change the setting to "FALSE".
- [ ] Check that word frames in FITB and BWFP are **not** in contextual form.
- [ ] Remove the setting.
- [ ] Check that word frames in FITB and BWFP are **not** in contextual form.
- [ ] Run the validator, while the language pack does **not** have this new setting.
- [ ] Check that the validator gives a recommendation to add the setting, if the user would like to contextualize word frames.