### PR TITLE
2.8.0 Deprecated code fixes, dependencies, etc.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,23 +2,26 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdk 36
+    compileSdk = 36
 
     defaultConfig {
         vectorDrawables.useSupportLibrary = true
         applicationId "org.alphatilesapps.alphatiles"
-        minSdkVersion 21
-        targetSdkVersion 36
-        versionCode 183
-        versionName "2.7.1"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        minSdk = 21
+        targetSdk = 36
+        versionCode = 183
+        versionName = "2.8.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    android {
-        buildFeatures {
-            buildConfig = true
-        }
+    buildFeatures {
+        buildConfig = true
+
     }
+
+//    tasks.withType(JavaCompile) {
+//        options.compilerArgs << "-Xlint:deprecation"
+//    }
 
     buildTypes {
         release {
@@ -50,6 +53,10 @@ android {
     namespace 'org.alphatilesapps.alphatiles'
 }
 
+//tasks.withType(JavaCompile).configureEach {
+//    options.compilerArgs += ['-Xlint:unchecked']
+//}
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.7.1'
@@ -59,7 +66,8 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.16.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.segment.analytics.android:analytics:4.11.3'
-    testImplementation 'androidx.test.ext:junit:1.2.1'
+    implementation 'androidx.core:core:1.17.0-rc01'
+    testImplementation 'androidx.test.ext:junit:1.3.0'
     testImplementation 'org.robolectric:robolectric:4.15.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/About.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/About.java
@@ -11,6 +11,8 @@ import android.text.util.Linkify;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
+import androidx.core.text.util.LinkifyCompat;
+import android.os.Build;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
@@ -57,7 +59,7 @@ public class About extends AppCompatActivity {
 
         TextView photoAudioCredits2 = findViewById(R.id.photoAudioCredits2);
         String mediaTwo = Start.langInfoList.find("Audio and image credits (lang 2)");
-        if (mediaTwo.equals("none") || mediaTwo.equals(null)|| mediaTwo.equals("")) {
+        if (mediaTwo != null && !mediaTwo.equalsIgnoreCase("none") && !mediaTwo.isEmpty()) {
             photoAudioCredits2.setText("");
         } else {
             photoAudioCredits2.setText(mediaTwo);
@@ -71,12 +73,12 @@ public class About extends AppCompatActivity {
         }
 
         TextView email = findViewById(R.id.email);
-        email.setAutoLinkMask(Linkify.EMAIL_ADDRESSES);
         String contactEmail = Start.langInfoList.find("Email");
-    if (contactEmail.equals("none") || contactEmail.equals(null)|| contactEmail.equals("")) {
+        if (contactEmail == null || contactEmail.equals("none") || contactEmail.isEmpty()) {
             email.setText("");
         } else {
             email.setText(contactEmail);
+            LinkifyCompat.addLinks(email, Linkify.EMAIL_ADDRESSES);
             email.setMovementMethod(LinkMovementMethod.getInstance());
         }
 
@@ -84,7 +86,12 @@ public class About extends AppCompatActivity {
 
         String httpText = Start.langInfoList.find("Privacy Policy");
         String linkText = "<a href=\"" + httpText + "\">" + "Privacy Policy" + "</a>";
-        CharSequence styledText = Html.fromHtml(linkText);
+        CharSequence styledText;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            styledText = Html.fromHtml(linkText, Html.FROM_HTML_MODE_LEGACY);
+        } else {
+            styledText = Html.fromHtml(linkText); // for API 21 to 23
+        }
         privacyPolicy.setText(styledText);
         privacyPolicy.setMovementMethod(LinkMovementMethod.getInstance());
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/ActivityLayouts.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/ActivityLayouts.java
@@ -1,21 +1,23 @@
 package org.alphatilesapps.alphatiles;
 
+import static com.google.android.material.color.MaterialColors.isColorLight;
+
 import android.app.Activity;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 
 import androidx.activity.ComponentActivity;
 import androidx.activity.EdgeToEdge;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
-
-// https://developer.android.com/develop/ui/views/layout/edge-to-edge-manually
-// https://stackoverflow.com/questions/76868700/set-insets-for-all-activities-android
-// https://stackoverflow.com/questions/57293449/go-edge-to-edge-on-android-correctly-with-windowinsets
+import androidx.core.view.WindowInsetsControllerCompat;
 
 public final class ActivityLayouts {
 
@@ -28,22 +30,58 @@ public final class ActivityLayouts {
         // Set Listener
         ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
             Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-            mlp.topMargin = insets.top;
-            mlp.bottomMargin = insets.bottom;
-            mlp.leftMargin = insets.left;
-            mlp.rightMargin = insets.right;
-            v.setLayoutParams(mlp);
+
+            // Example: only add padding to the bottom if your content needs to avoid the nav bar
+            v.setPadding(
+                    insets.left,
+                    insets.top,    // ✅ Add top padding so content starts below the status bar
+                    insets.right,
+                    insets.bottom  // ✅ Keep bottom padding for nav bar
+            );
+
             return windowInsets;
         });
 
     }
-    public static void setStatusAndNavColors (Activity activity) {
+    public static void setStatusAndNavColors(Activity activity) {
         Window window = activity.getWindow();
-        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-        window.setStatusBarColor(activity.getResources().getColor(R.color.themeBlue));
-        window.setNavigationBarColor(activity.getResources().getColor(R.color.themeBlue));
-    }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // On R+ / Android 11+ / API 30+, use WindowInsetsController
+            window.setDecorFitsSystemWindows(false);
+            window.setStatusBarColor(Color.TRANSPARENT);
+            window.setNavigationBarColor(Color.TRANSPARENT);
+
+            // Detect background color under the transparent status bar
+            View root = window.getDecorView().findViewById(android.R.id.content);
+            int statusColor = Color.TRANSPARENT; // default
+
+            Drawable bg = root.getBackground();
+            if (bg instanceof ColorDrawable) {
+                statusColor = ((ColorDrawable) bg).getColor();
+            }
+
+            // Fallback if still transparent or no drawable
+            if (statusColor == Color.TRANSPARENT) {
+                statusColor = ContextCompat.getColor(activity, android.R.color.background_light);
+            }
+
+            // Determine if background is light
+            boolean isLightBackground = isColorLight(statusColor);
+
+            // If background is light, force dark icons
+            WindowInsetsControllerCompat insetsControllerCompat =
+                    new WindowInsetsControllerCompat(window, window.getDecorView());
+            insetsControllerCompat.setAppearanceLightStatusBars(isLightBackground);
+            insetsControllerCompat.setAppearanceLightNavigationBars(isLightBackground);
+
+        } else {
+            // Pre-Android 11
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.setStatusBarColor(ContextCompat.getColor(activity, R.color.themeBlue));
+            window.setNavigationBarColor(ContextCompat.getColor(activity, R.color.themeBlue));
+        }
+    }
 }
+

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Celebration.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Celebration.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
 
 import static org.alphatilesapps.alphatiles.Start.gameSounds;
@@ -19,6 +20,15 @@ public class Celebration extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
 
         super.onCreate(savedInstanceState);
+
+        // Disable back navigation
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                // Intentionally empty — do nothing
+            }
+        });
+
         context = this;
         setContentView(R.layout.celebration);
 
@@ -36,11 +46,5 @@ public class Celebration extends AppCompatActivity {
         startActivity(intent);
         finish();
     }
-
-    @Override
-    public void onBackPressed() {
-        // no action
-    }
-
 
 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/ChoosePlayer.java
@@ -1,5 +1,6 @@
 package org.alphatilesapps.alphatiles;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
@@ -81,6 +82,15 @@ public class ChoosePlayer extends AppCompatActivity {
 
         setTheme(R.style.AppTheme);
         super.onCreate(savedInstanceState);
+
+        // Disable back navigation
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                // Intentionally empty — do nothing
+            }
+        });
+
         setContentView(R.layout.choose_player);
 
         ActivityLayouts.applyEdgeToEdge(this, R.id.choosePlayerCL);
@@ -119,8 +129,8 @@ public class ChoosePlayer extends AppCompatActivity {
         choosePlayerCL = findViewById(R.id.choosePlayerCL);
 
         // Populate arrays from what is actually in the layout
-        avatarIdList = new ArrayList();
-        avatarJpgList = new ArrayList();
+        avatarIdList = new ArrayList<>();
+        avatarJpgList = new ArrayList<>();
 
         for (int j = 0; j < choosePlayerCL.getChildCount(); j++) {
             View child = choosePlayerCL.getChildAt(j);
@@ -317,11 +327,6 @@ public class ChoosePlayer extends AppCompatActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             getWindow().getDecorView().setLayoutDirection(View.LAYOUT_DIRECTION_LTR);
         }
-    }
-
-    @Override
-    public void onBackPressed() {
-        // no action
     }
 
 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Earth.java
@@ -1,5 +1,6 @@
 package org.alphatilesapps.alphatiles;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.constraintlayout.widget.ConstraintLayout;
@@ -41,6 +42,15 @@ public class Earth extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Disable back navigation
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                // Intentionally empty — do nothing
+            }
+        });
+
         context = this;
         playerNumber = getIntent().getIntExtra("playerNumber", -1);
         playerString = Util.returnPlayerStringToAppend(playerNumber);
@@ -367,8 +377,4 @@ public class Earth extends AppCompatActivity {
         }
     }
 
-    @Override
-    public void onBackPressed() {
-        // no action
-    }
 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Ecuador.java
@@ -409,30 +409,34 @@ public class Ecuador extends GameActivity {
 
     public static Point getAppUsableScreenSize(Context context) {
         WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-        Display display = windowManager.getDefaultDisplay();
-        Point size = new Point();
-        display.getSize(size);
-        return size;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {  // API 30+
+            WindowMetrics metrics = windowManager.getCurrentWindowMetrics();
+            Insets insets = metrics.getWindowInsets().getInsetsIgnoringVisibility(
+                    WindowInsets.Type.systemBars() | WindowInsets.Type.displayCutout());
+            int width = metrics.getBounds().width() - insets.left - insets.right;
+            int height = metrics.getBounds().height() - insets.top - insets.bottom;
+            return new Point(width, height);
+        } else {
+            Display display = windowManager.getDefaultDisplay();
+            Point size = new Point();
+            display.getSize(size);
+            return size;
+        }
     }
 
     public static Point getRealScreenSize(Context context) {
         WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-        Display display = windowManager.getDefaultDisplay();
-        Point size = new Point();
-
-        if (Build.VERSION.SDK_INT >= 17) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {  // API 30+
+            WindowMetrics metrics = windowManager.getCurrentWindowMetrics();
+            int width = metrics.getBounds().width();
+            int height = metrics.getBounds().height();
+            return new Point(width, height);
+        } else {
+            Display display = windowManager.getDefaultDisplay();
+            Point size = new Point();
             display.getRealSize(size);
-        } else if (Build.VERSION.SDK_INT >= 14) {
-            try {
-                size.x = (Integer) Display.class.getMethod("getRawWidth").invoke(display);
-                size.y = (Integer) Display.class.getMethod("getRawHeight").invoke(display);
-            } catch (IllegalAccessException e) {
-            } catch (InvocationTargetException e) {
-            } catch (NoSuchMethodException e) {
-            }
+            return size;
         }
-
-        return size;
     }
 
     private void respondToWordSelection() {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -126,8 +126,8 @@ public abstract class GameActivity extends AppCompatActivity {
         for(Start.Word thisWord : wordList){
             ArrayList<Start.Tile> thisParsedTileArray = tileList.parseWordIntoTiles(thisWord.wordInLOP, thisWord);
             ArrayList<Start.Tile> thisPreliminaryParsedTileArray = tileList.parseWordIntoTilesPreliminary(thisWord.wordInLOP, thisWord);
-            ArrayList<String> thisParsedTileArrayStrings = new ArrayList();
-            ArrayList<String> thisPreliminaryParsedTileArrayStrings = new ArrayList();
+            ArrayList<String> thisParsedTileArrayStrings = new ArrayList<>();
+            ArrayList<String> thisPreliminaryParsedTileArrayStrings = new ArrayList<>();
             for(Start.Tile tile : thisParsedTileArray) {
                 thisParsedTileArrayStrings.add(tile.text);
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/LoadingScreen.java
@@ -7,11 +7,15 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.AssetFileDescriptor;
 import android.content.res.Resources;
+import android.graphics.BlendMode;
+import android.graphics.BlendModeColorFilter;
 import android.graphics.Color;
 import android.media.MediaMetadataRetriever;
 import android.media.SoundPool;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -44,7 +48,7 @@ public class LoadingScreen extends AppCompatActivity {
     //JP June 2022: moved loading of all SoundPool audio into this activity
     //note: audio instructions use MediaPlayer, not SoundPool
 
-    private Handler mHandler = new Handler();
+    private Handler mHandler;
     Context context;
     ProgressBar progressBar;
 
@@ -59,6 +63,8 @@ public class LoadingScreen extends AppCompatActivity {
         ActivityLayouts.setStatusAndNavColors(this);
 
         this.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+
+        mHandler = new Handler(Looper.getMainLooper());
 
         progressBar = findViewById(R.id.progressBar);
         String scriptDirection = langInfoList.find("Script direction (LTR or RTL)");
@@ -138,9 +144,15 @@ public class LoadingScreen extends AppCompatActivity {
                     @Override
                     public void run() {
 
-                        progressBar.getProgressDrawable().setColorFilter(
-                                Color.rgb(reds[mod_color[0]], greens[mod_color[0]], blues[mod_color[0]]),
-                                android.graphics.PorterDuff.Mode.SRC_IN);
+                        int color = Color.rgb(reds[mod_color[0]], greens[mod_color[0]], blues[mod_color[0]]);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) { // API 29+
+                            progressBar.getProgressDrawable().setColorFilter(
+                                    new BlendModeColorFilter(color, BlendMode.SRC_IN));
+                        } else {
+                            progressBar.getProgressDrawable().setColorFilter(
+                                    color,
+                                    android.graphics.PorterDuff.Mode.SRC_IN);
+                        }
 
                     }
                 });
@@ -180,7 +192,7 @@ public class LoadingScreen extends AppCompatActivity {
     public void loadWordAudio() {
         // load speech sounds
         Resources res = context.getResources();
-        wordAudioIDs = new HashMap();
+        wordAudioIDs = new HashMap<>();
 
         int i = 0;
         for (Start.Word word : wordList) {
@@ -198,7 +210,7 @@ public class LoadingScreen extends AppCompatActivity {
 
     public void loadSyllableAudio() {
         Resources res = context.getResources();
-        syllableAudioIDs = new HashMap();
+        syllableAudioIDs = new HashMap<>();
 
         int i = 0;
         for (Start.Syllable syllable : syllableList) {
@@ -216,8 +228,8 @@ public class LoadingScreen extends AppCompatActivity {
 
     public void loadTileAudio() {
         Resources res = context.getResources();
-        tileAudioIDs = new HashMap(0);
-        tileDurations = new HashMap();
+        tileAudioIDs = new HashMap<>(0);
+        tileDurations = new HashMap<>();
 
         int i = 0;
         for (Start.Tile tile : tileList) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Mexico.java
@@ -5,6 +5,7 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -19,7 +20,7 @@ import static org.alphatilesapps.alphatiles.Start.*;
 
 public class Mexico extends GameActivity {
 
-    ArrayList<String[]> memoryCollection = new ArrayList(); // KP
+    ArrayList<String[]> memoryCollection = new ArrayList<>();
     int justClickedCard;
     int priorClickedCard;
     int activeSelections = 0;
@@ -257,7 +258,7 @@ public class Mexico extends GameActivity {
             setOptionsRowUnclickable();
             setAllGameButtonsUnclickable();
 
-            handler = new Handler();
+            handler = new Handler(Looper.getMainLooper());
             handler.postDelayed(quickViewDelay, Long.valueOf(800));
         }
 
@@ -334,7 +335,7 @@ public class Mexico extends GameActivity {
             if (!delaySetting.equals("")) {
                 delay = Long.valueOf(delaySetting);
             }
-            handler = new Handler();
+            handler = new Handler(Looper.getMainLooper());
             handler.postDelayed(flipCardsBackOver, delay);
 
         }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Myanmar.java
@@ -2,12 +2,17 @@ package org.alphatilesapps.alphatiles;
 
 import android.content.res.Resources;
 import android.graphics.Color;
+import android.graphics.Insets;
 import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowMetrics;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -110,9 +115,18 @@ public class Myanmar extends GameActivity {
 
     public void setTextSizes() {
 
-        DisplayMetrics displayMetrics = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
-        int heightOfDisplay = displayMetrics.heightPixels;
+        int heightOfDisplay;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {  // API 30+
+            WindowMetrics windowMetrics = getWindowManager().getCurrentWindowMetrics();
+            Insets insets = windowMetrics.getWindowInsets()
+                    .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars());
+            heightOfDisplay = windowMetrics.getBounds().height() - insets.top - insets.bottom;
+        } else {
+            DisplayMetrics displayMetrics = new DisplayMetrics();
+            getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+            heightOfDisplay = displayMetrics.heightPixels;
+        }
         int pixelHeight = 0;
         double scaling = 0.45;
         int bottomToTopId;
@@ -612,7 +626,7 @@ public class Myanmar extends GameActivity {
                 updatePointsAndTrackers(wordsCompleted);
             }
             playCorrectSoundThenActiveWordClip(wordsCompleted == completionGoal);
-            handler = new Handler();
+            handler = new Handler(Looper.getMainLooper());
             handler.postDelayed(clearImageFromImageBank(indexOfFoundWord), Long.valueOf(refWord.duration + correctSoundDuration));
 
         } else { // Word not found

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Resources.java
@@ -161,7 +161,11 @@ public class Resources extends AppCompatActivity {
                 String httpText = resourcesList[r][1];
                 String displayText = resourcesList[r][0];
                 String linkText = "<a href=\"" + httpText + "\">" + displayText + "</a>";
-                promotedText.setText(Html.fromHtml(linkText));
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {  // API 24+
+                    promotedText.setText(Html.fromHtml(linkText, Html.FROM_HTML_MODE_LEGACY));
+                } else {
+                    promotedText.setText(Html.fromHtml(linkText));
+                }
                 promotedText.setMovementMethod(LinkMovementMethod.getInstance());
 
             } else {
@@ -217,7 +221,11 @@ public class Resources extends AppCompatActivity {
             String httpText = resourcesList[resourceIndex][1];
             String displayText = resourcesList[resourceIndex][0];
             String linkText = "<a href=\"" + httpText + "\">" + displayText + "</a>";
-            promotedText.setText(Html.fromHtml(linkText));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {  // API 24+
+                promotedText.setText(Html.fromHtml(linkText, Html.FROM_HTML_MODE_LEGACY));
+            } else {
+                promotedText.setText(Html.fromHtml(linkText));
+            }
             promotedText.setMovementMethod(LinkMovementMethod.getInstance());
 
             promotedResource.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/SetPlayerName.java
@@ -6,17 +6,21 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.graphics.Color;
+import android.graphics.Insets;
 import android.media.MediaPlayer;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.View;
+import android.view.WindowInsets;
 import android.view.WindowManager;
+import android.view.WindowMetrics;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
 
@@ -48,6 +52,15 @@ public class SetPlayerName extends AppCompatActivity {
         context = this;
 
         super.onCreate(savedInstanceState);
+
+        // Disable back navigation
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                // Intentionally empty — do nothing
+            }
+        });
+
         setContentView(R.layout.set_player_name);
 
         ActivityLayouts.applyEdgeToEdge(this, R.id.setPlayerNameCL);
@@ -114,9 +127,18 @@ public class SetPlayerName extends AppCompatActivity {
 
     public void setTextSizes() {
 
-        DisplayMetrics displayMetrics = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
-        int heightOfDisplay = displayMetrics.heightPixels;
+        int heightOfDisplay;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {  // API 30+
+            WindowMetrics windowMetrics = getWindowManager().getCurrentWindowMetrics();
+            Insets insets = windowMetrics.getWindowInsets()
+                    .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars());
+            heightOfDisplay = windowMetrics.getBounds().height() - insets.top - insets.bottom;
+        } else {
+            DisplayMetrics displayMetrics = new DisplayMetrics();
+            getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+            heightOfDisplay = displayMetrics.heightPixels;
+        }
         int pixelHeight = 0;
         double scaling = 0.45;
         int bottomToTopId;
@@ -366,9 +388,6 @@ public class SetPlayerName extends AppCompatActivity {
         }
     }
 
-    @Override
-    public void onBackPressed() {
-        // no action
-    }
+
 
 }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Share.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Share.java
@@ -3,11 +3,14 @@ package org.alphatilesapps.alphatiles;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
+import android.graphics.Insets;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.View;
 
 import android.graphics.Bitmap;
+import android.view.WindowInsets;
+import android.view.WindowMetrics;
 import android.widget.ImageView;
 
 import com.google.zxing.BarcodeFormat;
@@ -37,9 +40,19 @@ public class Share extends AppCompatActivity {
         String link = scanner.nextLine();
 
         // code taken from Azahar's comment to the question asked here: https://stackoverflow.com/questions/1016896/how-to-get-screen-dimensions-as-pixels-in-android
-        DisplayMetrics displaymetrics = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
-        int screenWidth = displaymetrics.widthPixels;
+        int screenWidth;
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            // API 30+
+            WindowMetrics windowMetrics = getWindowManager().getCurrentWindowMetrics();
+            Insets insets = windowMetrics.getWindowInsets()
+                    .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars());
+            screenWidth = windowMetrics.getBounds().width() - insets.left - insets.right;
+        } else {
+            DisplayMetrics displaymetrics = new DisplayMetrics();
+            getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
+            screenWidth = displaymetrics.widthPixels;
+        }
 
         // code taken from https://stackoverflow.com/a/25283174. Thank you Stefano
         QRCodeWriter writer = new QRCodeWriter();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Start.java
@@ -140,18 +140,13 @@ public class Start extends AppCompatActivity {
             stageCorrespondenceRatio = 0.5;
         }
 
-        // JP: the old constructor is deprecated after API 21, so account for both scenarios
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            AudioAttributes attributes = new AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_GAME)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                    .build();
-            gameSounds = new SoundPool.Builder()
-                    .setAudioAttributes(attributes)
-                    .build();
-        } else {
-            gameSounds = new SoundPool(1, AudioManager.STREAM_MUSIC, 0);
-        }
+        AudioAttributes attributes = new AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_GAME)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .build();
+        gameSounds = new SoundPool.Builder()
+                .setAudioAttributes(attributes)
+                .build();
 
         buildTileList();
         for (int d = 0; d < tileList.size(); d++) {
@@ -1277,7 +1272,7 @@ public class Start extends AppCompatActivity {
         public String colorTitle;
 
         public ArrayList<Syllable> parseWordIntoSyllables(Word refWord) {
-            ArrayList<Syllable> parsedWordArrayTemp = new ArrayList();
+            ArrayList<Syllable> parsedWordArrayTemp = new ArrayList<>();
             String noHashWord = refWord.wordInLOP.replaceAll("[#]", "");
             StringTokenizer st = new StringTokenizer(noHashWord, ".");
             while (st.hasMoreTokens()) {
@@ -1962,7 +1957,7 @@ public class Start extends AppCompatActivity {
 
         public ArrayList<Tile> returnFourTileChoices(Tile correctTile, int challengeLevel, String refTileType) {
 
-            ArrayList<Tile> fourTileChoices = new ArrayList();
+            ArrayList<Tile> fourTileChoices = new ArrayList<>();
             ArrayList<String> alreadyStoredAnswerChoices = new ArrayList<>();
 
             Tile aTile = correctTile;

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.0'
+        classpath 'com.android.tools.build:gradle:8.12.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 28 22:16:22 EDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
VERSION 2.8.0.

# 1
Update Gradle to 8.12.0 (after updating to Android Studio Narwhal Feature Drop | 2025.1.2).

# 2
Update gradle-wrapper.properties to 8.14.3.

# 3
[non-code update]: Update Android SDK and Tools: Android Emulator revision 36.1.9, API 36 ("Baklava"; Android 16.0): Google Play Intel x86_64 Atom System Image revision 7 (auto suggested after Narwhal update).

# 4
Full rewrite of ActivityLayouts.java for edge to edge. Light blue status bar/nav bar on older versions, edge to edge for API 30+. Tested without issues on...
<img width="794" height="270" alt="e2e testing" src="https://github.com/user-attachments/assets/818abc06-e07b-4f64-a69b-6c998c0147f8" />

# 5
Update dependencies in build.gradle, but BACKED OUT FIREBASE DEPENDENCY UPDATE, as it wanted to force API min increase from 21 to 23.

# 6
Update deprecated code for no action on back press in Earth, SetPlayerName, ChoosePlayer and Celebration.

# 7
Update deprecated for HTML text in Resources and About.

# 8
Fixed "unchecked conversions" in ChoosePlayer, GameActivity, LoadingScreen, Mexico and Start.

# 9
Update deprecated code (getDefaultDisplay()) in Ecuador, Myanmar, SetPlayerName and Share.

# 10
Update deprecated Handler code in LoadingScreen, Mexico and Myanmar.

# 11
Update deprecated setColorFilter code in LoadingScreen (for the color status bar).

# 12
Update deprecated code (SoundPool(int,int,int)) in Start. It was mistakenly noted that it was deprecated AFTER API21, but it was deprecated in API21, so we have a a single case to deal with.

# 13
Remove if/then for an API14 case (irrelevant now).