### PR TITLE
Allow teams to specify variant strings for tiles to occur in specific positions within words

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -363,8 +363,8 @@ public class Brazil extends GameActivity {
             }
             word = wordBuilder.toString();
         } else { // Tile game
-            Start.Tile blankTile = new Start.Tile("__", new ArrayList<>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, correctTile.typeOfThisTileInstance, 1, "", "No restrictions (default)");
-            parsedRefWordTileArray.set(indexToRemove, blankTile);
+            Start.Tile blankTile = new Start.Tile("__", new ArrayList<>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, correctTile.typeOfThisTileInstance, 1, "", "No restrictions (default)", "none", "none", "none");
+            parsedRefWordTileArray.set(index_to_remove, blankTile);
             if (scriptType.equals("Khmer") && correctTile.typeOfThisTileInstance.equals("C")){
                 if(indexToRemove < parsedRefWordTileArray.size()-1 && parsedRefWordTileArray.get(indexToRemove + 1).typeOfThisTileInstance.matches("(V|AV|BV|D)")) {
                     blankTile.text = "\u200B"; // The word will default to containing a placeholder circle. Add zero-width space, instead of line.

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -364,7 +364,7 @@ public class Brazil extends GameActivity {
             word = wordBuilder.toString();
         } else { // Tile game
             Start.Tile blankTile = new Start.Tile("__", new ArrayList<>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, correctTile.typeOfThisTileInstance, 1, "", "No restrictions (default)", "none", "none", "none");
-            parsedRefWordTileArray.set(index_to_remove, blankTile);
+            parsedRefWordTileArray.set(indexToRemove, blankTile);
             if (scriptType.equals("Khmer") && correctTile.typeOfThisTileInstance.equals("C")){
                 if(indexToRemove < parsedRefWordTileArray.size()-1 && parsedRefWordTileArray.get(indexToRemove + 1).typeOfThisTileInstance.matches("(V|AV|BV|D)")) {
                     blankTile.text = "\u200B"; // The word will default to containing a placeholder circle. Add zero-width space, instead of line.

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import static org.alphatilesapps.alphatiles.Start.*;
 
@@ -50,6 +51,7 @@ public class Brazil extends GameActivity {
     ArrayList<String> parsedRefWordSyllableArrayStrings;
 
     Start.SyllableList syllableListCopy;
+    private static final Logger LOGGER = Logger.getLogger(Brazil.class.getName());
 
     protected static final int[] GAME_BUTTONS = {
             R.id.tile01, R.id.tile02, R.id.tile03, R.id.tile04, R.id.tile05, R.id.tile06, R.id.tile07, R.id.tile08, R.id.tile09, R.id.tile10,
@@ -94,7 +96,7 @@ public class Brazil extends GameActivity {
             setContentView(R.layout.brazil_cl1);
         }
 
-        int gameID = 0;
+        int gameID;
         if (challengeLevel == 3 || challengeLevel == 6) {
             gameID = R.id.brazil_cl3_CL;
         } else {
@@ -297,7 +299,7 @@ public class Brazil extends GameActivity {
     private void removeTile() {
 
         Random rand = new Random();
-        int index = 0;
+        int index;
         indexToRemove = 0;
 
         boolean repeat = true;
@@ -389,6 +391,8 @@ public class Brazil extends GameActivity {
     }
 
     private void setUpSyllables() {
+        LOGGER.info("setUpSyllables: visible=" + visibleGameButtons + " level=" + challengeLevel);
+
         if (challengeLevel == 1) { // Find and add random alternatives
 
             WordPieceStringPositionSet alreadyAddedPlacements = new WordPieceStringPositionSet();
@@ -396,11 +400,15 @@ public class Brazil extends GameActivity {
             for (int b = 0; b < visibleGameButtons; b++) {
                 TextView gameButton = findViewById(GAME_BUTTONS[b]);
 
+                LOGGER.info("setUpSyllables: get fitting syllable: " + alreadyAddedPlacements.size() + "/"
+                + parsedRefWordSyllableArray.size() + "/" + indexToRemove);
                 Syllable option = fittingSyllableAlternative(alreadyAddedPlacements, parsedRefWordSyllableArray, indexToRemove);
                 if (Objects.isNull(option)) { // Fewer than 4 viable answer choices available. 'Restart' with new word.
                     playAgain();
                     return;
                 } else { // Display viable options.
+                    LOGGER.info("setUpSyllables: option=" + option.text);
+
                     gameButton.setText(option.text);
                     gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
                     gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
@@ -418,7 +426,7 @@ public class Brazil extends GameActivity {
                 gameButton.setText(correctSyllable.text);
             }
         } else { // Challenge level 2
-            // Alternatives are challenging: first  distractors, then syllables with the same initial or final characters, then random.
+            // Alternatives are challenging: first distractors, then syllables with the same initial or final characters, then random.
 
             // First, add correct answer and distractors
             Set<String> challengingAnswerChoices = new HashSet<String>(); // Duplicates will be prevented since this is a Set
@@ -517,7 +525,7 @@ public class Brazil extends GameActivity {
 
         WordPieceStringPositionSet alreadyAddedPlacements = new WordPieceStringPositionSet();
         Start.Tile option;
-
+        LOGGER.info("setUpTiles: visible=" + visibleGameButtons + " level=" + challengeLevel);
         for (int b = 0; b < visibleGameButtons; b++) {
             TextView gameButton = findViewById(GAME_BUTTONS[b]);
             switch (challengeLevel) {
@@ -544,11 +552,23 @@ public class Brazil extends GameActivity {
             if (Objects.isNull(option)) {
                 if (b < 4) {
                     option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, indexToRemove, cumulativeStageBasedTileList);
+                    LOGGER.info("setUpTiles (null b<4): option=" + option.text + " b=" + b);
                     if (Objects.isNull(option)) {
                         playAgain();
                         return;
                     }
+                    // Display viable answer choice
+                    LOGGER.info("setUpTiles: Entering fix!!");
+                    gameButton.setText(option.text);
+                    gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
+                    gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
+                    gameButton.setVisibility(View.VISIBLE);
+                    gameButton.setClickable(true);
+                    alreadyAddedPlacements.add(new WordPieceStringPosition(indexToRemove, option.text));
+                    LOGGER.info("setUpTiles: Exiting fix!!");
+
                 } else { // Viable answer choice beyond 4 not found
+                    LOGGER.info("setUpTiles (null b>=4): option=" + option.text + " b=" + b);
                     gameButton.setText(String.valueOf(b + 1));
                     gameButton.setBackgroundResource(R.drawable.textview_border);
                     gameButton.setTextColor(Color.parseColor("#000000")); // black
@@ -556,6 +576,7 @@ public class Brazil extends GameActivity {
                     gameButton.setVisibility(View.INVISIBLE);
                 }
             } else { // Display viable answer choice
+                LOGGER.info("setUpTiles (not null): option=" + option.text + " b=" + b);
                 gameButton.setText(option.text);
                 gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
                 gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
@@ -565,9 +586,11 @@ public class Brazil extends GameActivity {
             }
         }
 
+        // LOGGER.info("setUpTiles: loop " + visibleGameButtons + " to " + GAME_BUTTONS.length);
         for (int b=visibleGameButtons; b<GAME_BUTTONS.length; b++) { // Hide empty buttons
             TextView gameButton = findViewById(GAME_BUTTONS[b]);
             if(!Objects.isNull(gameButton)) {
+                // LOGGER.info("setUpTiles (not null): gameButton=" + gameButton + "b=" + b);
                 gameButton.setText(String.valueOf(b + 1));
                 gameButton.setBackgroundResource(R.drawable.textview_border);
                 gameButton.setTextColor(Color.parseColor("#000000")); // black
@@ -576,11 +599,13 @@ public class Brazil extends GameActivity {
             }
         }
 
-        if (!(alreadyAddedPlacements.contains(new WordPieceStringPosition(indexToRemove, correctTile.text)))) { // If the correct syllable wasn't randomly added as an answer choice, then here it overwrites one of the others
+        if (!(alreadyAddedPlacements.contains(new WordPieceStringPosition(indexToRemove, correctTile.text)))) {
+            // If the correct syllable wasn't randomly added as an answer choice, then here it overwrites one of the others
             Random rand = new Random();
             int randomNum = rand.nextInt(visibleGameButtons - 1); // KP
             TextView gameButton = findViewById(GAME_BUTTONS[randomNum]);
             gameButton.setText(correctTile.text);
+            LOGGER.info("put correct tile into block:" + correctTile.text);
         }
 
 
@@ -604,7 +629,7 @@ public class Brazil extends GameActivity {
 
     /**
      * For Arabic script apps
-     * Show the right form (medial, initial, final) of the missing sylllable choices
+     * Show the right form (medial, initial, final) of the missing syllable choices
      */
     private void produceContextualSyllableAnswerChoices() {
         for(int t = 0; t< visibleGameButtons; t++) { // For all answer choices
@@ -641,7 +666,7 @@ public class Brazil extends GameActivity {
                         .putValue("Correct Answer", correctString)
                         .putValue("Grade", studentGrade);
                 for (int i = 0; i < visibleGameButtons - 1; i++) {
-                    if (!incorrectAnswersSelected.get(i).equals("")) {
+                    if (!incorrectAnswersSelected.get(i).isEmpty()) {
                         info.putValue("Incorrect_" + (i + 1), incorrectAnswersSelected.get(i));
                     }
                 }
@@ -668,7 +693,7 @@ public class Brazil extends GameActivity {
             for (int i = 0; i < visibleGameButtons-1; i++) {
                 String item = incorrectAnswersSelected.get(i);
                 if (item.equals(gameButtonString)) break;  // this incorrect answer already selected
-                if (item.equals("")) {
+                if (item.isEmpty()) {
                     incorrectAnswersSelected.set(i, gameButtonString);
                     break;
                 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -391,8 +391,6 @@ public class Brazil extends GameActivity {
     }
 
     private void setUpSyllables() {
-        LOGGER.info("setUpSyllables: visible=" + visibleGameButtons + " level=" + challengeLevel);
-
         if (challengeLevel == 1) { // Find and add random alternatives
 
             WordPieceStringPositionSet alreadyAddedPlacements = new WordPieceStringPositionSet();
@@ -400,15 +398,11 @@ public class Brazil extends GameActivity {
             for (int b = 0; b < visibleGameButtons; b++) {
                 TextView gameButton = findViewById(GAME_BUTTONS[b]);
 
-                LOGGER.info("setUpSyllables: get fitting syllable: " + alreadyAddedPlacements.size() + "/"
-                + parsedRefWordSyllableArray.size() + "/" + indexToRemove);
                 Syllable option = fittingSyllableAlternative(alreadyAddedPlacements, parsedRefWordSyllableArray, indexToRemove);
                 if (Objects.isNull(option)) { // Fewer than 4 viable answer choices available. 'Restart' with new word.
                     playAgain();
                     return;
                 } else { // Display viable options.
-                    LOGGER.info("setUpSyllables: option=" + option.text);
-
                     gameButton.setText(option.text);
                     gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
                     gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
@@ -525,7 +519,7 @@ public class Brazil extends GameActivity {
 
         WordPieceStringPositionSet alreadyAddedPlacements = new WordPieceStringPositionSet();
         Start.Tile option;
-        LOGGER.info("setUpTiles: visible=" + visibleGameButtons + " level=" + challengeLevel);
+
         for (int b = 0; b < visibleGameButtons; b++) {
             TextView gameButton = findViewById(GAME_BUTTONS[b]);
             switch (challengeLevel) {
@@ -552,23 +546,21 @@ public class Brazil extends GameActivity {
             if (Objects.isNull(option)) {
                 if (b < 4) {
                     option = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, indexToRemove, cumulativeStageBasedTileList);
-                    LOGGER.info("setUpTiles (null b<4): option=" + option.text + " b=" + b);
                     if (Objects.isNull(option)) {
                         playAgain();
                         return;
                     }
-                    // Display viable answer choice
-                    LOGGER.info("setUpTiles: Entering fix!!");
+                    // Else we got back a viable answer choice  - display it
+                    // LOGGER.info("setUpTiles: Entering fix!!");
                     gameButton.setText(option.text);
                     gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
                     gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
                     gameButton.setVisibility(View.VISIBLE);
                     gameButton.setClickable(true);
                     alreadyAddedPlacements.add(new WordPieceStringPosition(indexToRemove, option.text));
-                    LOGGER.info("setUpTiles: Exiting fix!!");
+                    // LOGGER.info("setUpTiles: Exiting fix!!");
 
                 } else { // Viable answer choice beyond 4 not found
-                    LOGGER.info("setUpTiles (null b>=4): option=" + option.text + " b=" + b);
                     gameButton.setText(String.valueOf(b + 1));
                     gameButton.setBackgroundResource(R.drawable.textview_border);
                     gameButton.setTextColor(Color.parseColor("#000000")); // black
@@ -576,7 +568,6 @@ public class Brazil extends GameActivity {
                     gameButton.setVisibility(View.INVISIBLE);
                 }
             } else { // Display viable answer choice
-                LOGGER.info("setUpTiles (not null): option=" + option.text + " b=" + b);
                 gameButton.setText(option.text);
                 gameButton.setBackgroundColor(Color.parseColor(colorList.get(b % 5)));
                 gameButton.setTextColor(Color.parseColor("#FFFFFF")); // white
@@ -586,11 +577,9 @@ public class Brazil extends GameActivity {
             }
         }
 
-        // LOGGER.info("setUpTiles: loop " + visibleGameButtons + " to " + GAME_BUTTONS.length);
         for (int b=visibleGameButtons; b<GAME_BUTTONS.length; b++) { // Hide empty buttons
             TextView gameButton = findViewById(GAME_BUTTONS[b]);
             if(!Objects.isNull(gameButton)) {
-                // LOGGER.info("setUpTiles (not null): gameButton=" + gameButton + "b=" + b);
                 gameButton.setText(String.valueOf(b + 1));
                 gameButton.setBackgroundResource(R.drawable.textview_border);
                 gameButton.setTextColor(Color.parseColor("#000000")); // black
@@ -605,7 +594,6 @@ public class Brazil extends GameActivity {
             int randomNum = rand.nextInt(visibleGameButtons - 1); // KP
             TextView gameButton = findViewById(GAME_BUTTONS[randomNum]);
             gameButton.setText(correctTile.text);
-            LOGGER.info("put correct tile into block:" + correctTile.text);
         }
 
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -975,7 +975,15 @@ public abstract class GameActivity extends AppCompatActivity {
             if (i==indexOfReplacedTile && thisTile.text.contains("__")) {
                 stringToAppend = thisTile.text; // Leave any Arabic script contextualizing characters around blanks
             } else {
-                stringToAppend = isolateForm(thisTile.text);
+                if (i==0 && !thisTile.wordInitialVariant.equals("none")) {
+                    stringToAppend = isolateForm(thisTile.wordInitialVariant);
+                } else if (i>0 && i<tilesInThisWordOption.size()-1 && !thisTile.wordMedialVariant.equals("none")) {
+                    stringToAppend = isolateForm(thisTile.wordMedialVariant);
+                } else if (i==tilesInThisWordOption.size()-1 && !thisTile.wordFinalVariant.equals("none")) {
+                    stringToAppend = isolateForm(thisTile.wordFinalVariant);
+                } else {
+                    stringToAppend = isolateForm(thisTile.text);
+                }
             }
 
             if(stringToAppend.contains(placeholderCharacter) && stringToAppend.length() == 2) { // Filter these placeholders out; keep the complex tile ones

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -1225,13 +1225,15 @@ public abstract class GameActivity extends AppCompatActivity {
 
 
     /**
-     * This method is used for Arabic script apps in games which have been set to use contextual forms of word pieces.
+     * This method is used for Arabic script apps in games which have been set to use contextual
+     * forms of word pieces.
      * @param isolateWordPieceString a String to contextualize
      * @param indexInWord the position of that Tile or Syllable within its word or pseudo-word
      * @param stringPieces the ArrayList of tile or syllable strings within the word or pseudo-word
      * @return the WordPiece's text in proper contextual form
      */
-    public static String contextualizedWordPieceString(String isolateWordPieceString, int indexInWord, ArrayList<String> stringPieces) {
+    public static String contextualizedWordPieceString(String isolateWordPieceString, int indexInWord,
+                                                       ArrayList<String> stringPieces) {
 
         if (indexInWord==0) { // WORD-INITIAL
             // Handle subsequent non-joiners
@@ -1514,6 +1516,10 @@ public abstract class GameActivity extends AppCompatActivity {
     public Start.Syllable fittingSyllableAlternative(WordPieceStringPositionSet alreadyAddedPlacements, ArrayList<Start.Syllable> syllablesInRefWord, int indexInParsedRefWordSyllableArray) {
 
         ArrayList<Start.Syllable> syllableListCopy = (Start.SyllableList) Start.syllableList.clone();
+
+        // The Brazil and Georgia games require random syllables, so shuffle the list first.
+        Collections.shuffle(syllableListCopy);
+
         for (Start.Syllable s : syllableListCopy) {
             if (!(alreadyAddedPlacements.contains(new WordPieceStringPosition(indexInParsedRefWordSyllableArray, s.text)))
                     && s.canBePlacedInPosition(syllablesInRefWord, indexInParsedRefWordSyllableArray)) {
@@ -1535,6 +1541,10 @@ public abstract class GameActivity extends AppCompatActivity {
     public Start.Syllable fittingSyllableAlternative(Start.Syllable refSyllable, ArrayList<Start.Syllable> alreadyAddedChoices, String contextualPosition) {
 
         ArrayList<Start.Syllable> syllableListCopy = (Start.SyllableList) Start.syllableList.clone();
+
+        // The Brazil and Georgia games require random syllables, so shuffle the list first.
+        Collections.shuffle(syllableListCopy);
+
         for (Start.Syllable s : syllableListCopy) {
             if (!alreadyAddedChoices.contains(s) && s.canBePlacedInPosition(contextualPosition)) {
                 return s;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Georgia.java
@@ -94,7 +94,7 @@ public class Georgia extends GameActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         context = this;
-        int gameID = 0;
+        int gameID;
         if (syllableGame.equals("S")) {
             setContentView(R.layout.georgia_syll);
             gameID = R.id.georgiaCL_syll;
@@ -181,8 +181,8 @@ public class Georgia extends GameActivity {
         setAllGameButtonsClickable();
         setOptionsRowClickable();
 
-        for (int i = 0; i < GAME_BUTTONS.length; i++) {
-            TextView nextWord = (TextView) findViewById(GAME_BUTTONS[i]);
+        for (int gameButton : GAME_BUTTONS) {
+            TextView nextWord = (TextView) findViewById(gameButton);
             nextWord.setClickable(true);
         }
 
@@ -514,7 +514,7 @@ public class Georgia extends GameActivity {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
 
-        String correctString = "";
+        String correctString;
         if (syllableGame.equals("S")) {
             correctString = initialSyllable.text;
         } else {
@@ -538,7 +538,7 @@ public class Georgia extends GameActivity {
                         .putValue("Correct Answer", correctString)
                         .putValue("Grade", studentGrade);
                 for (int i = 0; i < visibleGameButtons - 1; i++) {
-                    if (!incorrectAnswersSelected.get(i).equals("")) {
+                    if (!incorrectAnswersSelected.get(i).isEmpty()) {
                         info.putValue("Incorrect_" + (i + 1), incorrectAnswersSelected.get(i));
                     }
                 }
@@ -562,7 +562,7 @@ public class Georgia extends GameActivity {
             for (int i = 0; i < visibleGameButtons - 1; i++) {
                 String item = incorrectAnswersSelected.get(i);
                 if (item.equals(selectedTileString)) break;  // this incorrect answer already selected
-                if (item.equals("")) {
+                if (item.isEmpty()) {
                     incorrectAnswersSelected.set(i, selectedTileString);
                     break;
                 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Peru.java
@@ -226,7 +226,7 @@ public class Peru extends GameActivity {
                                 }
                             }
                             if (!(replacementTile.canBePlacedInPosition(parsedRefWordTileArray, randomIndexToReplace))
-                                    || alreadyAddedPlacements.contains(new WordPieceStringPosition(randomIndexToReplace, replacementTile.text))) {
+                                || alreadyAddedPlacements.contains(new WordPieceStringPosition(randomIndexToReplace, replacementTile.text))) {
                                 replacementTile = fittingTileAlternative(alreadyAddedPlacements, parsedRefWordTileArray, randomIndexToReplace, cumulativeStageBasedTileList);
                             }
                             if (!Objects.isNull(replacementTile)) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -2521,6 +2521,7 @@ public class Start extends AppCompatActivity {
 
     }
 
+
     /**
      * tracks two fields together: an index within a word to place the WordPiece into, and the WordPiece's text
      * Used for determining that randomly generated WordPiece replacements in wrong answer choices are distinct

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -2000,7 +2000,6 @@ public class Start extends AppCompatActivity {
                                 nextTile.text = next1Chars;  // The variant text becomes the main text for this word's tile array
                                 break;
                         }
-                        referenceWordStringPreliminaryTileArray.add(nextTile);
                     }
                 }
             }
@@ -2018,13 +2017,48 @@ public class Start extends AppCompatActivity {
                         nextTile.stageOfFirstAppearanceForThisTileType = nextTile.stageOfFirstAppearance;
                         nextTile.audioForThisTileType = nextTile.audioName;
                     }
-                    referenceWordStringPreliminaryTileArrayFinal.add(nextTile);
                 } else {
                     nextTile.typeOfThisTileInstance = nextTile.tileType;
                     nextTile.stageOfFirstAppearanceForThisTileType = nextTile.stageOfFirstAppearance;
                     nextTile.audioForThisTileType = nextTile.audioName;
-                    referenceWordStringPreliminaryTileArrayFinal.add(nextTile);
                 }
+                if (positionalVariantHashMap.containsKey(nextTile.text)) { // variants, if parsed, replaced base texts, above
+                    switch(nextTile.typeOfThisTileInstance) {
+                        case "V":
+                        case "LV":
+                        case "AV":
+                        case "BV":
+                        case "FV":
+                            VOWELS.add(nextTile);
+                            CorV.add(nextTile);
+                            break;
+                        case "C":
+                        case "PC":
+                            CONSONANTS.add(nextTile);
+                            CorV.add(nextTile);
+                            break;
+                        case "AD":
+                            ADs.add(nextTile);
+                            break;
+                        case "D":
+                            Ds.add(nextTile);
+                            break;
+                        case "T":
+                            TONES.add(nextTile);
+                        case "SAD":
+                            SAD.add(nextTile);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                if (!tileHashMap.containsKey(nextTile.text)) {
+                    tileHashMap.put(nextTile.text, nextTile);
+                }
+                if (!nextTile.tileType.equals("SAD") && !tileHashMapNoSAD.containsKey(nextTile.text)) {
+                    tileHashMapNoSAD.put(nextTile.text, nextTile);
+                }
+                referenceWordStringPreliminaryTileArrayFinal.add(nextTile);
                 tileIndex++;
             }
 
@@ -2142,6 +2176,43 @@ public class Start extends AppCompatActivity {
                                     nextTile = new Tile (positionalVariantHashMap.get(next1Chars));
                                     nextTile.text = next1Chars;  // The variant text becomes the main text for this word's tile array
                                     break;
+                            }
+
+                            if (positionalVariantHashMap.containsKey(nextTile.text)) { // variants, if parsed, replaced base texts, above
+                                switch (nextTile.typeOfThisTileInstance) {
+                                    case "V":
+                                    case "LV":
+                                    case "AV":
+                                    case "BV":
+                                    case "FV":
+                                        VOWELS.add(nextTile);
+                                        CorV.add(nextTile);
+                                        break;
+                                    case "C":
+                                    case "PC":
+                                        CONSONANTS.add(nextTile);
+                                        CorV.add(nextTile);
+                                        break;
+                                    case "AD":
+                                        ADs.add(nextTile);
+                                        break;
+                                    case "D":
+                                        Ds.add(nextTile);
+                                        break;
+                                    case "T":
+                                        TONES.add(nextTile);
+                                    case "SAD":
+                                        SAD.add(nextTile);
+                                        break;
+                                    default:
+                                        break;
+                                }
+                            }
+                            if (!tileHashMap.containsKey(nextTile.text)) {
+                                tileHashMap.put(nextTile.text, nextTile);
+                            }
+                            if (!nextTile.tileType.equals("SAD") && !tileHashMapNoSAD.containsKey(nextTile.text)) {
+                                tileHashMapNoSAD.put(nextTile.text, nextTile);
                             }
                             stringToParsePreliminaryTileArray.add(nextTile);
                         }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -899,6 +899,11 @@ public class Start extends AppCompatActivity {
         }
     }
 
+    /**
+     * Initialize the positionalVariantHashmap and add any variant strings
+     * from gametiles columns Word-InitialVariant, Word-MedialVariant, and Word-FinalVariant
+     * as keys for the Tile objects they vary from
+     */
     public void buildPositionalVariantHashMap() {
         positionalVariantHashMap = new TileHashMap();
         for (int i = 0; i < tileList.size(); i++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -2000,6 +2000,7 @@ public class Start extends AppCompatActivity {
                                 nextTile.text = next1Chars;  // The variant text becomes the main text for this word's tile array
                                 break;
                         }
+                        referenceWordStringPreliminaryTileArray.add(nextTile);
                     }
                 }
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -428,7 +428,7 @@ public class Start extends AppCompatActivity {
                 distractors.add(thisLineArray[1]);
                 distractors.add(thisLineArray[2]);
                 distractors.add(thisLineArray[3]);
-                Tile tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[4], stageOfFirstAppearance, thisLineArray[5], positionRestrictions);
+                Tile tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[4], stageOfFirstAppearance, thisLineArray[5], positionRestrictions, thisLineArray[18], thisLineArray[19], thisLineArray[20]);
                 if (!tile.hasNull()) {
                     tileList.add(tile);
                     if (!tile.typeOfThisTileInstance.equals("SAD") && !(tile.audioForThisTileType.equals("zz_no_audio_needed") && !tile.typeOfThisTileInstance.equals("PC"))) {
@@ -436,7 +436,7 @@ public class Start extends AppCompatActivity {
                     }
                 }
                 if(!tile.tileTypeB.equals("none")){
-                    tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[7], stageOfFirstAppearanceType2, thisLineArray[8], positionRestrictions);
+                    tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[7], stageOfFirstAppearanceType2, thisLineArray[8], positionRestrictions, thisLineArray[18], thisLineArray[19], thisLineArray[20]);
                     if (!tile.hasNull()) {
                         tileList.add(tile);
                         if (!tile.typeOfThisTileInstance.equals("SAD") && !(tile.audioForThisTileType.equals("zz_no_audio_needed") && !tile.typeOfThisTileInstance.equals("PC"))) {
@@ -445,7 +445,7 @@ public class Start extends AppCompatActivity {
                     }
                 }
                 if(!tile.tileTypeC.equals("none")){
-                    tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[9], stageOfFirstAppearanceType3, thisLineArray[10], positionRestrictions);
+                    tile = new Tile(thisLineArray[0], distractors, thisLineArray[4], thisLineArray[5], thisLineArray[6], thisLineArray[7], thisLineArray[8], thisLineArray[9], thisLineArray[10], 0, 0, 0, stageOfFirstAppearance, stageOfFirstAppearanceType2, stageOfFirstAppearanceType3, thisLineArray[9], stageOfFirstAppearanceType3, thisLineArray[10], positionRestrictions, thisLineArray[18], thisLineArray[19], thisLineArray[20]);
                     if (!tile.hasNull()) {
                         tileList.add(tile);
                         if (!tile.typeOfThisTileInstance.equals("SAD") && !(tile.audioForThisTileType.equals("zz_no_audio_needed") && !tile.typeOfThisTileInstance.equals("PC"))) {
@@ -947,10 +947,12 @@ public class Start extends AppCompatActivity {
         public String typeOfThisTileInstance;
         public int stageOfFirstAppearanceForThisTileType;
         public String audioForThisTileType;
-
         public String positionRestrictions;
+        public String wordInitialVariant;
+        public String wordMedialVariant;
+        public String wordFinalVariant;
 
-        public Tile(String text, ArrayList<String> distractors, String tileType, String audioName, String upper, String tileTypeB, String audioNameB, String tileTypeC, String audioNameC, int tileDuration1, int tileDuration2, int tileDuration3, int stageOfFirstAppearance, int stageOfFirstAppearanceB, int stageOfFirstAppearanceC, String typeOfThisTileInstance, int stageOfFirstAppearanceForThisTileType, String audioForThisTileType, String positionRestrictions) {
+        public Tile(String text, ArrayList<String> distractors, String tileType, String audioName, String upper, String tileTypeB, String audioNameB, String tileTypeC, String audioNameC, int tileDuration1, int tileDuration2, int tileDuration3, int stageOfFirstAppearance, int stageOfFirstAppearanceB, int stageOfFirstAppearanceC, String typeOfThisTileInstance, int stageOfFirstAppearanceForThisTileType, String audioForThisTileType, String positionRestrictions, String wordInitialVariant, String wordMedialVariant, String wordFinalVariant) {
             super(text);
             this.distractors = distractors;
             this.tileType = tileType;
@@ -970,6 +972,9 @@ public class Start extends AppCompatActivity {
             this.stageOfFirstAppearanceForThisTileType = stageOfFirstAppearanceForThisTileType;
             this.audioForThisTileType = audioForThisTileType;
             this.positionRestrictions = positionRestrictions;
+            this.wordInitialVariant = wordInitialVariant;
+            this.wordMedialVariant = wordMedialVariant;
+            this.wordFinalVariant = wordFinalVariant;
         }
 
         public Tile (Tile anotherTile) {
@@ -992,6 +997,9 @@ public class Start extends AppCompatActivity {
             this.stageOfFirstAppearanceForThisTileType = anotherTile.stageOfFirstAppearanceForThisTileType;
             this.audioForThisTileType = anotherTile.audioForThisTileType;
             this.positionRestrictions = anotherTile.positionRestrictions;
+            this.wordInitialVariant = anotherTile.wordInitialVariant;
+            this.wordMedialVariant = anotherTile.wordMedialVariant;
+            this.wordFinalVariant = anotherTile.wordFinalVariant;
         }
 
         public boolean hasNull() {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -284,13 +284,25 @@ public class Thailand extends GameActivity {
                         case "CONTEXTUAL":
                             switch (contextualTilePosition) {
                                 case "INITIAL":
-                                    refString = contextualizedForm_Initial(refTile.text);
+                                    if (!refTile.wordInitialVariant.equals("none")) {
+                                        refString = refTile.wordInitialVariant;
+                                    } else {
+                                        refString = contextualizedForm_Initial(refTile.text);
+                                    }
                                     break;
                                 case "FINAL":
-                                    refString = contextualizedForm_Final(refTile.text);
+                                    if (!refTile.wordFinalVariant.equals("none")) {
+                                        refString = refTile.wordFinalVariant;
+                                    } else {
+                                        refString = contextualizedForm_Final(refTile.text);
+                                    }
                                     break;
                                 default: // MEDIAL
-                                    refString = contextualizedForm_Medial(refTile.text);
+                                    if (!refTile.wordMedialVariant.equals("none")) {
+                                        refString = refTile.wordMedialVariant;
+                                    } else {
+                                        refString = contextualizedForm_Medial(refTile.text);
+                                    }
                                     break;
                             }
                             break;
@@ -401,7 +413,11 @@ public class Thailand extends GameActivity {
                             int choiceColorNo = Color.parseColor(choiceColorStr);
                             choiceButton.setBackgroundColor(choiceColorNo);
                             choiceButton.setTextColor(Color.parseColor("#000000")); // black
-                            choiceButton.setText(contextualizedForm_Initial(fourTileChoices.get(t).text));
+                            if (!fourTileChoices.get(t).wordInitialVariant.equals("none")) {
+                                choiceButton.setText(fourTileChoices.get(t).wordInitialVariant);
+                            } else {
+                                choiceButton.setText(contextualizedForm_Initial(fourTileChoices.get(t).text));
+                            }
                         }
                         break;
                     case "FINAL":
@@ -411,7 +427,11 @@ public class Thailand extends GameActivity {
                             int choiceColorNo = Color.parseColor(choiceColorStr);
                             choiceButton.setBackgroundColor(choiceColorNo);
                             choiceButton.setTextColor(Color.parseColor("#000000")); // black
-                            choiceButton.setText(contextualizedForm_Final(fourTileChoices.get(t).text));
+                            if (!fourTileChoices.get(t).wordFinalVariant.equals("none")) {
+                                choiceButton.setText(fourTileChoices.get(t).wordFinalVariant);
+                            } else {
+                                choiceButton.setText(contextualizedForm_Final(fourTileChoices.get(t).text));
+                            }
                         }
                         break;
                     default: // MEDIAL
@@ -421,7 +441,11 @@ public class Thailand extends GameActivity {
                             int choiceColorNo = Color.parseColor(choiceColorStr);
                             choiceButton.setBackgroundColor(choiceColorNo);
                             choiceButton.setTextColor(Color.parseColor("#000000")); // black
-                            choiceButton.setText(contextualizedForm_Medial(fourTileChoices.get(t).text));
+                            if (!fourTileChoices.get(t).wordMedialVariant.equals("none")) {
+                                choiceButton.setText(fourTileChoices.get(t).wordMedialVariant);
+                            } else {
+                                choiceButton.setText(contextualizedForm_Medial(fourTileChoices.get(t).text));
+                            }
                         }
                         break;
                 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -151,7 +151,7 @@ public class UnitedStates extends GameActivity {
                 parsedRefWordSyllableArrayStrings.add(s.text);
             }
         } else {
-            Tile emptyTile = new Tile("__", new ArrayList<String>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, "", 0, "", "No restrictions (default)");
+            Tile emptyTile = new Tile("__", new ArrayList<String>(), "", "", "", "", "", "", "", 0, 0, 0, 0, 0, 0, "", 0, "", "No restrictions (default)", "none", "none", "none");
             tileSelections = new Tile[parsedLengthOfRefWord];
             for (int t = 0; t<parsedLengthOfRefWord; t++) {
                 tileSelections[t] = new Tile(emptyTile);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
+import java.util.logging.Logger;
 
 import android.graphics.Typeface;
 import android.widget.Button;
@@ -36,6 +37,8 @@ public class UnitedStates extends GameActivity {
 
     ArrayList<Tile> tileOptions = new ArrayList<>();
     Tile[] tileSelections;
+
+    private static final Logger LOGGER = Logger.getLogger(UnitedStates.class.getName());
 
     protected static final int[] GAME_BUTTONS = {
             R.id.button01a, R.id.button01b, R.id.button02a, R.id.button02b, R.id.button03a, R.id.button03b, R.id.button04a, R.id.button04b, R.id.button05a, R.id.button05b,
@@ -74,7 +77,7 @@ public class UnitedStates extends GameActivity {
         super.onCreate(savedInstanceState);
         context = this;
 
-        int gameID = 0;
+        int gameID;
         switch (challengeLevel) {
             case 2:
                 setContentView(R.layout.united_states_cl2);
@@ -268,10 +271,10 @@ public class UnitedStates extends GameActivity {
         }
 
         TextView constructedWord = findViewById(R.id.activeWordTextView);
-        String initialDisplay = "";
+        StringBuilder initialDisplay = new StringBuilder();
         for (int i = 0; i < numberOfPairs; i++)
-            initialDisplay += "__";
-        constructedWord.setText(initialDisplay);
+            initialDisplay.append("__");
+        constructedWord.setText(initialDisplay.toString());
 
 
         if (useContextualFormsBWFP) { // Option for Arabic scripts
@@ -331,21 +334,33 @@ public class UnitedStates extends GameActivity {
         } else {
             lastSelectedIndex = (tileIndex - 1) / 2;
         }
-
+        LOGGER.info("buildWord: tileIndex=" + tileIndex + "/lastIndex=" + lastSelectedIndex);
         String displayedWord;
         if (syllableGame.equals("S")){
             StringBuilder stringBuilder = new StringBuilder();
-
+            LOGGER.info("buildWord: numberOfPairs=" + numberOfPairs);
             for (int i = 0; i < numberOfPairs; i++) {
+                LOGGER.info("buildWord: i=" + i + "/pairHasSelection=" + pairHasSelection[i]);
                 if (pairHasSelection[i]) {
                     stringBuilder.append(selections[2 * i]);
                     stringBuilder.append(selections[2 * i + 1]);
                 } else {
-                    stringBuilder.append(contextualizedWordPieceString("__", i, parsedRefWordSyllableArrayStrings));
+                    // Be sure not to use the default dummy contextualizingCharacter value XYZXYZ,
+                    // as that is meaningless in non-Arabic languages.
+                    String underbars = "__";
+                    String s = contextualizedWordPieceString(underbars, i, parsedRefWordSyllableArrayStrings);
+                    if (s.startsWith("XYZXYZ")) {
+                        stringBuilder.append(underbars);
+                        LOGGER.info("buildWord: append=" + underbars);
+                    } else {
+                        stringBuilder.append(s);
+                        LOGGER.info("buildWord: append=" + s);
+                    }
                 }
             }
 
             displayedWord = stringBuilder.toString();
+            LOGGER.info("buildWord: displayedWord=" + displayedWord);
             constructedWord.setText(displayedWord);
 
         } else {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/UnitedStates.java
@@ -334,13 +334,12 @@ public class UnitedStates extends GameActivity {
         } else {
             lastSelectedIndex = (tileIndex - 1) / 2;
         }
-        LOGGER.info("buildWord: tileIndex=" + tileIndex + "/lastIndex=" + lastSelectedIndex);
+
         String displayedWord;
         if (syllableGame.equals("S")){
             StringBuilder stringBuilder = new StringBuilder();
-            LOGGER.info("buildWord: numberOfPairs=" + numberOfPairs);
+
             for (int i = 0; i < numberOfPairs; i++) {
-                LOGGER.info("buildWord: i=" + i + "/pairHasSelection=" + pairHasSelection[i]);
                 if (pairHasSelection[i]) {
                     stringBuilder.append(selections[2 * i]);
                     stringBuilder.append(selections[2 * i + 1]);
@@ -351,16 +350,13 @@ public class UnitedStates extends GameActivity {
                     String s = contextualizedWordPieceString(underbars, i, parsedRefWordSyllableArrayStrings);
                     if (s.startsWith("XYZXYZ")) {
                         stringBuilder.append(underbars);
-                        LOGGER.info("buildWord: append=" + underbars);
                     } else {
                         stringBuilder.append(s);
-                        LOGGER.info("buildWord: append=" + s);
                     }
                 }
             }
 
             displayedWord = stringBuilder.toString();
-            LOGGER.info("buildWord: displayedWord=" + displayedWord);
             constructedWord.setText(displayedWord);
 
         } else {

--- a/validator/templateTemplate/res/raw/aa_gametiles.txt
+++ b/validator/templateTemplate/res/raw/aa_gametiles.txt
@@ -1,2 +1,2 @@
-tiles	Or1	Or2	Or3	Type	AudioName	Upper	Type2	AudioName2	Type3	AudioName3	Placeholder	Placeholder	Placeholder	FirstAppearsInStage...	FirstAppearsInStage...(Type2)	FirstAppearsInStage...(Type3)   PositionRestrictions
-							none	X	none	X	0	0	0	-	-	-   No restrictions (default)
+tiles	Or1	Or2	Or3	Type	AudioName	Upper	Type2	AudioName2	Type3	AudioName3	Placeholder	Placeholder	Placeholder	FirstAppearsInStage...	FirstAppearsInStage...(Type2)	FirstAppearsInStage...(Type3)   PositionRestrictions	Word-InitialVariant	Word-MedialVariant	Word-FinalVariant
+							none	X	none	X	0	0	0	-	-	-   No restrictions (default)	none	none	none


### PR DESCRIPTION
This is a new feature pull request to the _contextual-forms_ branch. **Note that** this should be tested after #234, since it builds upon it.

In some orthographies, what is conceived of as 'the same' tile has different manifestations - distinct strings, not just contextual renderings - when it's in different parts of words (beginning, middle, or end). This new feature allows teams to indicate the variant strings for tiles, as long as they are consistently used in that position within the words of the wordlist.

**How to test**
This branch is based on top of the position-restrictions branch. Make sure you already have the PositionRestrictions column, probably with default values. See #234.
1. Add columns Word-InitialVariant, Word-MedialVariant, and Word-FinalVariant to gametiles, ideally in more than one different language pack.
2. Add default values "none" to every tile row under these three columns.
3. Run the validator with default values. It should not report any errors.
4. Run the app with default values. Check, ideally, every Game Activity. They should run as normal.
5. Repeat 3 and 4 with variants specified. Ideally, ask teams (JF, MS, JHY, JG) for the cases in which their apps' orthographies do this and test those cases.
6. If variants are specified but not used in the way specified in words, you should see errors reported by the validator.
7. If variant values are not "none" or something less than 5 characters long, you should see errors reported by the validator.
8. Change the PositionRestrictions values from defaults, if you haven't already. 
9. If position restrictions clash with positional variants, you should see errors reported by the validator. A tile cannot have a variant and be prohibited from that variant's position. It must be allowed into that position to be able to access the variant. 
10. If a configuration of these fields can be made to where everything may be parsed and validates correctly, try running the app and test the games again. 
11. Eventually, check with teams who use these features for their feedback.
12. Document these new columns for future language pack creators.