### PR TITLE
Casting 'findViewById(...)' to 'ImageView' is redundant

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/China.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/China.java
@@ -47,7 +47,7 @@ public class China extends GameActivity {
     @Override
     protected void hideInstructionAudioImage() {
 
-        ImageView instructionsButton = (ImageView) findViewById(R.id.instructions);
+        ImageView instructionsButton = findViewById(R.id.instructions);
         instructionsButton.setVisibility(View.GONE);
 
     }
@@ -76,8 +76,8 @@ public class China extends GameActivity {
         ActivityLayouts.setStatusAndNavColors(this);
 
         if (scriptDirection.equals("RTL")) {
-            ImageView instructionsImage = (ImageView) findViewById(R.id.instructions);
-            ImageView repeatImage = (ImageView) findViewById(R.id.repeatImage);
+            ImageView instructionsImage = findViewById(R.id.instructions);
+            ImageView repeatImage = findViewById(R.id.repeatImage);
 
             instructionsImage.setRotationY(180);
             repeatImage.setRotationY(180);


### PR DESCRIPTION
I think this is right