### PR TITLE
Level 2 for Italy (Loteria) where challengeLevel = 2, and where the word image is never displayed. 

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -137,6 +137,7 @@ public class Italy extends GameActivity {
         if(!Start.changeArrowColor) {
             playNextWordImage.setImageResource(R.drawable.zz_forward_green);
         }
+
         updatePointsAndTrackers(0);
         playAgain();
     }
@@ -246,6 +247,18 @@ public class Italy extends GameActivity {
         // Shuffle the gameCards again; they will be "called" in order from here on out
         Collections.shuffle(gameCards);
 
+        if (challengeLevel==1) {
+            for (int t = 0; t < 16; t++) {
+                ImageView wordImage = findViewById(WORD_IMAGES[t]);
+                wordImage.setVisibility(View.VISIBLE);
+            }
+        } else if (challengeLevel==2) {
+            for (int t = 0; t < 16; t++) {
+                ImageView wordImage = findViewById(WORD_IMAGES[t]);
+                wordImage.setVisibility(View.INVISIBLE);
+            }
+        }
+
         // Display the first word
         nextWordFromGameSet();
 
@@ -292,6 +305,7 @@ public class Italy extends GameActivity {
 
         ImageView imageJustSelected = findViewById(WORD_IMAGES[indexOfTileJustSelected - 1]);
         imageJustSelected.setImageResource(R.drawable.zz_bean);
+        imageJustSelected.setVisibility(View.VISIBLE);
 
         TextView thisCardText = findViewById(GAME_BUTTONS[indexOfTileJustSelected - 1]);
         thisCardText.setTextColor(Color.BLACK);
@@ -323,6 +337,7 @@ public class Italy extends GameActivity {
                 for (int i = 0; i < sequence.length; i++) {
                     ImageView bean = findViewById(WORD_IMAGES[sequence[i] - 1]);
                     bean.setImageResource(R.drawable.zz_bean_loteria);
+                    bean.setVisibility(View.VISIBLE);
                 }
                 return true;
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -108,6 +108,18 @@ public class Italy extends GameActivity {
             Collections.shuffle(sortableTilesArray);
         }
 
+        if (challengeLevel==1) {
+            for (int t = 0; t < 16; t++) {
+                ImageView wordImage = findViewById(WORD_IMAGES[t]);
+                wordImage.setVisibility(View.VISIBLE);
+            }
+        } else if (challengeLevel==2) {
+            for (int t = 0; t < 16; t++) {
+                ImageView wordImage = findViewById(WORD_IMAGES[t]);
+                wordImage.setVisibility(View.INVISIBLE);
+            }
+        }
+
         // override default deck size setting, if configured
         final String deckSizeSetting = Start.settingsList.find(ITALY_DECK_SIZE);
         if (! deckSizeSetting.isEmpty()) {
@@ -139,6 +151,7 @@ public class Italy extends GameActivity {
         nextWordArrow.setClickable(false);
 
         ImageView referenceItem = findViewById(R.id.referenceItem);
+
         referenceItem.setClickable(false);
 
         for (int t = 0; t < visibleGameButtons; t++) {


### PR DESCRIPTION
Go into aa_games.txt and replace game 77 with "77 Italy 2 1 X naWhileMPOnly T -". Then test game 77. There should be no images above the words.

Fixed bugs where images would stay loaded after the bingo round was over on the tiles that had beans from the previous round

https://github.com/AlphaTiles/AlphaTiles/issues/265