### PR TITLE
Add support for non-Roman numeral display

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
@@ -142,7 +142,7 @@ public class ChoosePlayer extends AppCompatActivity {
             if (localWordForName.equals("custom")) {
                 defaultName = nameList.get(nameID - 1);
             } else {
-                defaultName = localWordForName + " " + nameID;
+                defaultName = localWordForName + " " + convertNumeralSystem(String.valueOf(nameID));
             }
 
             String playerString = Util.returnPlayerStringToAppend(nameID);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
@@ -66,7 +66,7 @@ public class Earth extends AppCompatActivity {
         globalPoints = getIntent().getIntExtra("globalPoints", 0);
 
         TextView pointsEarned = findViewById(R.id.pointsTextView);
-        pointsEarned.setText(String.valueOf(globalPoints));
+        pointsEarned.setText(Start.convertNumeralSystem(String.valueOf((globalPoints))));
 
         ImageView avatar = findViewById(R.id.activePlayerImage);
         int resID = getResources().getIdentifier(String.valueOf(ChoosePlayer.AVATAR_JPG_IDS[playerNumber - 1]), "drawable", getPackageName());
@@ -78,7 +78,7 @@ public class Earth extends AppCompatActivity {
         if (localWordForName.equals("custom")) {
             defaultName = Start.nameList.get(playerNumber - 1);
         } else {
-            defaultName = localWordForName + " " + playerNumber;
+            defaultName = localWordForName + " " + Start.convertNumeralSystem(String.valueOf(playerNumber));
         }
         playerName = prefs.getString("storedName" + playerString, defaultName);
 
@@ -148,7 +148,8 @@ public class Earth extends AppCompatActivity {
                 try {
                     int doorIndex = Integer.parseInt((String) earthCL.getChildAt(j).getTag()) - 1;
                     String doorText = String.valueOf((pageNumber * doorsPerPage) + doorIndex + 1);
-                    ((TextView) child).setText(doorText);
+                    ((TextView) child).setText(Start.convertNumeralSystem(doorText));
+
                     if (((pageNumber * doorsPerPage) + doorIndex) >= Start.gameList.size()) {
                         ((TextView) child).setVisibility(View.INVISIBLE);
                     } else {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -249,10 +249,10 @@ public abstract class GameActivity extends AppCompatActivity {
         globalPoints+=pointsIncrease;
         points+=pointsIncrease;
         TextView pointsEarned = findViewById(R.id.pointsTextView);
-        pointsEarned.setText(String.valueOf(points));
+        pointsEarned.setText(Start.convertNumeralSystem(String.valueOf((points))));
 
         TextView gameNumberBox = findViewById(R.id.gameNumberView);
-        gameNumberBox.setText(String.valueOf(gameNumber));
+        gameNumberBox.setText(Start.convertNumeralSystem(String.valueOf(gameNumber)));
         int gameColor = Color.parseColor(colorList.get(Integer.parseInt(gameList.get(gameNumber-1).color)));
         gameNumberBox.setBackgroundColor(gameColor);
         pointsEarned.setBackgroundColor(gameColor);
@@ -271,7 +271,7 @@ public abstract class GameActivity extends AppCompatActivity {
         if (gameList.get(gameNumber-1).country.equals("Georgia") && challengeLevel > 6) {
             displayedChallengeLevel = displayedChallengeLevel - 6;
         }
-        challengeLevelBox.setText(String.valueOf(displayedChallengeLevel));
+        challengeLevelBox.setText(Start.convertNumeralSystem(String.valueOf(displayedChallengeLevel)));
 
         // Update tracker icons
         for (int t = 0; t < TRACKERS.length; t++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Romania.java
@@ -186,7 +186,9 @@ public class Romania extends GameActivity {
         String tileText = activeTile.text;
         gameTile.setText(tileText);
         TextView numberOfTotal = (TextView) findViewById(R.id.numberOfTotalText);
-        numberOfTotal.setText(indexWithinGroup + 1 + " / " + String.valueOf(String.valueOf(groupCount)));
+        String nthTileScrollArrows = Start.convertNumeralSystem(String.valueOf(indexWithinGroup + 1));
+        String totalTilesScrollArrows = Start.convertNumeralSystem(String.valueOf(groupCount));
+        numberOfTotal.setText(nthTileScrollArrows + " / " + totalTilesScrollArrows);
 
         gameTile.setClickable(true);
 
@@ -278,7 +280,9 @@ public class Romania extends GameActivity {
             gameTile.setBackgroundColor(tileColor);
             activeWord.setBackgroundColor(tileColor);
             TextView numberOfTotal = (TextView) findViewById(R.id.numberOfTotalText);
-            numberOfTotal.setText(indexWithinGroup + 1 + " / " + String.valueOf(groupCount));
+            String nthTileScrollArrows = Start.convertNumeralSystem(String.valueOf(indexWithinGroup + 1));
+            String totalTilesScrollArrows = Start.convertNumeralSystem(String.valueOf(groupCount));
+            numberOfTotal.setText(nthTileScrollArrows + " / " + totalTilesScrollArrows);
 
             if (failedToMatchInitialTile) {
                 tileColorStr = "#A9A9A9"; // dark gray
@@ -333,7 +337,9 @@ public class Romania extends GameActivity {
             activeWord.setBackgroundColor(tileColor);
             TextView numberOfTotal = (TextView) findViewById(R.id.numberOfTotalText);
 
-            numberOfTotal.setText(indexWithinGroup + 1 + " / " + String.valueOf(groupCount));
+            String nthTileScrollArrows = Start.convertNumeralSystem(String.valueOf(indexWithinGroup + 1));
+            String totalTilesScrollArrows = Start.convertNumeralSystem(String.valueOf(groupCount));
+            numberOfTotal.setText(nthTileScrollArrows + " / " + totalTilesScrollArrows);
             if (failedToMatchInitialTile) {
                 tileColorStr = "#A9A9A9"; // dark gray
                 tileColor = Color.parseColor(tileColorStr);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -40,6 +40,7 @@ public class Start extends AppCompatActivity {
 
     public static GameList gameList; // from aa_games.text
     public static LangInfoList langInfoList; // KP / from aa_langinfo.txt
+    public static NumeralList numeralList; // AH / from aa_numerals.txt
     public static SettingsList settingsList; // KP // from aa_settings.txt
     public static AvatarNameList nameList; // KP / from aa_names.txt
 
@@ -66,6 +67,8 @@ public class Start extends AppCompatActivity {
     public static Boolean hasTileAudio;
     public static Boolean hasSyllableAudio;
     public static Boolean hasSyllableGames = false;
+
+    public static Boolean nonRomanNumeralSystem;
     public static int after12checkedTrackers;
     public static Boolean differentiatesTileTypes;
     public static Boolean hasSAD = false;
@@ -110,7 +113,9 @@ public class Start extends AppCompatActivity {
         buildSettingsList();
         LOGGER.info("LoadProgress: completed buildSettingsList()");
         buildColorList();
-        LOGGER.info("LoadProgress: completed buildColorsList()");
+        LOGGER.info("LoadProgress: completed buildColorList()");
+        buildNumeralList();
+        LOGGER.info("LoadProgress: completed buildNumeralList()");
 
         hasTileAudio = getBooleanFromSettings("Has tile audio", false);
         differentiatesTileTypes = getBooleanFromSettings("Differentiates types of multitype symbols", false);
@@ -118,6 +123,7 @@ public class Start extends AppCompatActivity {
         hasSyllableAudio = getBooleanFromSettings("Has syllable audio", false);
         sendAnalytics = getBooleanFromSettings("Send analytics", false);
         changeArrowColor = getBooleanFromSettings("Change arrow colors", true);
+        nonRomanNumeralSystem = getBooleanFromSettings("Non-Roman Numeral System", false);
 
         String after12checkedTrackersSetting = settingsList.find("After 12 checked trackers");
         if (!after12checkedTrackersSetting.equals("")) {
@@ -243,6 +249,21 @@ public class Start extends AppCompatActivity {
         }
     }
 
+    public static String convertNumeralSystem(String someNumberAsString) {
+
+        if (nonRomanNumeralSystem) {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < someNumberAsString.length(); i++) {
+
+                builder.append(numeralList.find(someNumberAsString.substring(i, i + 1)));
+            }
+
+            return builder.toString();
+        } else {
+            return someNumberAsString;
+        }
+    }
+
     private void buildColorList() {
         Scanner scanner = new Scanner(getResources().openRawResource(R.raw.aa_colors));
 
@@ -255,6 +276,25 @@ public class Start extends AppCompatActivity {
                 header = false;
             } else {
                 colorList.add(thisLineArray[2]);
+            }
+        }
+    }
+
+    private void buildNumeralList() {
+        boolean header = true;
+        Scanner scanner = new Scanner(getResources().openRawResource(R.raw.aa_numerals));
+
+        numeralList = new NumeralList();
+        while (scanner.hasNext()) {
+            if (scanner.hasNextLine()) {
+                if (header) {
+                    numeralList.title = scanner.nextLine();
+                    header = false;
+                } else {
+                    String thisLine = scanner.nextLine();
+                    String[] thisLineArray = thisLine.split("\t");
+                    numeralList.put(thisLineArray[0], thisLineArray[1]);
+                }
             }
         }
     }
@@ -2078,6 +2118,21 @@ public class Start extends AppCompatActivity {
 
         public String keysTitle;
         public String colorTitle;
+
+    }
+
+    public class NumeralList extends HashMap<String, String> {
+
+        public String title;
+
+        public String find(String keyContains) {
+            for (String k : keySet()) {
+                if (k.contains(keyContains)) {
+                    return (get(k));
+                }
+            }
+            return "";
+        }
 
     }
 

--- a/validator/src/main/java/org/alphatilesapps/validator/Validator.java
+++ b/validator/src/main/java/org/alphatilesapps/validator/Validator.java
@@ -322,7 +322,8 @@ public class Validator {
             Map.entry("colors", "A1:C"),
             Map.entry("names", "A1:B"),
             Map.entry("notes", "A1:B"),
-            Map.entry("share", "A1:A")));
+            Map.entry("share", "A1:A"),
+            Map.entry("numerals", "A1:B11")));
 
     /**
      * A Map of the names of the folders needed for validation to the file types needed in each folder (in MIME type, comma delimited).


### PR DESCRIPTION
Teams can now display numbers in non-Roman format. To do this, using Eastern Arabic numerals as an example, create a aa_numerals.txt file with headers (e.g. "Roman", "Custom") and a column for 0 to 9 in Roman script and ٠ to ٩ in Eastern Arabic script. Then add the setting "Non-Roman Numeral System" and set it to TRUE.

Note:
Before the contextual forms branch is merged into main, updates should be made to the setup instructions, the Google Sheets template, and the tpxTeocuitlapa language pack (in Public Language Assets repo).