### PR TITLE
Remove tile type X from firstAudibleTile method.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "org.alphatilesapps.alphatiles"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 177
-        versionName "2.6.0"
+        versionCode 178
+        versionName "2.6.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -634,11 +634,11 @@ public class Thailand extends GameActivity {
         ArrayList<Tile> wordParsedIntoTiles = tileList.parseWordIntoTiles(word.wordInLOP, word);
         Tile tileToReturn = wordParsedIntoTiles.get(0);
         if ((tileToReturn.typeOfThisTileInstance.equals("LV") && !wordParsedIntoTiles.get(1).typeOfThisTileInstance.equals("PC"))
-                || tileToReturn.typeOfThisTileInstance.matches("(PC|AD|D|T|X)")) { // These are not first sounds, though they can be written first
+                || tileToReturn.typeOfThisTileInstance.matches("(PC|AD|D|T)")) { // These are not first sounds, though they can be written first
             tileToReturn = wordParsedIntoTiles.get(1);
         }
         int i = 2;
-        while (tileToReturn.typeOfThisTileInstance.matches("(PC|AD|D|T|X)")) {
+        while (tileToReturn.typeOfThisTileInstance.matches("(PC|AD|D|T)")) {
             tileToReturn = wordParsedIntoTiles.get(i);
             i++;
         }


### PR DESCRIPTION
Remove tile type X from the list of tiles with special handling in firstAudibleTile method. Tiles of type X should trigger no special handling. An example of a tile of type X is the word "daan" in Teocuitlapa Me'phaa where the final tile |n| is not a consonant, but rather an indicator of nasality of the preceding vowels. Functionally, setting up a tile as type X ensures that the Choose the Missing Vowel/Consonant (Brazil) games never present "daa_" and ask which tile is missing, as the tile |n| is neither a consonant or a vowel.