### PR TITLE
Allow teams to restrict tiles to surfacing in only some positions within words

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -357,7 +357,7 @@ public class Brazil extends GameActivity {
         StringBuilder wordBuilder = new StringBuilder();
         String word;
         if (syllableGame.equals("S")) {
-            Start.Syllable blankSyllable = new Start.Syllable("__", new ArrayList<>(),"X", 0, correctSyllable.color);
+            Start.Syllable blankSyllable = new Start.Syllable("__", new ArrayList<>(),"X", 0, correctSyllable.color, "No restrictions (default)");
             parsedRefWordSyllableArray.set(index_to_remove, blankSyllable);
             for (Syllable s : parsedRefWordSyllableArray) {
                 if (s != null) {
@@ -366,7 +366,7 @@ public class Brazil extends GameActivity {
             }
             word = wordBuilder.toString();
         } else { // Tile game
-            Start.Tile blankTile = new Start.Tile("__", new ArrayList<>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, correctTile.typeOfThisTileInstance, 1, "");
+            Start.Tile blankTile = new Start.Tile("__", new ArrayList<>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, correctTile.typeOfThisTileInstance, 1, "", "No restrictions (default)");
             parsedRefWordTileArray.set(index_to_remove, blankTile);
             if (scriptType.equals("Khmer") && correctTile.typeOfThisTileInstance.equals("C")){
                 if(index_to_remove < parsedRefWordTileArray.size()-1 && parsedRefWordTileArray.get(index_to_remove + 1).typeOfThisTileInstance.matches("(V|AV|BV|D)")) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -9,7 +9,6 @@ import android.widget.TextView;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Random;
@@ -42,7 +41,7 @@ import static org.alphatilesapps.alphatiles.Start.*;
 
 public class Brazil extends GameActivity {
     int numTones;
-    int index_to_remove;
+    int indexToRemove;
     Start.Tile correctTile;
     Start.Syllable correctSyllable;
     String correctString;
@@ -299,7 +298,7 @@ public class Brazil extends GameActivity {
 
         Random rand = new Random();
         int index = 0;
-        index_to_remove = 0;
+        indexToRemove = 0;
 
         boolean repeat = true;
 
@@ -311,14 +310,14 @@ public class Brazil extends GameActivity {
             while (repeat && !possibleIndices.isEmpty()) {
                 index = rand.nextInt(possibleIndices.size());
                 correctTile = parsedRefWordTileArray.get(possibleIndices.get(index));
-                index_to_remove = possibleIndices.get(index);
-                possibleIndices.remove((Integer)index_to_remove);
+                indexToRemove = possibleIndices.get(index);
+                possibleIndices.remove((Integer) indexToRemove);
 
                 while (SAD_STRINGS.contains(correctTile.text)) { // JP: Makes sure that SAD is never chosen as missing tile
                     index = rand.nextInt(possibleIndices.size());
                     correctTile = parsedRefWordTileArray.get(possibleIndices.get(index));
-                    index_to_remove = possibleIndices.get(index);
-                    possibleIndices.remove((Integer)index_to_remove);
+                    indexToRemove = possibleIndices.get(index);
+                    possibleIndices.remove((Integer) indexToRemove);
                 }
 
                 if (challengeLevel < 4) {
@@ -342,11 +341,11 @@ public class Brazil extends GameActivity {
             }
             correctString = correctTile.text;
         } else { // syllable game
-            index_to_remove = rand.nextInt(parsedRefWordSyllableArray.size());
-            correctSyllable = parsedRefWordSyllableArray.get(index_to_remove);
+            indexToRemove = rand.nextInt(parsedRefWordSyllableArray.size());
+            correctSyllable = parsedRefWordSyllableArray.get(indexToRemove);
             while (SAD_STRINGS.contains(correctSyllable.text)) { // JP: makes sure that SAD is never chosen as missing syllable
-                index_to_remove = rand.nextInt(parsedRefWordSyllableArray.size());
-                correctSyllable = parsedRefWordSyllableArray.get(index_to_remove);
+                indexToRemove = rand.nextInt(parsedRefWordSyllableArray.size());
+                correctSyllable = parsedRefWordSyllableArray.get(indexToRemove);
             }
             correctString = correctSyllable.text;
         }
@@ -356,7 +355,7 @@ public class Brazil extends GameActivity {
         String word;
         if (syllableGame.equals("S")) {
             Start.Syllable blankSyllable = new Start.Syllable("__", new ArrayList<>(),"X", 0, correctSyllable.color, "No restrictions (default)");
-            parsedRefWordSyllableArray.set(index_to_remove, blankSyllable);
+            parsedRefWordSyllableArray.set(indexToRemove, blankSyllable);
             for (Syllable s : parsedRefWordSyllableArray) {
                 if (s != null) {
                     wordBuilder.append(s.text);
@@ -365,26 +364,26 @@ public class Brazil extends GameActivity {
             word = wordBuilder.toString();
         } else { // Tile game
             Start.Tile blankTile = new Start.Tile("__", new ArrayList<>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, correctTile.typeOfThisTileInstance, 1, "", "No restrictions (default)");
-            parsedRefWordTileArray.set(index_to_remove, blankTile);
+            parsedRefWordTileArray.set(indexToRemove, blankTile);
             if (scriptType.equals("Khmer") && correctTile.typeOfThisTileInstance.equals("C")){
-                if(index_to_remove < parsedRefWordTileArray.size()-1 && parsedRefWordTileArray.get(index_to_remove + 1).typeOfThisTileInstance.matches("(V|AV|BV|D)")) {
+                if(indexToRemove < parsedRefWordTileArray.size()-1 && parsedRefWordTileArray.get(indexToRemove + 1).typeOfThisTileInstance.matches("(V|AV|BV|D)")) {
                     blankTile.text = "\u200B"; // The word will default to containing a placeholder circle. Add zero-width space, instead of line.
-                    parsedRefWordTileArray.set(index_to_remove, blankTile);
+                    parsedRefWordTileArray.set(indexToRemove, blankTile);
                 } else {
                     blankTile.text = placeholderCharacter; // Since Khmer has lots of placeholder circles, we'll use them for all consonant blanks.
-                    parsedRefWordTileArray.set(index_to_remove, blankTile);
+                    parsedRefWordTileArray.set(indexToRemove, blankTile);
                 }
             }
             if (scriptType.matches("(Thai|Lao)") && correctTile.typeOfThisTileInstance.equals("C")){
                 blankTile.text = placeholderCharacter;
-                parsedRefWordTileArray.set(index_to_remove, blankTile);
+                parsedRefWordTileArray.set(indexToRemove, blankTile);
             }
             if (useContextualFormsFITB) { // Setting used by some Arabic script apps to make tiles appear in contextual forms in answer choices and around blanks
-                blankTile.text = contextualizedWordPieceString(blankTile.text, index_to_remove, parsedRefWordTileArrayStrings);
+                blankTile.text = contextualizedWordPieceString(blankTile.text, indexToRemove, parsedRefWordTileArrayStrings);
             }
 
 
-            word = combineTilesToMakeWord(parsedRefWordTileArray, refWord, index_to_remove);
+            word = combineTilesToMakeWord(parsedRefWordTileArray, refWord, indexToRemove);
         }
         constructedWord.setText(word);
     }
@@ -392,12 +391,12 @@ public class Brazil extends GameActivity {
     private void setUpSyllables() {
         if (challengeLevel == 1) { // Find and add random alternatives
 
-            HashMap<Integer, Syllable> alreadyAddedPlacements = new HashMap<Integer, Syllable>();
+            WordPieceStringPositionSet alreadyAddedPlacements = new WordPieceStringPositionSet();
 
             for (int b = 0; b < visibleGameButtons; b++) {
                 TextView gameButton = findViewById(GAME_BUTTONS[b]);
 
-                Start.Syllable option = fittingSyllableAlternative(alreadyAddedPlacements, parsedRefWordSyllableArray, index_to_remove);
+                Syllable option = fittingSyllableAlternative(alreadyAddedPlacements, parsedRefWordSyllableArray, indexToRemove);
                 if (Objects.isNull(option)) { // Fewer than 4 viable answer choices available. 'Restart' with new word.
                     playAgain();
                     return;
@@ -407,12 +406,12 @@ public class Brazil extends GameActivity {
                     gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
                     gameButton.setVisibility(View.VISIBLE);
                     gameButton.setClickable(true);
-                    alreadyAddedPlacements.put(index_to_remove, option);
+                    alreadyAddedPlacements.add(new WordPieceStringPosition(indexToRemove, option.text));
                 }
 
             }
 
-            if (!(alreadyAddedPlacements.containsValue(correctSyllable) && alreadyAddedPlacements.containsKey(index_to_remove))) { // If the correct syllable wasn't randomly added as an answer choice, then here it overwrites one of the others
+            if (!(alreadyAddedPlacements.contains(new WordPieceStringPosition(indexToRemove, correctString)))) { // If the correct syllable wasn't randomly added as an answer choice, then here it overwrites one of the others
                 Random rand = new Random();
                 int randomNum = rand.nextInt(visibleGameButtons - 1); // KP
                 TextView gameButton = findViewById(GAME_BUTTONS[randomNum]);
@@ -425,7 +424,7 @@ public class Brazil extends GameActivity {
             Set<String> challengingAnswerChoices = new HashSet<String>(); // Duplicates will be prevented since this is a Set
             challengingAnswerChoices.add(correctSyllable.text);
             for (int d=0; d<3; d++) {
-                if(syllableHashMap.get(correctSyllable.distractors.get(d)).canBePlacedInPosition(parsedRefWordSyllableArray, index_to_remove)) {
+                if(syllableHashMap.get(correctSyllable.distractors.get(d)).canBePlacedInPosition(parsedRefWordSyllableArray, indexToRemove)) {
                     challengingAnswerChoices.add(correctSyllable.distractors.get(d));
                 }
             }
@@ -437,7 +436,7 @@ public class Brazil extends GameActivity {
                 if(option.length()>=2 && correctSyllable.text.length()>=2) {
                     if(option.charAt(0) == correctSyllable.text.charAt(0)
                             && option.charAt(1) == correctSyllable.text.charAt(1)
-                            && syllableHashMap.get(option).canBePlacedInPosition(parsedRefWordSyllableArray, index_to_remove)) {
+                            && syllableHashMap.get(option).canBePlacedInPosition(parsedRefWordSyllableArray, indexToRemove)) {
                         challengingAnswerChoices.add(option);
                     }
                 }
@@ -448,7 +447,7 @@ public class Brazil extends GameActivity {
             i = 0;
             while (challengingAnswerChoices.size() < visibleGameButtons && i < syllableListCopy.size()) {
                 String option = syllableListCopy.get(i).text;
-                if (syllableHashMap.get(option).canBePlacedInPosition(parsedRefWordSyllableArray, index_to_remove)) {
+                if (syllableHashMap.get(option).canBePlacedInPosition(parsedRefWordSyllableArray, indexToRemove)) {
                     if (option.charAt(0) == correctSyllable.text.charAt(0)) {
                         challengingAnswerChoices.add(option);
                     } else if (option.charAt(option.length() - 1) == correctSyllable.text.charAt(correctSyllable.text.length() - 1)) {
@@ -461,7 +460,7 @@ public class Brazil extends GameActivity {
             // Finally, fill any remaining empty game buttons with random syllables
             int j = 0;
             while (challengingAnswerChoices.size()<visibleGameButtons && j<syllableListCopy.size()) {
-                if (syllableListCopy.get(j).canBePlacedInPosition(parsedRefWordSyllableArray, index_to_remove)) {
+                if (syllableListCopy.get(j).canBePlacedInPosition(parsedRefWordSyllableArray, indexToRemove)) {
                     challengingAnswerChoices.add(syllableListCopy.get(j).text);
                 }
                 j++;
@@ -516,7 +515,7 @@ public class Brazil extends GameActivity {
             distractorTiles.add(distractorTile);
         }
 
-        HashMap<Integer, Tile> alreadyAddedPlacements = new HashMap<Integer, Tile>();
+        WordPieceStringPositionSet alreadyAddedPlacements = new WordPieceStringPositionSet();
         Start.Tile option;
 
         for (int b = 0; b < visibleGameButtons; b++) {
@@ -524,27 +523,27 @@ public class Brazil extends GameActivity {
             switch (challengeLevel) {
                 case 1:
                 case 3:
-                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, index_to_remove, VOWELS);
+                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, indexToRemove, VOWELS);
                     break;
                 case 2:
                 case 5:
-                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, index_to_remove, distractorTiles);
+                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, indexToRemove, distractorTiles);
                     break;
                 case 4:
                 case 6:
-                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, index_to_remove, CONSONANTS);
+                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, indexToRemove, CONSONANTS);
                     break;
                 case 7:
-                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, index_to_remove, TONES);
+                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, indexToRemove, TONES);
                     break;
                 default:
-                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, index_to_remove, cumulativeStageBasedTileList);
+                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, indexToRemove, cumulativeStageBasedTileList);
                     break;
             }
 
             if (Objects.isNull(option)) {
                 if (b < 4) {
-                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, index_to_remove, cumulativeStageBasedTileList);
+                    option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, indexToRemove, cumulativeStageBasedTileList);
                     if (Objects.isNull(option)) {
                         playAgain();
                         return;
@@ -562,7 +561,7 @@ public class Brazil extends GameActivity {
                 gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
                 gameButton.setVisibility(View.VISIBLE);
                 gameButton.setClickable(true);
-                alreadyAddedPlacements.put(index_to_remove, option);
+                alreadyAddedPlacements.add(new WordPieceStringPosition(indexToRemove, option.text));
             }
         }
 
@@ -577,7 +576,7 @@ public class Brazil extends GameActivity {
             }
         }
 
-        if (!(alreadyAddedPlacements.containsValue(correctTile) && alreadyAddedPlacements.containsKey(index_to_remove))) { // If the correct syllable wasn't randomly added as an answer choice, then here it overwrites one of the others
+        if (!(alreadyAddedPlacements.contains(new WordPieceStringPosition(indexToRemove, correctTile.text)))) { // If the correct syllable wasn't randomly added as an answer choice, then here it overwrites one of the others
             Random rand = new Random();
             int randomNum = rand.nextInt(visibleGameButtons - 1); // KP
             TextView gameButton = findViewById(GAME_BUTTONS[randomNum]);
@@ -598,7 +597,7 @@ public class Brazil extends GameActivity {
 
         for(int t = 0; t< visibleGameButtons; t++) { // For all answer choices
             TextView answerChoiceButton = findViewById(GAME_BUTTONS[t]);
-            String contextualizedChoice = contextualizedWordPieceString(answerChoiceButton.getText().toString(), index_to_remove, parsedRefWordTileArrayStrings);
+            String contextualizedChoice = contextualizedWordPieceString(answerChoiceButton.getText().toString(), indexToRemove, parsedRefWordTileArrayStrings);
             answerChoiceButton.setText(contextualizedChoice);
         }
     }
@@ -610,7 +609,7 @@ public class Brazil extends GameActivity {
     private void produceContextualSyllableAnswerChoices() {
         for(int t = 0; t< visibleGameButtons; t++) { // For all answer choices
             TextView answerChoiceButton = findViewById(GAME_BUTTONS[t]);
-            String contextualizedChoice = contextualizedWordPieceString(answerChoiceButton.getText().toString(), index_to_remove, parsedRefWordSyllableArrayStrings);
+            String contextualizedChoice = contextualizedWordPieceString(answerChoiceButton.getText().toString(), indexToRemove, parsedRefWordSyllableArrayStrings);
             answerChoiceButton.setText(contextualizedChoice);
         }
     }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -32,9 +32,12 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
 
+import static org.alphatilesapps.alphatiles.Start.CONSONANTS;
 import static org.alphatilesapps.alphatiles.Start.MULTITYPE_TILES;
 import static org.alphatilesapps.alphatiles.Start.NON_SPACERS_ARABIC;
 import static org.alphatilesapps.alphatiles.Start.SILENT_PRELIMINARY_TILES;
+import static org.alphatilesapps.alphatiles.Start.TONES;
+import static org.alphatilesapps.alphatiles.Start.VOWELS;
 import static org.alphatilesapps.alphatiles.Start.colorList;
 import static org.alphatilesapps.alphatiles.Start.differentiatesTileTypes;
 import static org.alphatilesapps.alphatiles.Start.gameList;
@@ -42,6 +45,7 @@ import static org.alphatilesapps.alphatiles.Start.non_joining_arabic_letters;
 import static org.alphatilesapps.alphatiles.Start.non_spacing_arabic_letters;
 import static org.alphatilesapps.alphatiles.Start.right_joining_arabic_letters;
 import static org.alphatilesapps.alphatiles.Start.stageCorrespondenceRatio;
+import static org.alphatilesapps.alphatiles.Start.syllableList;
 import static org.alphatilesapps.alphatiles.Start.tileAudioIDs;
 import static org.alphatilesapps.alphatiles.Start.tileDurations;
 import static org.alphatilesapps.alphatiles.Start.placeholderCharacter;
@@ -1478,6 +1482,129 @@ public abstract class GameActivity extends AppCompatActivity {
     public static String isolateForm(String  contextualizedForm) {
 
         return contextualizedForm.replace(contextualizingCharacter, "");
+    }
+
+
+    /**
+     * Finds a fitting alternative tile answer choice when an answer choice violates word position restrictions
+     * @param refTile the tile in the correct rendering of the word
+     * @param alreadyAddedChoices the other answer choices already selected (so we don't return a duplicate)
+     * @param tilesInRefWord
+     * @param indexInParsedRefWordTileArray
+     * @param typeMatters whether we are drawing from tiles of the same type only or all tiles
+     * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
+     */
+
+    public Start.Tile fittingTileAlternative(Start.Tile refTile, ArrayList<Start.Tile> alreadyAddedChoices, ArrayList<Start.Tile> tilesInRefWord, int indexInParsedRefWordTileArray, Boolean typeMatters) {
+
+        ArrayList<Start.Tile> tilesToDrawFrom;
+        if (typeMatters) {
+            String type = refTile.typeOfThisTileInstance;
+            switch (type) {
+                case "C":
+                    tilesToDrawFrom = CONSONANTS;
+                    break;
+                case "V":
+                    tilesToDrawFrom = VOWELS;
+                    break;
+                case "T":
+                    tilesToDrawFrom = TONES;
+                    break;
+                default:
+                    tilesToDrawFrom = cumulativeStageBasedTileList;
+            }
+        } else {
+            tilesToDrawFrom = cumulativeStageBasedTileList;
+        }
+
+        for (Start.Tile t : tilesToDrawFrom) {
+            if (!alreadyAddedChoices.contains(t) && t.canBePlacedInPosition(tilesInRefWord, indexInParsedRefWordTileArray)) {
+                return t;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Finds a fitting alternative tile answer choice when an answer choice violates word position restrictions
+     * @param refTile the tile in the correct rendering of the word
+     * @param alreadyAddedChoices the other answer choices already selected (so we don't return a duplicate)
+     * @param contextualPosition the position we want to place the tile in
+     * @param typeMatters whether we are drawing from tiles of the same type only or all tiles
+     * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
+     */
+    public Start.Tile fittingTileAlternative(Start.Tile refTile, ArrayList<Start.Tile> alreadyAddedChoices, String contextualPosition, Boolean typeMatters) {
+
+        ArrayList<Start.Tile> tilesToDrawFrom;
+        if (typeMatters) {
+            String type = refTile.typeOfThisTileInstance;
+            switch (type) {
+                case "C":
+                    tilesToDrawFrom = CONSONANTS;
+                    break;
+                case "V":
+                    tilesToDrawFrom = VOWELS;
+                    break;
+                case "T":
+                    tilesToDrawFrom = TONES;
+                    break;
+                default:
+                    tilesToDrawFrom = cumulativeStageBasedTileList;
+            }
+        } else {
+            tilesToDrawFrom = cumulativeStageBasedTileList;
+        }
+
+        for (Start.Tile t : tilesToDrawFrom) {
+            if (!alreadyAddedChoices.contains(t) && t.canBePlacedInPosition(contextualPosition)) {
+                return t;
+            }
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Finds a fitting alternative syllable answer choice when an answer choice violates word position restrictions
+     * @param refSyllable the syllable in the correct rendering of the word
+     * @param alreadyAddedChoices the other answer choices already selected (so we don't return a duplicate)
+     * @param syllablesInRefWord
+     * @param indexInParsedRefWordSyllableArray
+     * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
+     */
+
+    public Start.Syllable fittingSyllableAlternative(Start.Syllable refSyllable, ArrayList<Start.Syllable> alreadyAddedChoices, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
+
+
+        for (Start.Syllable s : syllableList) {
+            if (!alreadyAddedChoices.contains(s) && s.canBePlacedInPosition(syllablesInRefWord, indexInParsedRefWordSyllableArray)) {
+                return s;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Finds a fitting alternative syllable answer choice when an answer choice violates word position restrictions
+     * @param refSyllable the syllable in the correct rendering of the word
+     * @param alreadyAddedChoices the other answer choices already selected (so we don't return a duplicate)
+     * @param contextualPosition the position we want to put the syllable into
+     * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
+     */
+
+    public Start.Syllable fittingSyllableAlternative(Start.Syllable refSyllable, ArrayList<Start.Syllable> alreadyAddedChoices, String contextualPosition) {
+
+
+        for (Start.Syllable s : syllableList) {
+            if (!alreadyAddedChoices.contains(s) && s.canBePlacedInPosition(contextualPosition)) {
+                return s;
+            }
+        }
+
+        return null;
     }
 
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -23,6 +23,7 @@ import androidx.constraintlayout.widget.ConstraintSet;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.List;
@@ -1488,46 +1489,20 @@ public abstract class GameActivity extends AppCompatActivity {
 
     /**
      * Finds a fitting alternative tile answer choice when an answer choice violates word position restrictions
-     * @param refTile the tile in the correct rendering of the word
-     * @param alreadyAddedChoices the other answer choices already selected (so we don't return a duplicate)
-     * @param tilesInRefWord
-     * @param indexInParsedRefWordTileArray
-     * @param typeMatters whether we are drawing from tiles of the same type only or all tiles
-     * @param usingDistractors whether we are drawing from distractor set or all tiles
+     * @param alreadyAddedChoices the other answer choices already selected and which indexes they corresponded to, se we don't duplicate answer choices
+     * @param tilesInRefWord the tiles in the reference word
+     * @param indexInParsedRefWordTileArray the index of the tile under question from the reference word
+     * @param tilesToDrawFrom the tiles from which an alternative may be selected
      * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
      */
 
-    public Start.Tile fittingTileAlternative(Start.Tile refTile, ArrayList<Start.Tile> alreadyAddedChoices, ArrayList<Start.Tile> tilesInRefWord, int indexInParsedRefWordTileArray, boolean typeMatters, boolean usingDistractors) {
-
-        ArrayList<Start.Tile> tilesToDrawFrom;
-        if (typeMatters) {
-            String type = refTile.typeOfThisTileInstance;
-            switch (type) {
-                case "C":
-                    tilesToDrawFrom = CONSONANTS;
-                    break;
-                case "V":
-                    tilesToDrawFrom = VOWELS;
-                    break;
-                case "T":
-                    tilesToDrawFrom = TONES;
-                    break;
-                default:
-                    tilesToDrawFrom = cumulativeStageBasedTileList;
-            }
-        } else if (usingDistractors) {
-            tilesToDrawFrom = new ArrayList<Start.Tile>();
-            for (int i=0; i<3; i++) {
-                tilesToDrawFrom.add(tileHashMap.get(refTile.distractors.get(0)));
-            }
-        } else {
-            tilesToDrawFrom = cumulativeStageBasedTileList;
-        }
+    public Start.Tile fittingTileAlternative(HashMap<Integer, Start.Tile> alreadyAddedChoices, ArrayList<Start.Tile> tilesInRefWord, int indexInParsedRefWordTileArray, ArrayList<Start.Tile> tilesToDrawFrom) {
 
         Collections.shuffle(tilesToDrawFrom);
 
         for (Start.Tile t : tilesToDrawFrom) {
-            if (!alreadyAddedChoices.contains(t) && t.canBePlacedInPosition(tilesInRefWord, indexInParsedRefWordTileArray)) {
+            if (!(alreadyAddedChoices.containsValue(t) && alreadyAddedChoices.containsKey(indexInParsedRefWordTileArray))
+                    && t.canBePlacedInPosition(tilesInRefWord, indexInParsedRefWordTileArray)) {
                 return t;
             }
         }
@@ -1537,41 +1512,14 @@ public abstract class GameActivity extends AppCompatActivity {
 
     /**
      * Finds a fitting alternative tile answer choice when an answer choice violates word position restrictions
-     * @param refTile the tile in the correct rendering of the word
      * @param alreadyAddedChoices the other answer choices already selected (so we don't return a duplicate)
      * @param contextualPosition the position we want to place the tile in
-     * @param typeMatters whether we are drawing from tiles of the same type only or all tiles
-     * @param usingDistractors whether we are drawing from the distractor set or all tiles
+     * @param tilesToDrawFrom the tiles from which an alternative may be selected
      * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
      */
-    public Start.Tile fittingTileAlternative(Start.Tile refTile, ArrayList<Start.Tile> alreadyAddedChoices, String contextualPosition, boolean typeMatters, boolean usingDistractors) {
+    public Start.Tile fittingTileAlternative(ArrayList<Start.Tile> alreadyAddedChoices, String contextualPosition, ArrayList<Start.Tile> tilesToDrawFrom) {
 
-        ArrayList<Start.Tile> tilesToDrawFrom;
-        if (typeMatters) {
-            String type = refTile.typeOfThisTileInstance;
-            switch (type) {
-                case "C":
-                    tilesToDrawFrom = CONSONANTS;
-                    break;
-                case "V":
-                    tilesToDrawFrom = VOWELS;
-                    break;
-                case "T":
-                    tilesToDrawFrom = TONES;
-                    break;
-                default:
-                    tilesToDrawFrom = cumulativeStageBasedTileList;
-            }
-        } else if (usingDistractors) {
-            tilesToDrawFrom = new ArrayList<Start.Tile>();
-            for (int i=0; i<3; i++) {
-                tilesToDrawFrom.add(tileHashMap.get(refTile.distractors.get(0)));
-            }
-        } else {
-            tilesToDrawFrom = cumulativeStageBasedTileList;
-        }
-
-        Collections.shuffle(tilesToDrawFrom);
+        Collections.shuffle((Start.TileList) tilesToDrawFrom.clone());
 
         for (Start.Tile t : tilesToDrawFrom) {
             if (!alreadyAddedChoices.contains(t) && t.canBePlacedInPosition(contextualPosition)) {
@@ -1586,17 +1534,18 @@ public abstract class GameActivity extends AppCompatActivity {
     /**
      * Finds a fitting alternative syllable answer choice when an answer choice violates word position restrictions
      * @param refSyllable the syllable in the correct rendering of the word
-     * @param alreadyAddedChoices the other answer choices already selected (so we don't return a duplicate)
+     * @param alreadyAddedChoices the other answer choices already selected and the indexes they correspond to (so we don't return a duplicate answer choice)
      * @param syllablesInRefWord
      * @param indexInParsedRefWordSyllableArray
      * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
      */
 
-    public Start.Syllable fittingSyllableAlternative(Start.Syllable refSyllable, ArrayList<Start.Syllable> alreadyAddedChoices, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
+    public Start.Syllable fittingSyllableAlternative(Start.Syllable refSyllable, HashMap<Integer, Start.Syllable> alreadyAddedChoices, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
 
         ArrayList<Start.Syllable> syllableListCopy = (Start.SyllableList) Start.syllableList.clone();
         for (Start.Syllable s : syllableListCopy) {
-            if (!alreadyAddedChoices.contains(s) && s.canBePlacedInPosition(syllablesInRefWord, indexInParsedRefWordSyllableArray)) {
+            if ((alreadyAddedChoices.containsValue(s) && alreadyAddedChoices.containsKey(indexInParsedRefWordSyllableArray))
+                    && s.canBePlacedInPosition(syllablesInRefWord, indexInParsedRefWordSyllableArray)) {
                 return s;
             }
         }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -1533,18 +1533,17 @@ public abstract class GameActivity extends AppCompatActivity {
 
     /**
      * Finds a fitting alternative syllable answer choice when an answer choice violates word position restrictions
-     * @param refSyllable the syllable in the correct rendering of the word
      * @param alreadyAddedChoices the other answer choices already selected and the indexes they correspond to (so we don't return a duplicate answer choice)
      * @param syllablesInRefWord
      * @param indexInParsedRefWordSyllableArray
      * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
      */
 
-    public Start.Syllable fittingSyllableAlternative(Start.Syllable refSyllable, HashMap<Integer, Start.Syllable> alreadyAddedChoices, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
+    public Start.Syllable fittingSyllableAlternative(HashMap<Integer, Start.Syllable> alreadyAddedChoices, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
 
         ArrayList<Start.Syllable> syllableListCopy = (Start.SyllableList) Start.syllableList.clone();
         for (Start.Syllable s : syllableListCopy) {
-            if ((alreadyAddedChoices.containsValue(s) && alreadyAddedChoices.containsKey(indexInParsedRefWordSyllableArray))
+            if (!(alreadyAddedChoices.containsValue(s) && alreadyAddedChoices.containsKey(indexInParsedRefWordSyllableArray))
                     && s.canBePlacedInPosition(syllablesInRefWord, indexInParsedRefWordSyllableArray)) {
                 return s;
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -23,7 +23,6 @@ import androidx.constraintlayout.widget.ConstraintSet;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.List;
@@ -34,37 +33,9 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
 
-import static org.alphatilesapps.alphatiles.Start.CONSONANTS;
-import static org.alphatilesapps.alphatiles.Start.MULTITYPE_TILES;
-import static org.alphatilesapps.alphatiles.Start.NON_SPACERS_ARABIC;
-import static org.alphatilesapps.alphatiles.Start.SILENT_PRELIMINARY_TILES;
-import static org.alphatilesapps.alphatiles.Start.TONES;
-import static org.alphatilesapps.alphatiles.Start.VOWELS;
-import static org.alphatilesapps.alphatiles.Start.colorList;
-import static org.alphatilesapps.alphatiles.Start.differentiatesTileTypes;
-import static org.alphatilesapps.alphatiles.Start.gameList;
-import static org.alphatilesapps.alphatiles.Start.non_joining_arabic_letters;
-import static org.alphatilesapps.alphatiles.Start.non_spacing_arabic_letters;
-import static org.alphatilesapps.alphatiles.Start.right_joining_arabic_letters;
-import static org.alphatilesapps.alphatiles.Start.stageCorrespondenceRatio;
-import static org.alphatilesapps.alphatiles.Start.syllableList;
-import static org.alphatilesapps.alphatiles.Start.tileAudioIDs;
-import static org.alphatilesapps.alphatiles.Start.tileDurations;
-import static org.alphatilesapps.alphatiles.Start.placeholderCharacter;
-import static org.alphatilesapps.alphatiles.Start.contextualizingCharacter;
-import static org.alphatilesapps.alphatiles.Start.tileHashMap;
-import static org.alphatilesapps.alphatiles.Start.tileList;
-import static org.alphatilesapps.alphatiles.Start.tileStagesLists;
-import static org.alphatilesapps.alphatiles.Start.wordList;
-import static org.alphatilesapps.alphatiles.Start.wordStagesLists;
+
+import static org.alphatilesapps.alphatiles.Start.*;
 import static org.alphatilesapps.alphatiles.Testing.tempSoundPoolSwitch;
-import static org.alphatilesapps.alphatiles.Start.correctFinalSoundID;
-import static org.alphatilesapps.alphatiles.Start.correctSoundDuration;
-import static org.alphatilesapps.alphatiles.Start.correctSoundID;
-import static org.alphatilesapps.alphatiles.Start.gameSounds;
-import static org.alphatilesapps.alphatiles.Start.incorrectSoundID;
-import static org.alphatilesapps.alphatiles.Start.wordAudioIDs;
-import static org.alphatilesapps.alphatiles.Start.after12checkedTrackers;
 
 
 public abstract class GameActivity extends AppCompatActivity {
@@ -830,14 +801,14 @@ public abstract class GameActivity extends AppCompatActivity {
     protected boolean tileShouldPlayAudio(Start.Tile tile) {
         // make sure audio can be found
         if (tempSoundPoolSwitch && tile.audioForThisTileType.equals("X")) {
-                return false;
+            return false;
         }
 
         if(!tempSoundPoolSwitch) {
             try{
                 getResources().getIdentifier(tile.audioForThisTileType, "raw", getPackageName());
             } catch (NullPointerException e) {
-                 return false;
+                return false;
             }
         }
 
@@ -1047,11 +1018,11 @@ public abstract class GameActivity extends AppCompatActivity {
             } else {
                 replacingLVwithOtherV = replacedTile.typeOfThisTileInstance.equals("LV");
                 replacingOtherVwithLV = tilesInThisWordOption.get(indexOfReplacedTile).typeOfThisTileInstance.equals("LV")
-                                        && replacedTile.typeOfThisTileInstance.matches("(AV|BV|FV|V)");
+                        && replacedTile.typeOfThisTileInstance.matches("(AV|BV|FV|V)");
             }
 
             if ((replacingLVwithOtherV && index == indexOfReplacedTile && (thisTile.typeOfThisTileInstance.matches("(AV|BV|FV|V)")))
-            || (replacingOtherVwithLV && index==indexOfReplacedTile-1 && thisTile.typeOfThisTileInstance.matches("(C|PC)"))) {
+                    || (replacingOtherVwithLV && index==indexOfReplacedTile-1 && thisTile.typeOfThisTileInstance.matches("(C|PC)"))) {
                 previousString = stringToAppend;
                 previousTile = thisTile;
                 // Don't append this string. (That would put FV, etc. in LV position or LV in FV,etc position)
@@ -1094,12 +1065,12 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     /**
-    ADs (Above/Following Diacritics) should be placed above AVs (Above Vowels).
-    If a gametiles list stores C+AD tiles, assembling these C+AD tiles with AV tiles or complex vowels
-    will put ADs and AVS in the reverse order.
-    This method fixes that.
+     ADs (Above/Following Diacritics) should be placed above AVs (Above Vowels).
+     If a gametiles list stores C+AD tiles, assembling these C+AD tiles with AV tiles or complex vowels
+     will put ADs and AVS in the reverse order.
+     This method fixes that.
 
-    s: String to check and fix the stacking in, if necessary
+     s: String to check and fix the stacking in, if necessary
      **/
     public static String stackInProperSequence(String assembledWordInProgress, Start.Word wordListWord) {
 
@@ -1119,7 +1090,7 @@ public abstract class GameActivity extends AppCompatActivity {
                 }
             }
             if (tileHashMap.containsKey(String.valueOf(correctlyStackedString.charAt(0)))
-             || tileHashMap.containsKey(placeholderCharacter + String.valueOf(correctlyStackedString.charAt(0)))) {
+                    || tileHashMap.containsKey(placeholderCharacter + String.valueOf(correctlyStackedString.charAt(0)))) {
                 Start.Tile firstCharAsTile = tileHashMap.get(String.valueOf(correctlyStackedString.charAt(0)));
                 if (firstCharAsTile==null) {
                     firstCharAsTile = tileHashMap.get(placeholderCharacter + String.valueOf(correctlyStackedString.charAt(0)));
@@ -1136,9 +1107,9 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     /**
-    AVs should be stacked before ADs, not the other way around.
-    ADs should not be placed on top of FVs, but only on top of a C+(AV)+(AD) base.
-    This initializes the prohibitedCharSequences ArrayList with the prohibited stacking combinations in wordListWord.
+     AVs should be stacked before ADs, not the other way around.
+     ADs should not be placed on top of FVs, but only on top of a C+(AV)+(AD) base.
+     This initializes the prohibitedCharSequences ArrayList with the prohibited stacking combinations in wordListWord.
      **/
     public static ArrayList<String> generateProhibitedCharSequences(Start.Word wordListWord) {
         ArrayList<String> prohibitedCharSequences = new ArrayList<>();
@@ -1197,7 +1168,7 @@ public abstract class GameActivity extends AppCompatActivity {
         // Add other non-ambiguous AV, AD, FV, and BV tiles to avoid
         for(Start.Tile tile : tileList) {
             if (!MULTITYPE_TILES.contains(tile.text) && tile.text.length()==1
-            || (tile.text.contains(placeholderCharacter) && tile.text.length()==2)) {
+                    || (tile.text.contains(placeholderCharacter) && tile.text.length()==2)) {
                 String thisTileString = tile.text.replace(placeholderCharacter, "");
                 switch (tile.tileType) {
                     case "AV":
@@ -1241,10 +1212,10 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     /**
-    Sometimes, the assembled version of words differs slightly from what's in the wordlist, because of invisible character stacking differences.
-    This method takes a word and returns the parsed and reassembled version so that when compared to other assembled tile lists, it will match up.
+     Sometimes, the assembled version of words differs slightly from what's in the wordlist, because of invisible character stacking differences.
+     This method takes a word and returns the parsed and reassembled version so that when compared to other assembled tile lists, it will match up.
 
-    word: The word object whose wordInLOP you would like to represent in standardized assembled form
+     word: The word object whose wordInLOP you would like to represent in standardized assembled form
      **/
     protected String wordInLOPWithStandardizedSequenceOfCharacters(Start.Word wordListWord) {
 
@@ -1316,13 +1287,13 @@ public abstract class GameActivity extends AppCompatActivity {
             if (indexInWord==(stringPieces.size()-1)) { // WORD-FINAL
                 // Handle previous right-joiners:
                 if(Arrays.asList(right_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i-1]))
-                    || Arrays.asList(non_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i-1]))) {
+                        || Arrays.asList(non_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i-1]))) {
                     return isolateWordPieceString;
                 }
                 if (indexInWord>1) {
                     if (Arrays.asList(non_spacing_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i - 1]))
                             && (Arrays.asList(right_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i - 2]))
-                               || Arrays.asList(non_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i - 2])))
+                            || Arrays.asList(non_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i - 2])))
                     ) {
                         return isolateWordPieceString;
                     }
@@ -1333,13 +1304,13 @@ public abstract class GameActivity extends AppCompatActivity {
                 boolean atLeastInitialNotMedial = false;
                 // Handle previous right-joiners:
                 if(Arrays.asList(right_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i-1]))
-                    || Arrays.asList(non_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i-1]))){
+                        || Arrays.asList(non_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i-1]))){
                     atLeastInitialNotMedial = true;
                 }
                 if (indexInWord>1) {
                     if (Arrays.asList(non_spacing_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i - 1]))
                             && (Arrays.asList(right_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i - 2]))
-                                || Arrays.asList(non_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i-1])))
+                            || Arrays.asList(non_joining_arabic_letters).contains(String.valueOf(previousTwoPlusChars[i-1])))
                     ) {
                         atLeastInitialNotMedial = true;
                     }
@@ -1375,18 +1346,18 @@ public abstract class GameActivity extends AppCompatActivity {
                     }
                 }
 
-               // Decide on correct form based on surrounding characters
-               if (atLeastInitialNotMedial) {
-                   if (atLeastFinalNotMedial) {
-                       return isolateWordPieceString; // Doesn't join before or after
-                   } else {
-                       return contextualizedForm_Initial(isolateWordPieceString); // Only joins after
-                   }
-               } else if (atLeastFinalNotMedial) {
-                   return contextualizedForm_Final(isolateWordPieceString); // Only joins before
-               } else {
-                   return contextualizedForm_Medial(isolateWordPieceString); // joins before and after
-               }
+                // Decide on correct form based on surrounding characters
+                if (atLeastInitialNotMedial) {
+                    if (atLeastFinalNotMedial) {
+                        return isolateWordPieceString; // Doesn't join before or after
+                    } else {
+                        return contextualizedForm_Initial(isolateWordPieceString); // Only joins after
+                    }
+                } else if (atLeastFinalNotMedial) {
+                    return contextualizedForm_Final(isolateWordPieceString); // Only joins before
+                } else {
+                    return contextualizedForm_Medial(isolateWordPieceString); // joins before and after
+                }
             }
         }
     }
@@ -1402,13 +1373,13 @@ public abstract class GameActivity extends AppCompatActivity {
 
         String finalCharacter = isolateForm.substring(isolateForm.length() - 1);
         if(Arrays.asList(non_joining_arabic_letters).contains(isolateForm)
-        || Arrays.asList(right_joining_arabic_letters).contains(finalCharacter)) {
+                || Arrays.asList(right_joining_arabic_letters).contains(finalCharacter)) {
             return isolateForm;
         } else if (Arrays.asList(non_spacing_arabic_letters).contains(finalCharacter)) {
             if(isolateForm.length() > 1){
                 String penultimateCharacter = isolateForm.substring(isolateForm.length() - 2, isolateForm.length() - 1);
                 if (Arrays.asList(right_joining_arabic_letters).contains(penultimateCharacter)
-                || Arrays.asList(non_joining_arabic_letters).contains(penultimateCharacter)) {
+                        || Arrays.asList(non_joining_arabic_letters).contains(penultimateCharacter)) {
                     return isolateForm;
                 } else {
                     return isolateForm + contextualizingCharacter;
@@ -1489,19 +1460,20 @@ public abstract class GameActivity extends AppCompatActivity {
 
     /**
      * Finds a fitting alternative tile answer choice when an answer choice violates word position restrictions
-     * @param alreadyAddedChoices the other answer choices already selected and which indexes they corresponded to, se we don't duplicate answer choices
+     * @param alreadyAddedPlacements the other answer choices already selected and which indexes they corresponded to, se we don't duplicate answer choices
      * @param tilesInRefWord the tiles in the reference word
      * @param indexInParsedRefWordTileArray the index of the tile under question from the reference word
      * @param tilesToDrawFrom the tiles from which an alternative may be selected
      * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
      */
 
-    public Start.Tile fittingTileAlternative(HashMap<Integer, Start.Tile> alreadyAddedChoices, ArrayList<Start.Tile> tilesInRefWord, int indexInParsedRefWordTileArray, ArrayList<Start.Tile> tilesToDrawFrom) {
+    public Start.Tile fittingTileAlternative(WordPieceStringPositionSet alreadyAddedPlacements, ArrayList<Start.Tile> tilesInRefWord, int indexInParsedRefWordTileArray, ArrayList<Start.Tile> tilesToDrawFrom) {
 
         Collections.shuffle(tilesToDrawFrom);
 
         for (Start.Tile t : tilesToDrawFrom) {
-            if (!(alreadyAddedChoices.containsValue(t) && alreadyAddedChoices.containsKey(indexInParsedRefWordTileArray))
+            WordPieceStringPosition placement = new WordPieceStringPosition(indexInParsedRefWordTileArray, t.text);
+            if (!(alreadyAddedPlacements.contains(placement))
                     && t.canBePlacedInPosition(tilesInRefWord, indexInParsedRefWordTileArray)) {
                 return t;
             }
@@ -1533,17 +1505,17 @@ public abstract class GameActivity extends AppCompatActivity {
 
     /**
      * Finds a fitting alternative syllable answer choice when an answer choice violates word position restrictions
-     * @param alreadyAddedChoices the other answer choices already selected and the indexes they correspond to (so we don't return a duplicate answer choice)
-     * @param syllablesInRefWord
-     * @param indexInParsedRefWordSyllableArray
+     * @param alreadyAddedPlacements the other answer choices already selected and the indexes they correspond to (so we don't return a duplicate answer choice)
+     * @param syllablesInRefWord the syllables in the correctly spelled word
+     * @param indexInParsedRefWordSyllableArray the index in the reference word of the syllable under consideration
      * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
      */
 
-    public Start.Syllable fittingSyllableAlternative(HashMap<Integer, Start.Syllable> alreadyAddedChoices, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
+    public Start.Syllable fittingSyllableAlternative(WordPieceStringPositionSet alreadyAddedPlacements, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
 
         ArrayList<Start.Syllable> syllableListCopy = (Start.SyllableList) Start.syllableList.clone();
         for (Start.Syllable s : syllableListCopy) {
-            if (!(alreadyAddedChoices.containsValue(s) && alreadyAddedChoices.containsKey(indexInParsedRefWordSyllableArray))
+            if (!(alreadyAddedPlacements.contains(new WordPieceStringPosition(indexInParsedRefWordSyllableArray, s.text)))
                     && s.canBePlacedInPosition(syllablesInRefWord, indexInParsedRefWordSyllableArray)) {
                 return s;
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -22,6 +22,7 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.List;
@@ -1492,10 +1493,11 @@ public abstract class GameActivity extends AppCompatActivity {
      * @param tilesInRefWord
      * @param indexInParsedRefWordTileArray
      * @param typeMatters whether we are drawing from tiles of the same type only or all tiles
+     * @param usingDistractors whether we are drawing from distractor set or all tiles
      * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
      */
 
-    public Start.Tile fittingTileAlternative(Start.Tile refTile, ArrayList<Start.Tile> alreadyAddedChoices, ArrayList<Start.Tile> tilesInRefWord, int indexInParsedRefWordTileArray, Boolean typeMatters) {
+    public Start.Tile fittingTileAlternative(Start.Tile refTile, ArrayList<Start.Tile> alreadyAddedChoices, ArrayList<Start.Tile> tilesInRefWord, int indexInParsedRefWordTileArray, boolean typeMatters, boolean usingDistractors) {
 
         ArrayList<Start.Tile> tilesToDrawFrom;
         if (typeMatters) {
@@ -1513,9 +1515,16 @@ public abstract class GameActivity extends AppCompatActivity {
                 default:
                     tilesToDrawFrom = cumulativeStageBasedTileList;
             }
+        } else if (usingDistractors) {
+            tilesToDrawFrom = new ArrayList<Start.Tile>();
+            for (int i=0; i<3; i++) {
+                tilesToDrawFrom.add(tileHashMap.get(refTile.distractors.get(0)));
+            }
         } else {
             tilesToDrawFrom = cumulativeStageBasedTileList;
         }
+
+        Collections.shuffle(tilesToDrawFrom);
 
         for (Start.Tile t : tilesToDrawFrom) {
             if (!alreadyAddedChoices.contains(t) && t.canBePlacedInPosition(tilesInRefWord, indexInParsedRefWordTileArray)) {
@@ -1532,9 +1541,10 @@ public abstract class GameActivity extends AppCompatActivity {
      * @param alreadyAddedChoices the other answer choices already selected (so we don't return a duplicate)
      * @param contextualPosition the position we want to place the tile in
      * @param typeMatters whether we are drawing from tiles of the same type only or all tiles
+     * @param usingDistractors whether we are drawing from the distractor set or all tiles
      * @return a fresh tile answer choice that complies with position restrictions OR null (in which case there is no fitting alternative)
      */
-    public Start.Tile fittingTileAlternative(Start.Tile refTile, ArrayList<Start.Tile> alreadyAddedChoices, String contextualPosition, Boolean typeMatters) {
+    public Start.Tile fittingTileAlternative(Start.Tile refTile, ArrayList<Start.Tile> alreadyAddedChoices, String contextualPosition, boolean typeMatters, boolean usingDistractors) {
 
         ArrayList<Start.Tile> tilesToDrawFrom;
         if (typeMatters) {
@@ -1552,9 +1562,16 @@ public abstract class GameActivity extends AppCompatActivity {
                 default:
                     tilesToDrawFrom = cumulativeStageBasedTileList;
             }
+        } else if (usingDistractors) {
+            tilesToDrawFrom = new ArrayList<Start.Tile>();
+            for (int i=0; i<3; i++) {
+                tilesToDrawFrom.add(tileHashMap.get(refTile.distractors.get(0)));
+            }
         } else {
             tilesToDrawFrom = cumulativeStageBasedTileList;
         }
+
+        Collections.shuffle(tilesToDrawFrom);
 
         for (Start.Tile t : tilesToDrawFrom) {
             if (!alreadyAddedChoices.contains(t) && t.canBePlacedInPosition(contextualPosition)) {
@@ -1577,8 +1594,8 @@ public abstract class GameActivity extends AppCompatActivity {
 
     public Start.Syllable fittingSyllableAlternative(Start.Syllable refSyllable, ArrayList<Start.Syllable> alreadyAddedChoices, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
 
-
-        for (Start.Syllable s : syllableList) {
+        ArrayList<Start.Syllable> syllableListCopy = (Start.SyllableList) Start.syllableList.clone();
+        for (Start.Syllable s : syllableListCopy) {
             if (!alreadyAddedChoices.contains(s) && s.canBePlacedInPosition(syllablesInRefWord, indexInParsedRefWordSyllableArray)) {
                 return s;
             }
@@ -1597,8 +1614,8 @@ public abstract class GameActivity extends AppCompatActivity {
 
     public Start.Syllable fittingSyllableAlternative(Start.Syllable refSyllable, ArrayList<Start.Syllable> alreadyAddedChoices, String contextualPosition) {
 
-
-        for (Start.Syllable s : syllableList) {
+        ArrayList<Start.Syllable> syllableListCopy = (Start.SyllableList) Start.syllableList.clone();
+        for (Start.Syllable s : syllableListCopy) {
             if (!alreadyAddedChoices.contains(s) && s.canBePlacedInPosition(contextualPosition)) {
                 return s;
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 
@@ -230,21 +231,16 @@ public class Georgia extends GameActivity {
 
     private void setUpSyllables() {
 
-
-
-        ArrayList<Start.Syllable> alreadyAddedChoices = new ArrayList<>();
-        // Add them to buttons
-
-
-
             if (challengeLevel == 1 || challengeLevel == 2 || challengeLevel == 3) { // Find and add random alternatives
+
+                ArrayList<Start.Syllable> alreadyAddedChoices = new ArrayList<>();
 
                 for (int b = 0; b < GAME_BUTTONS.length; b++) {
                     TextView gameButton = findViewById(GAME_BUTTONS[b]);
                     if (b < visibleGameButtons) {
                         Start.Syllable option = fittingSyllableAlternative(initialSyllable, alreadyAddedChoices, "INITIAL");
-                        if (option.hasNull()) {
-                            if (b < 3) { // Less then three alternatives can go in INITIAL position
+                        if (Objects.isNull(option)) {
+                            if (b < 4) { // Less then three alternatives can go in INITIAL position
                                 playAgain();
                                 return;
                             } else { // Viable alternatives beyond 3 are not found. Hide these last buttons.
@@ -376,8 +372,8 @@ public class Georgia extends GameActivity {
                     TextView gameButton = findViewById(GAME_BUTTONS[b]);
                     if (b < visibleGameButtons) {
                         Start.Tile option = fittingTileAlternative(alreadyAddedChoices, "INITIAL", CorV);
-                        if (option.hasNull()) {
-                            if (b < 3) { // Less than 4 answer choices available in word-initial position; restart with a new word
+                        if (Objects.isNull(option)) {
+                            if (b < 4) { // Less than 4 answer choices available in word-initial position; restart with a new word
                                 playAgain();
                                 return;
                             } else { // Viable answer choice beyond 4 not found

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -18,6 +18,7 @@ import static org.alphatilesapps.alphatiles.Start.sendAnalytics;
 import static org.alphatilesapps.alphatiles.Start.colorList;
 import static org.alphatilesapps.alphatiles.Start.CorV;
 import static org.alphatilesapps.alphatiles.Start.syllableHashMap;
+import static org.alphatilesapps.alphatiles.Start.tileHashMap;
 import static org.alphatilesapps.alphatiles.Start.useContextualFormsITI;
 
 import com.segment.analytics.Analytics;
@@ -51,7 +52,6 @@ import com.segment.analytics.Properties;
 public class Georgia extends GameActivity {
 
     Start.SyllableList syllableListCopy; //JP
-    Set<String> challengingAnswerChoices = new HashSet<String>();
     Start.Tile initialTile;
     Start.Syllable initialSyllable;
 
@@ -229,270 +229,283 @@ public class Georgia extends GameActivity {
     }
 
     private void setUpSyllables() {
-        boolean correctSyllableRepresented = false;
 
-        // To the challengingAnswerChoices Set, first add the distractors, then syllables with the same initial or final characters,
-        // then random.
-        // Note that duplicates will automatically be excluded because challengingAnswerChoices is a Set.
 
-        // First, add correct answer and distractors
-        challengingAnswerChoices.clear();
-        challengingAnswerChoices.add(initialSyllable.text);
-        for (int d=0; d<3; d++) {
-            if(syllableHashMap.get(initialSyllable.distractors.get(d)).canBePlacedInPosition("INITIAL")) {
-                challengingAnswerChoices.add(initialSyllable.distractors.get(d));
-            }
-        }
-
-        // Then, add syllables with the same 2 initial characters
-        int i = 0;
-        while (challengingAnswerChoices.size() < visibleGameButtons && i < syllableListCopy.size()) {
-            String option = syllableListCopy.get(i).text;
-            if(option.length()>=2 && initialSyllable.text.length()>=2) {
-                if(option.charAt(0) == initialSyllable.text.charAt(0)
-                        && option.charAt(1) == initialSyllable.text.charAt(1)
-                        && syllableHashMap.get(option).canBePlacedInPosition("INITIAL")) {
-                    challengingAnswerChoices.add(option);
-                }
-            }
-            i++;
-        }
-
-        // The, add syllables with the same one initial or final character
-        i = 0;
-        while (challengingAnswerChoices.size() < visibleGameButtons && i < syllableListCopy.size()) {
-            String option = syllableListCopy.get(i).text;
-            if (syllableHashMap.get(option).canBePlacedInPosition("INITIAL")) {
-                if (option.charAt(0) == initialSyllable.text.charAt(0)) {
-                    challengingAnswerChoices.add(option);
-                } else if (option.charAt(option.length() - 1) == initialSyllable.text.charAt(initialSyllable.text.length() - 1)) {
-                    challengingAnswerChoices.add(option);
-                }
-            }
-            i++;
-        }
-
-        // Finally, fill any remaining empty game buttons with random syllables
-        int j = 0;
-        while (challengingAnswerChoices.size()<visibleGameButtons && j<syllableListCopy.size()) {
-            if (syllableListCopy.get(j).canBePlacedInPosition("INITIAL")) {
-                challengingAnswerChoices.add(syllableListCopy.get(j).text);
-            }
-            j++;
-        }
-
-        // Make the gameButtons contain contextual forms for some Arabic script apps
-        Set<String> contextualizedChallengingChoices = new HashSet<String>();
-        if(useContextualFormsITI){
-            for (String answerChoiceString : challengingAnswerChoices) {
-                contextualizedChallengingChoices.add(contextualizedForm_Initial(answerChoiceString));
-            }
-            challengingAnswerChoices = contextualizedChallengingChoices;
-        }
-
-        List<String> challengingAnswerChoicesList = new ArrayList<>(challengingAnswerChoices); // to index the answer choices
 
         ArrayList<Start.Syllable> alreadyAddedChoices = new ArrayList<>();
         // Add them to buttons
-        for (int t = 0; t < GAME_BUTTONS.length; t++) {
 
-            TextView gameTile = findViewById(GAME_BUTTONS[t]);
-            String tileColorStr = colorList.get(t % 5);
-            int tileColor = Color.parseColor(tileColorStr);
+
 
             if (challengeLevel == 1 || challengeLevel == 2 || challengeLevel == 3) { // Find and add random alternatives
-                if (t < visibleGameButtons) {
-                    Start.Syllable option = fittingSyllableAlternative(initialSyllable, alreadyAddedChoices, "INITIAL");
-                    if (option.hasNull()) {
-                        if (t < 3) {
-                            playAgain();
-                            return;
-                        } else {
-                            gameTile.setText(String.valueOf(t + 1));
-                            gameTile.setBackgroundResource(R.drawable.textview_border);
-                            gameTile.setTextColor(Color.parseColor("#000000")); // black
-                            gameTile.setClickable(false);
-                            gameTile.setVisibility(View.INVISIBLE);
+
+                for (int b = 0; b < GAME_BUTTONS.length; b++) {
+                    TextView gameButton = findViewById(GAME_BUTTONS[b]);
+                    if (b < visibleGameButtons) {
+                        Start.Syllable option = fittingSyllableAlternative(initialSyllable, alreadyAddedChoices, "INITIAL");
+                        if (option.hasNull()) {
+                            if (b < 3) { // Less then three alternatives can go in INITIAL position
+                                playAgain();
+                                return;
+                            } else { // Viable alternatives beyond 3 are not found. Hide these last buttons.
+                                gameButton.setText(String.valueOf(b + 1));
+                                gameButton.setBackgroundResource(R.drawable.textview_border);
+                                gameButton.setTextColor(Color.parseColor("#000000")); // black
+                                gameButton.setClickable(false);
+                                gameButton.setVisibility(View.INVISIBLE);
+                            }
+                        } else { // Display viable options.
+                            String syllableOptionText = option.text;
+                            if (useContextualFormsITI) { // For some Arabic script apps
+                                gameButton.setText(contextualizedForm_Initial(syllableOptionText));
+                            } else {
+                                gameButton.setText(syllableOptionText);
+                            }
+                            gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
+                            gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
+                            gameButton.setVisibility(View.VISIBLE);
+                            gameButton.setClickable(true);
+                            alreadyAddedChoices.add(option);
                         }
                     } else {
-                        String syllableOptionText = option.text;
-                        if (useContextualFormsITI) { // For some Arabic script apps
-                            gameTile.setText(contextualizedForm_Initial(syllableOptionText));
-                        } else {
-                            gameTile.setText(syllableOptionText);
-                        }
-                        gameTile.setBackgroundColor(tileColor);
-                        gameTile.setTextColor(Color.parseColor("#FFFFFF")); // white
-                        gameTile.setVisibility(View.VISIBLE);
-                        gameTile.setClickable(true);
-                        alreadyAddedChoices.add(option);
+                        gameButton.setText(String.valueOf(b + 1));
+                        gameButton.setBackgroundResource(R.drawable.textview_border);
+                        gameButton.setTextColor(Color.parseColor("#000000")); // black
+                        gameButton.setClickable(false);
+                        gameButton.setVisibility(View.INVISIBLE);
                     }
-                    if (alreadyAddedChoices.contains(initialSyllable)) {
-                        correctSyllableRepresented = true;
-                    }
-                } else {
-                    gameTile.setText(String.valueOf(t + 1));
-                    gameTile.setBackgroundResource(R.drawable.textview_border);
-                    gameTile.setTextColor(Color.parseColor("#000000")); // black
-                    gameTile.setClickable(false);
-                    gameTile.setVisibility(View.INVISIBLE);
                 }
-            } else { // Alternatives are challenging
-                if (t < visibleGameButtons) {
-                    gameTile.setText(challengingAnswerChoicesList.get(t)); // KP
-                    gameTile.setBackgroundColor(tileColor);
-                    gameTile.setTextColor(Color.parseColor("#FFFFFF")); // white
-                    gameTile.setVisibility(View.VISIBLE);
-                } else {
-                    gameTile.setText(String.valueOf(t + 1));
-                    gameTile.setBackgroundResource(R.drawable.textview_border);
-                    gameTile.setTextColor(Color.parseColor("#000000")); // black
-                    gameTile.setClickable(false);
-                    gameTile.setVisibility(View.INVISIBLE);
+
+                if (!alreadyAddedChoices.contains(initialSyllable)) { // If the correct syllable wasn't randomly added as an answer choice, then here it overwrites one of the others
+                    Random rand = new Random();
+                    int randomNum = rand.nextInt(visibleGameButtons - 1); // KP
+                    TextView gameButton = findViewById(GAME_BUTTONS[randomNum]);
+                    gameButton.setText(initialSyllable.text);
+                }
+            } else { // Challenge levels 4, 5, and 6
+                // Alternatives are challenging: first  distractors, then syllables with the same initial or final characters, then random.
+
+                // First, add correct answer and distractors
+                Set<String> challengingAnswerChoices = new HashSet<String>(); // Duplicates will be prevented since this is a Set
+                challengingAnswerChoices.add(initialSyllable.text);
+                for (int d=0; d<3; d++) {
+                    if(syllableHashMap.get(initialSyllable.distractors.get(d)).canBePlacedInPosition("INITIAL")) {
+                        challengingAnswerChoices.add(initialSyllable.distractors.get(d));
+                    }
+                }
+
+                // Then, add syllables with the same 2 initial characters
+                int i = 0;
+                while (challengingAnswerChoices.size() < visibleGameButtons && i < syllableListCopy.size()) {
+                    String option = syllableListCopy.get(i).text;
+                    if(option.length()>=2 && initialSyllable.text.length()>=2) {
+                        if(option.charAt(0) == initialSyllable.text.charAt(0)
+                                && option.charAt(1) == initialSyllable.text.charAt(1)
+                                && syllableHashMap.get(option).canBePlacedInPosition("INITIAL")) {
+                            challengingAnswerChoices.add(option);
+                        }
+                    }
+                    i++;
+                }
+
+                // The, add syllables with the same one initial or final character
+                i = 0;
+                while (challengingAnswerChoices.size() < visibleGameButtons && i < syllableListCopy.size()) {
+                    String option = syllableListCopy.get(i).text;
+                    if (syllableHashMap.get(option).canBePlacedInPosition("INITIAL")) {
+                        if (option.charAt(0) == initialSyllable.text.charAt(0)) {
+                            challengingAnswerChoices.add(option);
+                        } else if (option.charAt(option.length() - 1) == initialSyllable.text.charAt(initialSyllable.text.length() - 1)) {
+                            challengingAnswerChoices.add(option);
+                        }
+                    }
+                    i++;
+                }
+
+                // Finally, fill any remaining empty game buttons with random syllables
+                int j = 0;
+                while (challengingAnswerChoices.size()<visibleGameButtons && j<syllableListCopy.size()) {
+                    if (syllableListCopy.get(j).canBePlacedInPosition("INITIAL")) {
+                        challengingAnswerChoices.add(syllableListCopy.get(j).text);
+                    }
+                    j++;
+                }
+
+                // Make the gameButtons contain contextual forms for some Arabic script apps
+                Set<String> contextualizedChallengingChoices = new HashSet<String>();
+                if(useContextualFormsITI){
+                    for (String answerChoiceString : challengingAnswerChoices) {
+                        contextualizedChallengingChoices.add(contextualizedForm_Initial(answerChoiceString));
+                    }
+                    challengingAnswerChoices = contextualizedChallengingChoices;
+                }
+
+                List<String> challengingAnswerChoicesList = new ArrayList<>(challengingAnswerChoices); // Index and shuffle
+                Collections.shuffle(challengingAnswerChoicesList);
+
+                for (int b = 0; b < GAME_BUTTONS.length; b++) { // Add the choices to buttons
+
+                    TextView gameButton = findViewById(GAME_BUTTONS[b]);
+
+                    if (b < visibleGameButtons && b < challengingAnswerChoicesList.size()) {
+                        gameButton.setText(challengingAnswerChoicesList.get(b)); // KP
+                        gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
+                        gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
+                        gameButton.setVisibility(View.VISIBLE);
+                    } else {
+                        gameButton.setText(String.valueOf(b + 1));
+                        gameButton.setBackgroundResource(R.drawable.textview_border);
+                        gameButton.setTextColor(Color.parseColor("#000000")); // black
+                        gameButton.setClickable(false);
+                        gameButton.setVisibility(View.INVISIBLE);
+                    }
                 }
             }
-        }
-
-        if (!correctSyllableRepresented) { // If the correct syllable didn't randomly come up for less-challenging levels, then here the correct syllable overwrites one of the others
-            Random rand = new Random();
-            int randomNum = rand.nextInt(visibleGameButtons - 1); // KP
-            TextView gameButton = findViewById(GAME_BUTTONS[randomNum]);
-            gameButton.setText(initialSyllable.text);
-        }
 
     }
 
 
     private void setUpTiles() {
 
-        boolean correctTileRepresented = false;
-
-        // For harder challenge levels, first add distractors, then add tiles that start with the same chars, then add random tiles
-        // Duplicates will automatically not be added because challengingAnswerChoices is a Set
-        challengingAnswerChoices.clear();
-        // First add the correct answer and distractors
-        challengingAnswerChoices.add(initialTile.text);
-        challengingAnswerChoices.add(initialTile.distractors.get(0));
-        challengingAnswerChoices.add(initialTile.distractors.get(1));
-        challengingAnswerChoices.add(initialTile.distractors.get(2));
-
-
-        // Then add tiles that begin with the same two chars, if they exist
-        int i = 0;
-        while (challengingAnswerChoices.size() < visibleGameButtons && i < CorV.size()) {
-            Random rand = new Random();
-            int index = rand.nextInt(CorV.size() - 1);
-            String option = CorV.get(index).text;
-            if(option.length()>=2 && initialTile.text.length()>=2) {
-                if(option.charAt(0) == initialTile.text.charAt(0)
-                        && option.charAt(1) == initialTile.text.charAt(1)) {
-                    challengingAnswerChoices.add(option);
-                }
-            }
-            i++;
-        }
-
-        // Then add tiles that begin or end with the same char
-        i = 0;
-        while (challengingAnswerChoices.size() < visibleGameButtons && i < CorV.size()) {
-            Random rand = new Random();
-            int index = rand.nextInt(CorV.size() - 1);
-            String option = CorV.get(index).text;
-            if (option.charAt(0) == initialTile.text.charAt(0)) {
-                challengingAnswerChoices.add(option);
-            } else if (option.charAt(option.length() - 1) == initialTile.text.charAt(initialTile.text.length() - 1)) {
-                challengingAnswerChoices.add(option);
-            }
-            i++;
-        }
-
-        // Then fill the remaining options with random tiles
-        while (challengingAnswerChoices.size() < visibleGameButtons) {
-            Random rand = new Random();
-            int index = rand.nextInt(CorV.size() - 1);
-            challengingAnswerChoices.add(CorV.get(index).text);
-        }
-
-        // Make the gameButtons contain contextual forms for some Arabic script apps
-        Set<String> contextualizedChallengingChoices = new HashSet<String>();
-        if(useContextualFormsITI) { // For some Arabic script apps
-            for (String answerChoiceString : challengingAnswerChoices) {
-                contextualizedChallengingChoices.add(contextualizedForm_Initial(answerChoiceString));
-            }
-            challengingAnswerChoices = contextualizedChallengingChoices;
-        }
-
-        // Index the answer choices
-        List<String> challengingAnswerChoicesList = new ArrayList<>(challengingAnswerChoices);
-
-
-        ArrayList<String> stringsAdded = new ArrayList<>();
-        Random rand = new Random();
-        int randomNum;
-        // Add them to buttons
-        for (int t = 0; t < GAME_BUTTONS.length; t++) {
-
-            TextView gameTile = findViewById(GAME_BUTTONS[t]);
-            String tileColorStr = colorList.get(t % 5);
-            int tileColor = Color.parseColor(tileColorStr);
-
             if (challengeLevel == 1 || challengeLevel == 2 || challengeLevel == 3
-                || challengeLevel == 7 || challengeLevel == 8 || challengeLevel == 9) { // Alternatives are random
-                if (t < visibleGameButtons) {
-                    randomNum = rand.nextInt(CorV.size());
-                    String tileOptionText = CorV.get(randomNum).text;
-                    while (stringsAdded.contains(tileOptionText)) {
-                        randomNum = rand.nextInt(CorV.size());
-                        tileOptionText = CorV.get(randomNum).text;
-                    }
-                    if (useContextualFormsITI) { // For some Arabic script apps
-                        gameTile.setText(contextualizedForm_Initial(tileOptionText));
-                    } else {
-                        gameTile.setText(tileOptionText);
-                    }
-                    gameTile.setBackgroundColor(tileColor);
-                    gameTile.setTextColor(Color.parseColor("#FFFFFF")); // white
-                    gameTile.setVisibility(View.VISIBLE);
-                    gameTile.setClickable(true);
-                    stringsAdded.add(tileOptionText);
-                    if (stringsAdded.contains(initialTile.text)) {
-                        correctTileRepresented = true;
-                    }
-                } else {
-                    gameTile.setText(String.valueOf(t + 1));
-                    gameTile.setBackgroundResource(R.drawable.textview_border);
-                    gameTile.setTextColor(Color.parseColor("#000000")); // black
-                    gameTile.setClickable(false);
-                    gameTile.setVisibility(View.INVISIBLE);
-                }
-            } else { // Alternatives are challenging
-                if (t < visibleGameButtons) {
-                    gameTile.setText(challengingAnswerChoicesList.get(t)); // KP
-                    gameTile.setBackgroundColor(tileColor);
-                    gameTile.setTextColor(Color.parseColor("#FFFFFF")); // white
-                    gameTile.setVisibility(View.VISIBLE);
-                } else {
-                    gameTile.setText(String.valueOf(t + 1));
-                    gameTile.setBackgroundResource(R.drawable.textview_border);
-                    gameTile.setTextColor(Color.parseColor("#000000")); // black
-                    gameTile.setClickable(false);
-                    gameTile.setVisibility(View.INVISIBLE);
-                }
-                correctTileRepresented = true;
-            }
-        }
+                || challengeLevel == 7 || challengeLevel == 8 || challengeLevel == 9) { // Find and add random alternatives
 
-        if (!correctTileRepresented) {
-            // If the correct tile didn't randomly show up for the non-challenging choices, then here the correct tile overwrites one of the others
-            rand = new Random();
-            randomNum = rand.nextInt(visibleGameButtons - 1);
-            TextView gameTile = findViewById(GAME_BUTTONS[randomNum]);
-            if(useContextualFormsITI) {
-                gameTile.setText(contextualizedForm_Initial(initialTile.text));
-            } else {
-                gameTile.setText(initialTile.text);
+                ArrayList<Start.Tile> alreadyAddedChoices = new ArrayList<>();
+
+                for (int b = 0; b < GAME_BUTTONS.length; b++) {
+                    TextView gameButton = findViewById(GAME_BUTTONS[b]);
+                    if (b < visibleGameButtons) {
+                        Start.Tile option = fittingTileAlternative(alreadyAddedChoices, "INITIAL", CorV);
+                        if (option.hasNull()) {
+                            if (b < 3) { // Less than 4 answer choices available in word-initial position; restart with a new word
+                                playAgain();
+                                return;
+                            } else { // Viable answer choice beyond 4 not found
+                                gameButton.setText(String.valueOf(b + 1));
+                                gameButton.setBackgroundResource(R.drawable.textview_border);
+                                gameButton.setTextColor(Color.parseColor("#000000")); // black
+                                gameButton.setClickable(false);
+                                gameButton.setVisibility(View.INVISIBLE);
+                            }
+                        } else { // display viable answer choice
+                            if (useContextualFormsITI) { // For some Arabic script apps
+                                gameButton.setText(contextualizedForm_Initial(option.text));
+                            } else {
+                                gameButton.setText(option.text);
+                            }
+                            gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
+                            gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
+                            gameButton.setVisibility(View.VISIBLE);
+                            gameButton.setClickable(true);
+                            alreadyAddedChoices.add(option);
+                        }
+                    } else {
+                        gameButton.setText(String.valueOf(b + 1));
+                        gameButton.setBackgroundResource(R.drawable.textview_border);
+                        gameButton.setTextColor(Color.parseColor("#000000")); // black
+                        gameButton.setClickable(false);
+                        gameButton.setVisibility(View.INVISIBLE);
+                    }
+                }
+
+                if (!alreadyAddedChoices.contains(initialTile)) { // If the correct tile wasn't randomly selected as a choice, it overwrites a random choice here
+                    Random rand = new Random();
+                    int randomNum = rand.nextInt(visibleGameButtons - 1);
+                    TextView gameButton = findViewById(GAME_BUTTONS[randomNum]);
+                    if(useContextualFormsITI) {
+                        gameButton.setText(contextualizedForm_Initial(initialTile.text));
+                    } else {
+                        gameButton.setText(initialTile.text);
+                    }
+                }
+            } else { // Challenge levels 4, 5, 6, 10, 11, and 12
+                // Alternatives are challenging: first distractors, then tiles that start with the same chars, then random tiles
+
+                Set<String> challengingAnswerChoices = new HashSet<String>(); // Duplicate choices are automatically prevented in a Set
+
+                // First add the correct answer and distractors
+                challengingAnswerChoices.add(initialTile.text);
+                for (int d=0; d<3; d++) {
+                    if(tileHashMap.get(initialTile.distractors.get(d)).canBePlacedInPosition("INITIAL")) {
+                        challengingAnswerChoices.add(initialTile.distractors.get(d));
+                    }
+                }
+
+
+                // Then add tiles that begin with the same two chars, if they exist
+                int i = 0;
+                while (challengingAnswerChoices.size()<visibleGameButtons && i<CorV.size()) {
+                    Random rand = new Random();
+                    int index = rand.nextInt(CorV.size() - 1);
+                    String option = CorV.get(index).text;
+                    if(option.length()>=2 && initialTile.text.length()>=2) {
+                        if(option.charAt(0) == initialTile.text.charAt(0)
+                                && option.charAt(1) == initialTile.text.charAt(1)
+                                && tileHashMap.get(option).canBePlacedInPosition("INITIAL")) {
+                            challengingAnswerChoices.add(option);
+                        }
+                    }
+                    i++;
+                }
+
+                // Then add tiles that begin or end with the same char
+                i = 0;
+                while (challengingAnswerChoices.size()<visibleGameButtons && i<CorV.size()) {
+                    Random rand = new Random();
+                    int index = rand.nextInt(CorV.size() - 1);
+                    String option = CorV.get(index).text;
+                    if (tileHashMap.get(option).canBePlacedInPosition("INITIAL")) {
+                        if (option.charAt(0) == initialTile.text.charAt(0)) {
+                            challengingAnswerChoices.add(option);
+                        } else if (option.charAt(option.length() - 1) == initialTile.text.charAt(initialTile.text.length() - 1)) {
+                            challengingAnswerChoices.add(option);
+                        }
+                    }
+                    i++;
+                }
+
+                // Then fill the remaining options with random tiles
+                Collections.shuffle(CorV);
+                int t = 0;
+                while (challengingAnswerChoices.size()<visibleGameButtons && t<CorV.size()) {
+                    if (CorV.get(t).canBePlacedInPosition("INITIAL")) {
+                        challengingAnswerChoices.add(CorV.get(t).text);
+                    }
+                    t++;
+                }
+
+                // Make the gameButtons contain contextual forms for some Arabic script apps
+                Set<String> contextualizedChallengingChoices = new HashSet<String>();
+                if(useContextualFormsITI) { // For some Arabic script apps
+                    for (String answerChoiceString : challengingAnswerChoices) {
+                        contextualizedChallengingChoices.add(contextualizedForm_Initial(answerChoiceString));
+                    }
+                    challengingAnswerChoices = contextualizedChallengingChoices;
+                }
+
+                // Index and shuffle the answer choices
+                List<String> challengingAnswerChoicesList = new ArrayList<>(challengingAnswerChoices);
+                Collections.shuffle(challengingAnswerChoicesList);
+
+                for (int b = 0; b < GAME_BUTTONS.length; b++) { // Add the answer choices to buttons
+
+                    TextView gameButton = findViewById(GAME_BUTTONS[b]);
+
+                    if (b < visibleGameButtons && b<challengingAnswerChoicesList.size()) {
+                        gameButton.setText(challengingAnswerChoicesList.get(b)); // KP
+                        gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
+                        gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
+                        gameButton.setVisibility(View.VISIBLE);
+                    } else {
+                        gameButton.setText(String.valueOf(b + 1));
+                        gameButton.setBackgroundResource(R.drawable.textview_border);
+                        gameButton.setTextColor(Color.parseColor("#000000")); // black
+                        gameButton.setClickable(false);
+                        gameButton.setVisibility(View.INVISIBLE);
+                    }
+                }
             }
-        }
+
     }
 
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
@@ -223,7 +223,7 @@ public class Peru extends GameActivity {
                             if (!replacementTile.canBePlacedInPosition(parsedRefWordTileArray, randomIndexToReplace)) {
                                 replacementTile = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, 0, cumulativeStageBasedTileList);
                             }
-                            if (Objects.isNull(replacementTile)) {
+                            if (!Objects.isNull(replacementTile)) {
                                 alreadyAddedPlacements.put(randomIndexToReplace, replacementTile);
                                 replacementTile.typeOfThisTileInstance = parsedRefWordTileArray.get(randomIndexToReplace).typeOfThisTileInstance;
                                 tilesInIncorrectChoice.set(randomIndexToReplace, replacementTile);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.logging.Logger;
 
@@ -155,7 +156,7 @@ public class Peru extends GameActivity {
                             Tile replacementTile = tileHashMap.find(shuffledDistractorTiles.get(incorrectLapNo - 1));
                             if (!replacementTile.canBePlacedInPosition("INITIAL")) {
                                 replacementTile = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, 0, cumulativeStageBasedTileList);
-                                if (replacementTile.hasNull()) { // Not enough tiles can be placed in initial position
+                                if (Objects.isNull(replacementTile)) { // Not enough tiles can be placed in initial position
                                     playAgain(); // Restart the game, to be set up with a different word
                                     return;
                                 }
@@ -197,7 +198,7 @@ public class Peru extends GameActivity {
                             tilesInIncorrectChoice.set(randomIndexToReplace, replacementTile);
                             String incorrectChoice2 = combineTilesToMakeWord(tilesInIncorrectChoice, refWord, randomIndexToReplace);// LM // resets to true and keeps looping if a duplicate has been made:
 
-                            generateDifferentAnswerChoice = replacementTile.hasNull();
+                            generateDifferentAnswerChoice = Objects.isNull(replacementTile);
 
                             for (int j = 0; j < incorrectChoice2.length() - 2; j++) {
                                 if (incorrectChoice2.substring(j, j + 3).equals("للہ")) {
@@ -222,7 +223,7 @@ public class Peru extends GameActivity {
                             if (!replacementTile.canBePlacedInPosition(parsedRefWordTileArray, randomIndexToReplace)) {
                                 replacementTile = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, 0, cumulativeStageBasedTileList);
                             }
-                            if (!replacementTile.hasNull()) {
+                            if (Objects.isNull(replacementTile)) {
                                 alreadyAddedPlacements.put(randomIndexToReplace, replacementTile);
                                 replacementTile.typeOfThisTileInstance = parsedRefWordTileArray.get(randomIndexToReplace).typeOfThisTileInstance;
                                 tilesInIncorrectChoice.set(randomIndexToReplace, replacementTile);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -948,6 +948,8 @@ public class Start extends AppCompatActivity {
         public int stageOfFirstAppearanceForThisTileType;
         public String audioForThisTileType;
 
+        public String positionRestrictions;
+
         public Tile(String text, ArrayList<String> distractors, String tileType, String audioName, String upper, String tileTypeB, String audioNameB, String tileTypeC, String audioNameC, int tileDuration1, int tileDuration2, int tileDuration3, int stageOfFirstAppearance, int stageOfFirstAppearanceB, int stageOfFirstAppearanceC, String typeOfThisTileInstance, int stageOfFirstAppearanceForThisTileType, String audioForThisTileType, String positionRestrictions) {
             super(text);
             this.distractors = distractors;
@@ -1032,6 +1034,11 @@ public class Start extends AppCompatActivity {
             }
         }
 
+        /**
+         * A method used to determine whether a tile can be substituted into a word for another tile, based on its ability to function word-initially, word-medially, and/or word-finally, as defined in aa_gametiles.txt under PositionRestrictions
+         * @param position either "INITIAL", "MEDIAL", or "FINAL"; else defaults to true
+         * @return true or false depending on whether this tile is allowed to be inserted into the given word position, based on any position restrictions specified for the tile
+         */
         public Boolean canBePlacedInPosition (String position) {
 
             if (position.equals("INITIAL") && this.positionRestrictions.matches("(Word-medial ONLY|Word-final ONLY|Anywhere EXCEPT word-initially)")) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -117,6 +117,12 @@ public class Start extends AppCompatActivity {
             "\u0610", "\u0611", "\u0612", "\u0613", "\u0614", "\u0615", "\u0616", "\u0617", "\u0618", "\u0619", "\u061A", "\u064B", "\u064C", "\u064D", "\u064E", "\u064F", "\u0650", "\u0651", "\u0652", "\u0653", "\u0654", "\u0655", "\u0656", "\u0657", "\u0658", "\u0659", "\u065A", "\u065B", "\u065C", "\u065D", "\u065E", "\u065F", "\u0670", "\u06D6", "\u06D7", "\u06D8", "\u06D9", "\u06DA", "\u06DB", "\u06DC", "\u06DF", "\u06E0", "\u06E1", "\u06E2", "\u06E3", "\u06E4", "\u06E7", "\u06E8", "\u06EA", "\u06EB", "\u06EC", "\u06ED"
     };
 
+    protected static final String [] wordPositionRestrictionOptions = {
+            "No restrictions (default)", "Anywhere EXCEPT word-initially", "Anywhere EXCEPT word-medially", "Anywhere EXCEPT word-finally", "Word-initial ONLY", "Word-medial ONLY", "Word-final ONLY"
+    };
+
+    public static final List<String> wordPositionRestrictionOptionsSet = Arrays.asList(wordPositionRestrictionOptions);
+
     private static final Logger LOGGER = Logger.getLogger( Start.class.getName() );
 
     @Override
@@ -377,6 +383,7 @@ public class Start extends AppCompatActivity {
                 tileList.stageOfFirstAppearanceTitle = thisLineArray[14];
                 tileList.stageOfFirstAppearanceTitleType2 = thisLineArray[15];
                 tileList.stageOfFirstAppearanceTitleType3 = thisLineArray[16];
+                tileList.positionRestrictionsTitle = thisLineArray[17];
 
                 header = false;
             } else {
@@ -406,12 +413,22 @@ public class Start extends AppCompatActivity {
                         stageOfFirstAppearance = 1;
                     }
                 }
+
+                // Process any position restrictions designated
+                String positionRestrictions;
+                if(!wordPositionRestrictionOptionsSet.contains(thisLineArray[17])) {
+                    positionRestrictions = "No restrictions (default)";
+                } else {
+                    positionRestrictions = thisLineArray[17];
+                }
+
+
                 // Create tile(s) and add to list; may add up to three tiles from the same line if it has multiple types
                 ArrayList<String> distractors = new ArrayList<>();
                 distractors.add(thisLineArray[1]);
                 distractors.add(thisLineArray[2]);
                 distractors.add(thisLineArray[3]);
-                Tile tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[4], stageOfFirstAppearance, thisLineArray[5]);
+                Tile tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[4], stageOfFirstAppearance, thisLineArray[5], positionRestrictions);
                 if (!tile.hasNull()) {
                     tileList.add(tile);
                     if (!tile.typeOfThisTileInstance.equals("SAD") && !(tile.audioForThisTileType.equals("zz_no_audio_needed") && !tile.typeOfThisTileInstance.equals("PC"))) {
@@ -419,7 +436,7 @@ public class Start extends AppCompatActivity {
                     }
                 }
                 if(!tile.tileTypeB.equals("none")){
-                    tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[7], stageOfFirstAppearanceType2, thisLineArray[8]);
+                    tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[7], stageOfFirstAppearanceType2, thisLineArray[8], positionRestrictions);
                     if (!tile.hasNull()) {
                         tileList.add(tile);
                         if (!tile.typeOfThisTileInstance.equals("SAD") && !(tile.audioForThisTileType.equals("zz_no_audio_needed") && !tile.typeOfThisTileInstance.equals("PC"))) {
@@ -428,7 +445,7 @@ public class Start extends AppCompatActivity {
                     }
                 }
                 if(!tile.tileTypeC.equals("none")){
-                    tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[9], stageOfFirstAppearanceType3, thisLineArray[10]);
+                    tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[9], stageOfFirstAppearanceType3, thisLineArray[10], positionRestrictions);
                     if (!tile.hasNull()) {
                         tileList.add(tile);
                         if (!tile.typeOfThisTileInstance.equals("SAD") && !(tile.audioForThisTileType.equals("zz_no_audio_needed") && !tile.typeOfThisTileInstance.equals("PC"))) {
@@ -490,20 +507,27 @@ public class Start extends AppCompatActivity {
 
         while (scanner.hasNext()) {
             String thisLine = scanner.nextLine();
-            String[] thisLineArray = thisLine.split("\t", 7);
+            String[] thisLineArray = thisLine.split("\t");
             if (header) {
                 syllableList.syllableTitle = thisLineArray[0];
                 syllableList.distractorsTitles = new String[]{thisLineArray[1], thisLineArray[2], thisLineArray[3]};
                 syllableList.syllableAudioNameTitle = thisLineArray[4];
                 syllableList.syllableDurationTitle = thisLineArray[5];
                 syllableList.colorTitle = thisLineArray[6];
+                syllableList.positionRestrictionsTitle = thisLineArray[7];
                 header = false;
             } else {
                 ArrayList<String> distractors = new ArrayList<>();
                 distractors.add(thisLineArray[1]);
                 distractors.add(thisLineArray[2]);
                 distractors.add(thisLineArray[3]);
-                Syllable syllable = new Syllable(thisLineArray[0], distractors, thisLineArray[4], Integer.parseInt(thisLineArray[5]), thisLineArray[6]);
+                String positionRestrictions;
+                if (wordPositionRestrictionOptionsSet.contains(thisLineArray[7])) {
+                    positionRestrictions = thisLineArray[7];
+                } else {
+                    positionRestrictions = "No restrictions (default)";
+                }
+                Syllable syllable = new Syllable(thisLineArray[0], distractors, thisLineArray[4], Integer.parseInt(thisLineArray[5]), thisLineArray[6], positionRestrictions);
                 if (!syllable.hasNull()) {
                     syllableList.add(syllable);
                 }
@@ -571,7 +595,7 @@ public class Start extends AppCompatActivity {
         boolean firstLetterStageCorrespondence = false;
         int stage1and2MaxWordLength = Integer.MAX_VALUE;
         if(!settingsList.find("First letter stage correspondence").equals("")){
-           firstLetterStageCorrespondence = Boolean.parseBoolean(settingsList.find("First letter stage correspondence"));
+            firstLetterStageCorrespondence = Boolean.parseBoolean(settingsList.find("First letter stage correspondence"));
         }
         if(!settingsList.find("Stage 1-2 max word length").equals("")){
             stage1and2MaxWordLength = Integer.parseInt(settingsList.find("Stage 1-2 max word length"));
@@ -924,7 +948,7 @@ public class Start extends AppCompatActivity {
         public int stageOfFirstAppearanceForThisTileType;
         public String audioForThisTileType;
 
-        public Tile(String text, ArrayList<String> distractors, String tileType, String audioName, String upper, String tileTypeB, String audioNameB, String tileTypeC, String audioNameC, int tileDuration1, int tileDuration2, int tileDuration3, int stageOfFirstAppearance, int stageOfFirstAppearanceB, int stageOfFirstAppearanceC, String typeOfThisTileInstance, int stageOfFirstAppearanceForThisTileType, String audioForThisTileType) {
+        public Tile(String text, ArrayList<String> distractors, String tileType, String audioName, String upper, String tileTypeB, String audioNameB, String tileTypeC, String audioNameC, int tileDuration1, int tileDuration2, int tileDuration3, int stageOfFirstAppearance, int stageOfFirstAppearanceB, int stageOfFirstAppearanceC, String typeOfThisTileInstance, int stageOfFirstAppearanceForThisTileType, String audioForThisTileType, String positionRestrictions) {
             super(text);
             this.distractors = distractors;
             this.tileType = tileType;
@@ -943,6 +967,7 @@ public class Start extends AppCompatActivity {
             this.typeOfThisTileInstance = typeOfThisTileInstance;
             this.stageOfFirstAppearanceForThisTileType = stageOfFirstAppearanceForThisTileType;
             this.audioForThisTileType = audioForThisTileType;
+            this.positionRestrictions = positionRestrictions;
         }
 
         public Tile (Tile anotherTile) {
@@ -964,6 +989,7 @@ public class Start extends AppCompatActivity {
             this.typeOfThisTileInstance = anotherTile.typeOfThisTileInstance;
             this.stageOfFirstAppearanceForThisTileType = anotherTile.stageOfFirstAppearanceForThisTileType;
             this.audioForThisTileType = anotherTile.audioForThisTileType;
+            this.positionRestrictions = anotherTile.positionRestrictions;
         }
 
         public boolean hasNull() {
@@ -985,6 +1011,40 @@ public class Start extends AppCompatActivity {
 
             return this.audioForThisTileType;
         }
+
+
+        /**
+         * A method used to determine whether a tile can be substituted into a word for another tile, based on its ability to function word-initially, word-medially, and/or word-finally, as defined in aa_gametiles.txt under PositionRestrictions
+         * @param tilesInRefWord The tiles parsed from a word into which the game is considering to insert this tile
+         * @param indexInParsedRefWordTileArray The index in the list of parsed tiles where this tile would be placed
+         * @return true or false depending on whether this tile is allowed to be inserted into the given word position, based on any position restrictions specified for the tile
+         */
+        public Boolean canBePlacedInPosition(ArrayList<Tile> tilesInRefWord, int indexInParsedRefWordTileArray) {
+
+            if (indexInParsedRefWordTileArray==0 && this.positionRestrictions.matches("(Word-medial ONLY|Word-final ONLY|Anywhere EXCEPT word-initially)")) {
+                return false;
+            } else if (indexInParsedRefWordTileArray==tilesInRefWord.size()-1 && this.positionRestrictions.matches("(Word-initial ONLY|Word-medial ONLY|Anywhere EXCEPT word-finally)")) {
+                return false;
+            } else if (indexInParsedRefWordTileArray<tilesInRefWord.size()-1 && indexInParsedRefWordTileArray>0 && this.positionRestrictions.matches("(Word-initial ONLY|Word-final ONLY|Anywhere EXCEPT word-medially)")) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+        public Boolean canBePlacedInPosition (String position) {
+
+            if (position.equals("INITIAL") && this.positionRestrictions.matches("(Word-medial ONLY|Word-final ONLY|Anywhere EXCEPT word-initially)")) {
+                return false;
+            } else if (position.equals("FINAL") && this.positionRestrictions.matches("(Word-initial ONLY|Word-medial ONLY|Anywhere EXCEPT word-finally)")) {
+                return false;
+            } else if (position.equals("MEDIAL") && this.positionRestrictions.matches("(Word-initial ONLY|Word-final ONLY|Anywhere EXCEPT word-medially)")) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
     }
 
     public class Key {
@@ -1233,7 +1293,7 @@ public class Start extends AppCompatActivity {
                 }
 
                 if (firstTileString.equals(refTile.text) && !refWord.wordInLOP.equals(aWord.wordInLOP)) {
-                        hardWords.add(aWord);
+                    hardWords.add(aWord);
                 }
 
             }
@@ -1332,6 +1392,7 @@ public class Start extends AppCompatActivity {
         public String text;
         public ArrayList<String> distractors;
         public String audioName;
+        public String positionRestrictions;
 
         public WordPiece(String textOfThisWordPiece) {
             this.text = textOfThisWordPiece;
@@ -1341,6 +1402,7 @@ public class Start extends AppCompatActivity {
             this.text = anotherWordPiece.text;
             this.distractors = anotherWordPiece.distractors;
             this.audioName = anotherWordPiece.audioName;
+            this.positionRestrictions = anotherWordPiece.positionRestrictions;
         }
 
     }
@@ -1349,18 +1411,57 @@ public class Start extends AppCompatActivity {
         public String color;
 
 
-        public Syllable(String text, ArrayList<String> distractors, String audioName, int duration, String color) {
+        public Syllable(String text, ArrayList<String> distractors, String audioName, int duration, String color, String positionRestrictions) {
             super(text);
             this.text = text;
             this.distractors = distractors;
             this.audioName = audioName;
             this.duration = duration;
             this.color = color;
+            this.positionRestrictions = positionRestrictions;
         }
 
 
         public boolean hasNull() {
             return text == null || distractors.isEmpty() || audioName == null || color == null;
+        }
+
+
+        /**
+         * A method used to determine whether a syllable can be substituted into a word for another syllable, based on its ability to function word-initially, word-medially, and/or word-finally, as defined in aa_gametiles.txt under PositionRestrictions
+         * @param syllablesInRefWord The syllables parsed from a word into which the game is considering to insert this syllable
+         * @param indexInParsedRefWordSyllableArray The index in the list of parsed syllables where this syllable would be placed
+         * @return true or false depending on whether this syllable is allowed to be inserted into the given word position, based on any position restrictions specified for the syllable
+         */
+        public Boolean canBePlacedInPosition(ArrayList<Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
+
+            if (indexInParsedRefWordSyllableArray==0 && this.positionRestrictions.matches("(Word-medial ONLY|Word-final ONLY|Anywhere EXCEPT word-initially)")) {
+                return false;
+            } else if (indexInParsedRefWordSyllableArray==syllablesInRefWord.size()-1 && this.positionRestrictions.matches("(Word-initial ONLY|Word-medial ONLY|Anywhere EXCEPT word-finally)")) {
+                return false;
+            } else if (indexInParsedRefWordSyllableArray<syllablesInRefWord.size()-1 && indexInParsedRefWordSyllableArray>0 && this.positionRestrictions.matches("(Word-initial ONLY|Word-final ONLY|Anywhere EXCEPT word-medially)")) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+        /**
+         * A method used to determine whether a syllable can be substituted into a word for another syllable, based on its ability to function word-initially, word-medially, and/or word-finally, as defined in aa_gametiles.txt under PositionRestrictions
+         * @param position the position we want to check fit with
+         * @return true or false depending on whether this syllable is allowed to be inserted into the given word position, based on any position restrictions specified for the syllable
+         */
+        public Boolean canBePlacedInPosition(String position) {
+
+            if (position.equals("INITIAL") && this.positionRestrictions.matches("(Word-medial ONLY|Word-final ONLY|Anywhere EXCEPT word-initially)")) {
+                return false;
+            } else if (position.equals("FINAL") && this.positionRestrictions.matches("(Word-initial ONLY|Word-medial ONLY|Anywhere EXCEPT word-finally)")) {
+                return false;
+            } else if (position.equals("MEDIAL") && this.positionRestrictions.matches("(Word-initial ONLY|Word-final ONLY|Anywhere EXCEPT word-medially)")) {
+                return false;
+            } else {
+                return true;
+            }
         }
     }
 
@@ -1370,6 +1471,8 @@ public class Start extends AppCompatActivity {
         public String syllableAudioNameTitle;
         public String syllableDurationTitle;
         public String colorTitle;
+
+        public String positionRestrictionsTitle;
 
         public ArrayList<Syllable> parseWordIntoSyllables(Word refWord) {
             ArrayList<Syllable> parsedWordArrayTemp = new ArrayList();
@@ -1526,6 +1629,8 @@ public class Start extends AppCompatActivity {
         public String stageOfFirstAppearanceTitle;
         public String stageOfFirstAppearanceTitleType2;
         public String stageOfFirstAppearanceTitleType3;
+
+        public String positionRestrictionsTitle;
 
         public boolean contains(Tile tile) {
             for(int t=0; t<size(); t++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -2329,4 +2329,41 @@ public class Start extends AppCompatActivity {
 
     }
 
+    /**
+     * tracks two fields together: an index within a word to place the WordPiece into, and the WordPiece's text
+     * Used for determining that randomly generated WordPiece replacements in wrong answer choices are distinct
+     */
+    public static class WordPieceStringPosition {
+        Integer parsedWordArrayWordPieceIndex;
+        String wordPieceText;
+        public WordPieceStringPosition(Integer parsedWordArrayWordPieceIndex, String wordPieceText) {
+            this.parsedWordArrayWordPieceIndex = parsedWordArrayWordPieceIndex;
+            this.wordPieceText = wordPieceText;
+        }
+
+        public boolean equals(WordPieceStringPosition other) {
+            return (this.parsedWordArrayWordPieceIndex.intValue() == other.parsedWordArrayWordPieceIndex.intValue()
+                    && this.wordPieceText.equals(other.wordPieceText));
+        }
+    }
+
+    /**
+     * Special contains method - compares field values, rather than objects
+     * Used for gathering randomly generated WordPiece replacements for a word and finding out which ones have already been done
+     * so as to prevent duplicates
+     */
+    public static class WordPieceStringPositionSet extends ArrayList<WordPieceStringPosition> {
+
+        public boolean contains (WordPieceStringPosition aTileStringPosition) {
+            for (int p=0; p<size(); p++) {
+                if (get(p).parsedWordArrayWordPieceIndex.intValue() == aTileStringPosition.parsedWordArrayWordPieceIndex.intValue()
+                        && get(p).wordPieceText.equals(aTileStringPosition.wordPieceText)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    }
+
 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -253,9 +253,9 @@ public class Thailand extends GameActivity {
 
         } else {
             if (refType.contains("TILE") || refType.equals("CONTEXTUAL")) { // Set a permissible refTile and set refTileType and refString
-                boolean permissibleTile = false;
+                boolean permissibleRefTile = false;
                 int freshChecks = 0;
-                while (!permissibleTile) {
+                while (!permissibleRefTile) {
                     freshChecks++;
                     int randomTileIndex = rand.nextInt(tileListNoSAD.size());
                     refTile = tileListNoSAD.get(randomTileIndex);
@@ -302,10 +302,11 @@ public class Thailand extends GameActivity {
                     // Disallow non-joining and non-spacing (non-contextual) characters from contextual forms matching games (Arabic script)
                     // Disallow tiles with placeholders from contextual forms matching games (Arabic script)
                     // Disallow tiles that are already displayed with a contextual character in the tile list (Arabic script)
-                    permissibleTile = verifyFreshTile(refString, freshChecks)
+                    // Disallow testing a tile in a certain contextual position that it cannot occur in (see: position restrictions)
+                    permissibleRefTile = verifyFreshTile(refString, freshChecks)
                             && CorV.contains(refTile)
                             && !(refTileType.matches("(PC)"))
-                            && !((refType.matches("CONTEXTUAL") || choiceType.matches("CONTEXTUAL")) && (NON_JOINERS_ARABIC.contains(refTile) || NON_SPACERS_ARABIC.contains(refTile) || choicesContainContextualizersOrPlaceholders))
+                            && !((refType.matches("CONTEXTUAL") || choiceType.matches("CONTEXTUAL")) && (NON_JOINERS_ARABIC.contains(refTile) || NON_SPACERS_ARABIC.contains(refTile) || choicesContainContextualizersOrPlaceholders || (!refTile.canBePlacedInPosition(contextualTilePosition))))
                             && !(contextualTilePosition.matches("INITIAL") && (RIGHT_JOINERS_ARABIC.contains(refTile)))
                            ;
                 }
@@ -347,6 +348,26 @@ public class Thailand extends GameActivity {
             // challengeLevelThai 1 = pull random tiles for wrong choices
             // challengeLevelThai 2 = pull distractor tiles for wrong choices
             fourTileChoices = tileListNoSAD.returnFourTileChoices(refTile, challengeLevelThai, refTileType);
+            if (choiceType.equals("CONTEXTUAL")) {
+                for (Tile t: fourTileChoices) {
+                    if (!t.canBePlacedInPosition(contextualTilePosition)) {
+                        fourTileChoices.remove(t);
+                        boolean usingDistractors = false;
+                        if(challengeLevelThai==2) {
+                            usingDistractors = true;
+                        }
+                        Tile alternativeTileChoice = fittingTileAlternative(refTile, fourTileChoices, contextualTilePosition, false, usingDistractors);
+                        if (alternativeTileChoice.hasNull()) {
+                            // Couldn't find three fitting answer choices for this contextual tile position
+                            playAgain();
+                            return;
+                        } else {
+                            fourTileChoices.add(alternativeTileChoice);
+                        }
+                    }
+                }
+            }
+
         } else if (choiceType.matches("(WORD_TEXT|WORD_IMAGE)") && (!refType.contains("SYLLABLE"))) {
             fourWordChoices = wordList.returnFourWords(refWord, refTile, challengeLevelThai, refType);
             // challengeLevelThai 1 = pull words that begin with random tiles (not distractor, not same) for wrong choices

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -352,11 +352,12 @@ public class Thailand extends GameActivity {
                 for (Tile t: fourTileChoices) {
                     if (!t.canBePlacedInPosition(contextualTilePosition)) {
                         fourTileChoices.remove(t);
-                        boolean usingDistractors = false;
+                        ArrayList<Start.Tile> tilesToDrawFrom = cumulativeStageBasedTileList;
                         if(challengeLevelThai==2) {
-                            usingDistractors = true;
+                            tilesToDrawFrom.clear();
+                            tilesToDrawFrom.addAll(CorV);
                         }
-                        Tile alternativeTileChoice = fittingTileAlternative(refTile, fourTileChoices, contextualTilePosition, false, usingDistractors);
+                        Tile alternativeTileChoice = fittingTileAlternative(fourTileChoices, contextualTilePosition, tilesToDrawFrom);
                         if (alternativeTileChoice.hasNull()) {
                             // Couldn't find three fitting answer choices for this contextual tile position
                             playAgain();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -9,6 +9,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Random;
 
 import com.segment.analytics.Analytics;
@@ -358,7 +359,7 @@ public class Thailand extends GameActivity {
                             tilesToDrawFrom.addAll(CorV);
                         }
                         Tile alternativeTileChoice = fittingTileAlternative(fourTileChoices, contextualTilePosition, tilesToDrawFrom);
-                        if (alternativeTileChoice.hasNull()) {
+                        if (Objects.isNull(alternativeTileChoice)) {
                             // Couldn't find three fitting answer choices for this contextual tile position
                             playAgain();
                             return;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -209,7 +209,7 @@ public class UnitedStates extends GameActivity {
                     String distractorSyllableString = parsedRefWordSyllableArray.get(parseIndex).distractors.get(0);
                     for (int d=1; d<4; d++) {
                         if (!syllableHashMap.get(distractorSyllableString).canBePlacedInPosition(parsedRefWordSyllableArray, parseIndex)) {
-                            distractorSyllableString = distractorSyllableString = parsedRefWordSyllableArray.get(parseIndex).distractors.get(d);
+                            distractorSyllableString = parsedRefWordSyllableArray.get(parseIndex).distractors.get(d);
                         }
                     }
                     // If none of the distractors happen to work in this word position, restart the game to use a different word.

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -215,7 +215,7 @@ public class UnitedStates extends GameActivity {
                     // If none of the distractors happen to work in this word position, restart the game to use a different word.
                     if (!syllableHashMap.get(distractorSyllableString).canBePlacedInPosition(parsedRefWordSyllableArray, parseIndex)) {
                         playAgain();
-                        break;
+                        return;
                     } else { // Add this syllable string and its distractor the game buttons
                         if (randomlyCorrectStringGoesBelow == 0) { // Correct string goes above
                             gameButtonA.setText(correctSyllableString);

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.0'
+        classpath 'com.android.tools.build:gradle:8.9.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.2'
+        classpath 'com.android.tools.build:gradle:8.11.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/validator/templateTemplate/res/raw/aa_gametiles.txt
+++ b/validator/templateTemplate/res/raw/aa_gametiles.txt
@@ -1,2 +1,2 @@
-tiles	Or1	Or2	Or3	Type	AudioName	Upper	Type2	AudioName2	Type3	AudioName3	Placeholder	Placeholder	Placeholder	FirstAppearsInStage...	FirstAppearsInStage...(Type2)	FirstAppearsInStage...(Type3)
-							none	X	none	X	0	0	0	-	-	-
+tiles	Or1	Or2	Or3	Type	AudioName	Upper	Type2	AudioName2	Type3	AudioName3	Placeholder	Placeholder	Placeholder	FirstAppearsInStage...	FirstAppearsInStage...(Type2)	FirstAppearsInStage...(Type3)   PositionRestrictions
+							none	X	none	X	0	0	0	-	-	-   No restrictions (default)


### PR DESCRIPTION
This PR provides the proposed solution to #232 

Incorporates a field called ‘PositionRestrictions’ from gametiles to restrict tiles from being inserted into positions they should not be inserted based on the orthography.


**How to test**
1. Add column R "PositionRestrictions" to the gametiles tab of a language pack spreadsheet. (Would be good to try a couple langauge packs). 
2. The values of the column should be set by a dropdown. See glh for this dropdown. It uses Google Sheets > Data > Data Validation > Criteria > Dropdown. The options are 
- No restrictions (default)
- Word-initial only
- Word-medial only
- Word-final only
- Anywhere EXCEPT word-initially
- Anywhere EXCEPT word-medially
- Anywhere EXCEPT word-finally
3. Run the validator, using all default values (No restrictions (default)). There should be no fatal errors reported.
4. Run the app, using all default values. The app should run. Try Brazil, Georgia, Peru, UnitedStates, and any contextual position Thailand games (affected games). Everything should work as normal.
5. Repeat 4 and 5, changing the values in the dropdowns to test many different configurations. If possible, get language teams to weigh in on actual examples of tiles restricted to certain positions and test the ideal configurations for those language packs. (JF, MS, JG).