### PR TITLE
Col Pages

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -134,6 +134,11 @@ public class Colombia extends GameActivity {
         ImageView wordImage = (ImageView) findViewById(R.id.wordImage);
         wordImage.setClickable(true);
 
+        if (totalScreens > 1) {
+            keyboardScreenNo = 1;
+            updateKeyboard();
+        }
+
     }
 
     private void setWord() {


### PR DESCRIPTION
After spelling one word and going to the next, the app seems to remember the page last used. E.g. if the final character typed for the first word was on ‘page 2’, and then one starts to type the second word and the first character is on ‘page 1’, then the app still seems to be on ‘page 2’ and even though the player selects a character that is on page 1, the character ‘below’ (on page 2) appears. 

**See corresponding issue for more info.**