### PR TITLE
Audio choice refactoring anton

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -196,7 +196,7 @@ public class Brazil extends GameActivity {
     }
 
     public void playAgain() {
-        if (isAudioPlaying) {
+        if (mediaPlayerIsPlaying) {
             return;
         }
 
@@ -598,7 +598,7 @@ public class Brazil extends GameActivity {
 
     private void respondToTileSelection(int justClickedButton) {
 
-        if (isAudioPlaying) {
+        if (mediaPlayerIsPlaying) {
             return;
         }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Brazil.java
@@ -196,7 +196,7 @@ public class Brazil extends GameActivity {
     }
 
     public void playAgain() {
-        if (mediaPlayerIsPlaying) {
+        if (isAudioPlaying) {
             return;
         }
 
@@ -598,7 +598,7 @@ public class Brazil extends GameActivity {
 
     private void respondToTileSelection(int justClickedButton) {
 
-        if (mediaPlayerIsPlaying) {
+        if (isAudioPlaying) {
             return;
         }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -590,14 +590,14 @@ public abstract class GameActivity extends AppCompatActivity {
         playActiveWordClip(false);
     }
 
-    protected void playActiveWordClip(final boolean playFinalSound) {
-        //??if (tempSoundPoolSwitch) {
-            playActiveWordClip1(playFinalSound);    //SoundPool
-        //??} else
-        //??   playActiveWordClip0(playFinalSound);    //MediaPlayer
-    }
+//??    protected void playActiveWordClip(final boolean playFinalSound) {
+//        if (tempSoundPoolSwitch) {
+//            playActiveWordClip1(playFinalSound);    //SoundPool
+//        } else
+//            playActiveWordClip0(playFinalSound);    //MediaPlayer
+//    }
 
-    protected void playActiveWordClip1(final boolean playFinalSound) {
+    protected void playActiveWordClip(final boolean playFinalSound) {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
 
@@ -631,30 +631,30 @@ public abstract class GameActivity extends AppCompatActivity {
         }, refWord.duration);
     }
 
-    protected void playActiveWordClip0(final boolean playFinalSound) {
-        setAllGameButtonsUnclickable();
-        setOptionsRowUnclickable();
-        int resID = getResources().getIdentifier(refWord.wordInLWC, "raw", getPackageName());
-        final MediaPlayer mp1 = MediaPlayer.create(this, resID);
-        isAudioPlaying  = true;
-        //mp1.start();
-        mp1.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-            @Override
-            public void onCompletion(MediaPlayer mp1) {
-                mpCompletion(mp1, playFinalSound);
-            }
-        });
-        mp1.start();
-    }
+    //?? protected void playActiveWordClip0(final boolean playFinalSound) {
+//        setAllGameButtonsUnclickable();
+//        setOptionsRowUnclickable();
+//        int resID = getResources().getIdentifier(refWord.wordInLWC, "raw", getPackageName());
+//        final MediaPlayer mp1 = MediaPlayer.create(this, resID);
+//        isAudioPlaying  = true;
+//        //mp1.start();
+//        mp1.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
+//            @Override
+//            public void onCompletion(MediaPlayer mp1) {
+//                mpCompletion(mp1, playFinalSound);
+//            }
+//        });
+//        mp1.start();
+//    }
+
+//    ??protected void playCorrectSoundThenActiveWordClip(final boolean playFinalSound) {
+//        if (tempSoundPoolSwitch)
+//            playCorrectSoundThenActiveWordClip1(playFinalSound);
+//        else
+//        playCorrectSoundThenActiveWordClip0(playFinalSound);
+  //  }
 
     protected void playCorrectSoundThenActiveWordClip(final boolean playFinalSound) {
-        //??if (tempSoundPoolSwitch)
-            playCorrectSoundThenActiveWordClip1(playFinalSound);
-        //??else
-        //??playCorrectSoundThenActiveWordClip0(playFinalSound);
-    }
-
-    protected void playCorrectSoundThenActiveWordClip1(final boolean playFinalSound) {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
 
@@ -678,30 +678,30 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
 
-    protected void playCorrectSoundThenActiveWordClip0(final boolean playFinalSound) {
-        setAllGameButtonsUnclickable();
-        setOptionsRowUnclickable();
-        MediaPlayer mp2 = MediaPlayer.create(this, R.raw.zz_correct);
-        isAudioPlaying  = true;
-        mp2.start();
-        mp2.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-            @Override
-            public void onCompletion(MediaPlayer mp2) {
-                mp2.reset(); //JP: fixed "mediaplayer went away with unhandled events" issue
-                mp2.release();
-                playActiveWordClip(playFinalSound);
-            }
-        });
-    }
+  //??  protected void playCorrectSoundThenActiveWordClip0(final boolean playFinalSound) {
+//        setAllGameButtonsUnclickable();
+//        setOptionsRowUnclickable();
+//        MediaPlayer mp2 = MediaPlayer.create(this, R.raw.zz_correct);
+//        isAudioPlaying  = true;
+//        mp2.start();
+//        mp2.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
+//            @Override
+//            public void onCompletion(MediaPlayer mp2) {
+//                mp2.reset(); //JP: fixed "mediaplayer went away with unhandled events" issue
+//                mp2.release();
+//                playActiveWordClip(playFinalSound);
+//            }
+//        });
+//    }
+
+//?? protected void playIncorrectSound() {
+//        if (tempSoundPoolSwitch)
+//            playIncorrectSound1();
+//        else
+//        playIncorrectSound0();
+//    }
 
     protected void playIncorrectSound() {
-        //??if (tempSoundPoolSwitch)
-            playIncorrectSound1();
-        //??else
-        //??playIncorrectSound0();
-    }
-
-    protected void playIncorrectSound1() {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
         gameSounds.play(incorrectSoundID, 1.0f, 1.0f, 3, 0, 1.0f);
@@ -709,32 +709,32 @@ public abstract class GameActivity extends AppCompatActivity {
         setOptionsRowClickable();
     }
 
-    protected void playIncorrectSound0() {
-        setAllGameButtonsUnclickable();
-        setOptionsRowUnclickable();
-        mp3 = MediaPlayer.create(this, R.raw.zz_incorrect);
-        isAudioPlaying  = true;
-        mp3.start();
-        mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-            @Override
-            public void onCompletion(MediaPlayer mp3) {
-                isAudioPlaying  = false;
-                setAllGameButtonsClickable();
-                setOptionsRowClickable();
-                mp3.reset(); //JP
-                mp3.release();
-            }
-        });
-    }
+//??    protected void playIncorrectSound0() {
+//        setAllGameButtonsUnclickable();
+//        setOptionsRowUnclickable();
+//        mp3 = MediaPlayer.create(this, R.raw.zz_incorrect);
+//        isAudioPlaying  = true;
+//        mp3.start();
+//        mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
+//            @Override
+//            public void onCompletion(MediaPlayer mp3) {
+//                isAudioPlaying  = false;
+//                setAllGameButtonsClickable();
+//                setOptionsRowClickable();
+//                mp3.reset(); //JP
+//                mp3.release();
+//            }
+//        });
+//    }
+
+    //?? protected void playCorrectFinalSound() {
+//        if (tempSoundPoolSwitch)
+//            playCorrectFinalSound1();
+//        else
+//        playCorrectFinalSound0();
+//    }
 
     protected void playCorrectFinalSound() {
-        //??if (tempSoundPoolSwitch)
-            playCorrectFinalSound1();
-        //??else
-        //??playCorrectFinalSound0();
-    }
-
-    protected void playCorrectFinalSound1() {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
         gameSounds.play(correctFinalSoundID, 1.0f, 1.0f, 1, 0, 1.0f);
@@ -750,23 +750,23 @@ public abstract class GameActivity extends AppCompatActivity {
         }
     }
 
-    protected void playCorrectFinalSound0() {
-        setAllGameButtonsUnclickable();
-        setOptionsRowUnclickable();
-        isAudioPlaying  = true;
-        mp3 = MediaPlayer.create(this, R.raw.zz_correct_final);
-        mp3.start();
-        mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-            @Override
-            public void onCompletion(MediaPlayer mp3) {
-                isAudioPlaying  = false;
-                setAllGameButtonsClickable();
-                setOptionsRowClickable();
-                mp3.reset(); //JP
-                mp3.release();
-            }
-        });
-    }
+//??    protected void playCorrectFinalSound0() {
+//        setAllGameButtonsUnclickable();
+//        setOptionsRowUnclickable();
+//        isAudioPlaying  = true;
+//        mp3 = MediaPlayer.create(this, R.raw.zz_correct_final);
+//        mp3.start();
+//        mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
+//            @Override
+//            public void onCompletion(MediaPlayer mp3) {
+//                isAudioPlaying  = false;
+//                setAllGameButtonsClickable();
+//                setOptionsRowClickable();
+//                mp3.reset(); //JP
+//                mp3.release();
+//            }
+//        });
+//    }
 
     public void playAudioInstructions(View view) {
         if (isAudioPlaying ){

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -38,14 +38,12 @@ import static org.alphatilesapps.alphatiles.Start.differentiatesTileTypes;
 import static org.alphatilesapps.alphatiles.Start.gameList;
 import static org.alphatilesapps.alphatiles.Start.stageCorrespondenceRatio;
 import static org.alphatilesapps.alphatiles.Start.tileAudioIDs;
-import static org.alphatilesapps.alphatiles.Start.tileDurations;
 import static org.alphatilesapps.alphatiles.Start.placeholderCharacter;
 import static org.alphatilesapps.alphatiles.Start.tileHashMap;
 import static org.alphatilesapps.alphatiles.Start.tileList;
 import static org.alphatilesapps.alphatiles.Start.tileStagesLists;
 import static org.alphatilesapps.alphatiles.Start.wordList;
 import static org.alphatilesapps.alphatiles.Start.wordStagesLists;
-//??import static org.alphatilesapps.alphatiles.Testing.tempSoundPoolSwitch;
 import static org.alphatilesapps.alphatiles.Start.correctFinalSoundID;
 import static org.alphatilesapps.alphatiles.Start.correctSoundDuration;
 import static org.alphatilesapps.alphatiles.Start.correctSoundID;
@@ -94,7 +92,7 @@ public abstract class GameActivity extends AppCompatActivity {
     Queue<String> lastXWords = new LinkedList<>();  // avoid reusing words too quickly
 
 
-    boolean isAudioPlaying  = false;
+    boolean mediaPlayerIsPlaying = false;
     boolean repeatLocked = true;
     Handler soundSequencer;
 
@@ -226,7 +224,7 @@ public abstract class GameActivity extends AppCompatActivity {
 
     public void goBackToChoosePlayer(View view) {
 
-        if (isAudioPlaying ) {
+        if (mediaPlayerIsPlaying) {
             return;
         }
         startActivity(new Intent(context, ChoosePlayer.class));
@@ -590,13 +588,6 @@ public abstract class GameActivity extends AppCompatActivity {
         playActiveWordClip(false);
     }
 
-//??    protected void playActiveWordClip(final boolean playFinalSound) {
-//        if (tempSoundPoolSwitch) {
-//            playActiveWordClip1(playFinalSound);    //SoundPool
-//        } else
-//            playActiveWordClip0(playFinalSound);    //MediaPlayer
-//    }
-
     protected void playActiveWordClip(final boolean playFinalSound) {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
@@ -631,28 +622,6 @@ public abstract class GameActivity extends AppCompatActivity {
         }, refWord.duration);
     }
 
-    //?? protected void playActiveWordClip0(final boolean playFinalSound) {
-//        setAllGameButtonsUnclickable();
-//        setOptionsRowUnclickable();
-//        int resID = getResources().getIdentifier(refWord.wordInLWC, "raw", getPackageName());
-//        final MediaPlayer mp1 = MediaPlayer.create(this, resID);
-//        isAudioPlaying  = true;
-//        //mp1.start();
-//        mp1.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-//            @Override
-//            public void onCompletion(MediaPlayer mp1) {
-//                mpCompletion(mp1, playFinalSound);
-//            }
-//        });
-//        mp1.start();
-//    }
-
-//    ??protected void playCorrectSoundThenActiveWordClip(final boolean playFinalSound) {
-//        if (tempSoundPoolSwitch)
-//            playCorrectSoundThenActiveWordClip1(playFinalSound);
-//        else
-//        playCorrectSoundThenActiveWordClip0(playFinalSound);
-  //  }
 
     protected void playCorrectSoundThenActiveWordClip(final boolean playFinalSound) {
         setAllGameButtonsUnclickable();
@@ -678,29 +647,6 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
 
-  //??  protected void playCorrectSoundThenActiveWordClip0(final boolean playFinalSound) {
-//        setAllGameButtonsUnclickable();
-//        setOptionsRowUnclickable();
-//        MediaPlayer mp2 = MediaPlayer.create(this, R.raw.zz_correct);
-//        isAudioPlaying  = true;
-//        mp2.start();
-//        mp2.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-//            @Override
-//            public void onCompletion(MediaPlayer mp2) {
-//                mp2.reset(); //JP: fixed "mediaplayer went away with unhandled events" issue
-//                mp2.release();
-//                playActiveWordClip(playFinalSound);
-//            }
-//        });
-//    }
-
-//?? protected void playIncorrectSound() {
-//        if (tempSoundPoolSwitch)
-//            playIncorrectSound1();
-//        else
-//        playIncorrectSound0();
-//    }
-
     protected void playIncorrectSound() {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
@@ -709,30 +655,6 @@ public abstract class GameActivity extends AppCompatActivity {
         setOptionsRowClickable();
     }
 
-//??    protected void playIncorrectSound0() {
-//        setAllGameButtonsUnclickable();
-//        setOptionsRowUnclickable();
-//        mp3 = MediaPlayer.create(this, R.raw.zz_incorrect);
-//        isAudioPlaying  = true;
-//        mp3.start();
-//        mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-//            @Override
-//            public void onCompletion(MediaPlayer mp3) {
-//                isAudioPlaying  = false;
-//                setAllGameButtonsClickable();
-//                setOptionsRowClickable();
-//                mp3.reset(); //JP
-//                mp3.release();
-//            }
-//        });
-//    }
-
-    //?? protected void playCorrectFinalSound() {
-//        if (tempSoundPoolSwitch)
-//            playCorrectFinalSound1();
-//        else
-//        playCorrectFinalSound0();
-//    }
 
     protected void playCorrectFinalSound() {
         setAllGameButtonsUnclickable();
@@ -750,42 +672,25 @@ public abstract class GameActivity extends AppCompatActivity {
         }
     }
 
-//??    protected void playCorrectFinalSound0() {
-//        setAllGameButtonsUnclickable();
-//        setOptionsRowUnclickable();
-//        isAudioPlaying  = true;
-//        mp3 = MediaPlayer.create(this, R.raw.zz_correct_final);
-//        mp3.start();
-//        mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-//            @Override
-//            public void onCompletion(MediaPlayer mp3) {
-//                isAudioPlaying  = false;
-//                setAllGameButtonsClickable();
-//                setOptionsRowClickable();
-//                mp3.reset(); //JP
-//                mp3.release();
-//            }
-//        });
-//    }
 
     public void playAudioInstructions(View view) {
-        if (isAudioPlaying ){
+        if (mediaPlayerIsPlaying){
             mp3.stop();
             mp3.release();
-            isAudioPlaying  = false;
+            mediaPlayerIsPlaying = false;
             setAllGameButtonsClickable();
             setOptionsRowClickable();
             return;
         }
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
-        isAudioPlaying  = true;
+        mediaPlayerIsPlaying = true;
         mp3 = MediaPlayer.create(this, getAudioInstructionsResID());
         mp3.start();
         mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mp3) {
-                isAudioPlaying  = false;
+                mediaPlayerIsPlaying = false;
                 setAllGameButtonsClickable();
                 setOptionsRowClickable();
                 mp3.release();
@@ -801,15 +706,12 @@ public abstract class GameActivity extends AppCompatActivity {
 
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
-        //??if(!tempSoundPoolSwitch) {
-            playTileAudio(playFinalSound, tileAudioNumber(tile), -1);
-        //??} else {
-        //??playTileAudio(playFinalSound, tileAudioNumber(tile), tileDurations.get(tile.audioForThisTileType));
-        //??}
+        playTileAudio(playFinalSound, tileAudioNumber(tile), -1);
+
     }
 
     protected boolean isReadyToPlayTileAudio() {
-        if(isAudioPlaying ) {
+        if(mediaPlayerIsPlaying) {
             return false;
         }
 
@@ -818,46 +720,26 @@ public abstract class GameActivity extends AppCompatActivity {
 
     protected boolean tileShouldPlayAudio(Start.Tile tile) {
         // make sure audio can be found
-        if (/**??tempSoundPoolSwitch && */tile.audioForThisTileType.equals("X")) {
+        if (tile.audioForThisTileType.equals("X")) {
                 return false;
         }
-
-        //??if(!tempSoundPoolSwitch) {
-//            try{
-//                getResources().getIdentifier(tile.audioForThisTileType, "raw", getPackageName());
-//            } catch (NullPointerException e) {
-//                 return false;
-//            }
-//        }
-
         return true;
     }
 
     protected int tileAudioNumber(Start.Tile tile) {
         String audioName = tile.getAudioNameAccountingForMultitypeSymbols();
-        //??if (tempSoundPoolSwitch) {
             return tileAudioIDs.get(audioName);
-        //??} else {
-        //??return getResources().getIdentifier(audioName, "raw", getPackageName());
-        //?? }
     }
 
     protected void playTileAudio(boolean playFinalSound, int audioNumber, int audioDuration) {
-        //??if (tempSoundPoolSwitch) {
             playTileAudioSoundPool(playFinalSound, audioNumber,audioDuration);
-        //??} else {
-        //?? playTileAudioMediaPlayer(playFinalSound, audioNumber);
-        //??}
     }
-
-
-
 
 
     private void playTileAudioMediaPlayer(final boolean playFinalSound, int resID) {     //JP: for Media Player; tile audio
 
         final MediaPlayer mp1 = MediaPlayer.create(this, resID);
-        isAudioPlaying  = true;
+        mediaPlayerIsPlaying = true;
         mp1.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mp1) {
@@ -900,7 +782,7 @@ public abstract class GameActivity extends AppCompatActivity {
             repeatLocked = false;
             playCorrectFinalSound();
         } else {
-            isAudioPlaying  = false;
+            mediaPlayerIsPlaying = false;
             if (repeatLocked) {
                 setAllGameButtonsClickable();
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -45,7 +45,7 @@ import static org.alphatilesapps.alphatiles.Start.tileList;
 import static org.alphatilesapps.alphatiles.Start.tileStagesLists;
 import static org.alphatilesapps.alphatiles.Start.wordList;
 import static org.alphatilesapps.alphatiles.Start.wordStagesLists;
-import static org.alphatilesapps.alphatiles.Testing.tempSoundPoolSwitch;
+//??import static org.alphatilesapps.alphatiles.Testing.tempSoundPoolSwitch;
 import static org.alphatilesapps.alphatiles.Start.correctFinalSoundID;
 import static org.alphatilesapps.alphatiles.Start.correctSoundDuration;
 import static org.alphatilesapps.alphatiles.Start.correctSoundID;
@@ -94,7 +94,7 @@ public abstract class GameActivity extends AppCompatActivity {
     Queue<String> lastXWords = new LinkedList<>();  // avoid reusing words too quickly
 
 
-    boolean mediaPlayerIsPlaying = false;
+    boolean isAudioPlaying  = false;
     boolean repeatLocked = true;
     Handler soundSequencer;
 
@@ -226,7 +226,7 @@ public abstract class GameActivity extends AppCompatActivity {
 
     public void goBackToChoosePlayer(View view) {
 
-        if (mediaPlayerIsPlaying) {
+        if (isAudioPlaying ) {
             return;
         }
         startActivity(new Intent(context, ChoosePlayer.class));
@@ -591,10 +591,10 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     protected void playActiveWordClip(final boolean playFinalSound) {
-        if (tempSoundPoolSwitch) {
+        //??if (tempSoundPoolSwitch) {
             playActiveWordClip1(playFinalSound);    //SoundPool
-        } else
-            playActiveWordClip0(playFinalSound);    //MediaPlayer
+        //??} else
+        //??   playActiveWordClip0(playFinalSound);    //MediaPlayer
     }
 
     protected void playActiveWordClip1(final boolean playFinalSound) {
@@ -636,7 +636,7 @@ public abstract class GameActivity extends AppCompatActivity {
         setOptionsRowUnclickable();
         int resID = getResources().getIdentifier(refWord.wordInLWC, "raw", getPackageName());
         final MediaPlayer mp1 = MediaPlayer.create(this, resID);
-        mediaPlayerIsPlaying = true;
+        isAudioPlaying  = true;
         //mp1.start();
         mp1.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
@@ -648,10 +648,10 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     protected void playCorrectSoundThenActiveWordClip(final boolean playFinalSound) {
-        if (tempSoundPoolSwitch)
+        //??if (tempSoundPoolSwitch)
             playCorrectSoundThenActiveWordClip1(playFinalSound);
-        else
-            playCorrectSoundThenActiveWordClip0(playFinalSound);
+        //??else
+        //??playCorrectSoundThenActiveWordClip0(playFinalSound);
     }
 
     protected void playCorrectSoundThenActiveWordClip1(final boolean playFinalSound) {
@@ -682,7 +682,7 @@ public abstract class GameActivity extends AppCompatActivity {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
         MediaPlayer mp2 = MediaPlayer.create(this, R.raw.zz_correct);
-        mediaPlayerIsPlaying = true;
+        isAudioPlaying  = true;
         mp2.start();
         mp2.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
@@ -695,10 +695,10 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     protected void playIncorrectSound() {
-        if (tempSoundPoolSwitch)
+        //??if (tempSoundPoolSwitch)
             playIncorrectSound1();
-        else
-            playIncorrectSound0();
+        //??else
+        //??playIncorrectSound0();
     }
 
     protected void playIncorrectSound1() {
@@ -713,12 +713,12 @@ public abstract class GameActivity extends AppCompatActivity {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
         mp3 = MediaPlayer.create(this, R.raw.zz_incorrect);
-        mediaPlayerIsPlaying = true;
+        isAudioPlaying  = true;
         mp3.start();
         mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mp3) {
-                mediaPlayerIsPlaying = false;
+                isAudioPlaying  = false;
                 setAllGameButtonsClickable();
                 setOptionsRowClickable();
                 mp3.reset(); //JP
@@ -728,10 +728,10 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     protected void playCorrectFinalSound() {
-        if (tempSoundPoolSwitch)
+        //??if (tempSoundPoolSwitch)
             playCorrectFinalSound1();
-        else
-            playCorrectFinalSound0();
+        //??else
+        //??playCorrectFinalSound0();
     }
 
     protected void playCorrectFinalSound1() {
@@ -753,13 +753,13 @@ public abstract class GameActivity extends AppCompatActivity {
     protected void playCorrectFinalSound0() {
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
-        mediaPlayerIsPlaying = true;
+        isAudioPlaying  = true;
         mp3 = MediaPlayer.create(this, R.raw.zz_correct_final);
         mp3.start();
         mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mp3) {
-                mediaPlayerIsPlaying = false;
+                isAudioPlaying  = false;
                 setAllGameButtonsClickable();
                 setOptionsRowClickable();
                 mp3.reset(); //JP
@@ -769,23 +769,23 @@ public abstract class GameActivity extends AppCompatActivity {
     }
 
     public void playAudioInstructions(View view) {
-        if (mediaPlayerIsPlaying){
+        if (isAudioPlaying ){
             mp3.stop();
             mp3.release();
-            mediaPlayerIsPlaying = false;
+            isAudioPlaying  = false;
             setAllGameButtonsClickable();
             setOptionsRowClickable();
             return;
         }
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
-        mediaPlayerIsPlaying = true;
+        isAudioPlaying  = true;
         mp3 = MediaPlayer.create(this, getAudioInstructionsResID());
         mp3.start();
         mp3.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mp3) {
-                mediaPlayerIsPlaying = false;
+                isAudioPlaying  = false;
                 setAllGameButtonsClickable();
                 setOptionsRowClickable();
                 mp3.release();
@@ -801,15 +801,15 @@ public abstract class GameActivity extends AppCompatActivity {
 
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
-        if(!tempSoundPoolSwitch) {
+        //??if(!tempSoundPoolSwitch) {
             playTileAudio(playFinalSound, tileAudioNumber(tile), -1);
-        } else {
-            playTileAudio(playFinalSound, tileAudioNumber(tile), tileDurations.get(tile.audioForThisTileType));
-        }
+        //??} else {
+        //??playTileAudio(playFinalSound, tileAudioNumber(tile), tileDurations.get(tile.audioForThisTileType));
+        //??}
     }
 
     protected boolean isReadyToPlayTileAudio() {
-        if(mediaPlayerIsPlaying) {
+        if(isAudioPlaying ) {
             return false;
         }
 
@@ -818,36 +818,36 @@ public abstract class GameActivity extends AppCompatActivity {
 
     protected boolean tileShouldPlayAudio(Start.Tile tile) {
         // make sure audio can be found
-        if (tempSoundPoolSwitch && tile.audioForThisTileType.equals("X")) {
+        if (/**??tempSoundPoolSwitch && */tile.audioForThisTileType.equals("X")) {
                 return false;
         }
 
-        if(!tempSoundPoolSwitch) {
-            try{
-                getResources().getIdentifier(tile.audioForThisTileType, "raw", getPackageName());
-            } catch (NullPointerException e) {
-                 return false;
-            }
-        }
+        //??if(!tempSoundPoolSwitch) {
+//            try{
+//                getResources().getIdentifier(tile.audioForThisTileType, "raw", getPackageName());
+//            } catch (NullPointerException e) {
+//                 return false;
+//            }
+//        }
 
         return true;
     }
 
     protected int tileAudioNumber(Start.Tile tile) {
         String audioName = tile.getAudioNameAccountingForMultitypeSymbols();
-        if (tempSoundPoolSwitch) {
+        //??if (tempSoundPoolSwitch) {
             return tileAudioIDs.get(audioName);
-        } else {
-            return getResources().getIdentifier(audioName, "raw", getPackageName());
-        }
+        //??} else {
+        //??return getResources().getIdentifier(audioName, "raw", getPackageName());
+        //?? }
     }
 
     protected void playTileAudio(boolean playFinalSound, int audioNumber, int audioDuration) {
-        if (tempSoundPoolSwitch) {
+        //??if (tempSoundPoolSwitch) {
             playTileAudioSoundPool(playFinalSound, audioNumber,audioDuration);
-        } else {
-            playTileAudioMediaPlayer(playFinalSound, audioNumber);
-        }
+        //??} else {
+        //?? playTileAudioMediaPlayer(playFinalSound, audioNumber);
+        //??}
     }
 
 
@@ -857,7 +857,7 @@ public abstract class GameActivity extends AppCompatActivity {
     private void playTileAudioMediaPlayer(final boolean playFinalSound, int resID) {     //JP: for Media Player; tile audio
 
         final MediaPlayer mp1 = MediaPlayer.create(this, resID);
-        mediaPlayerIsPlaying = true;
+        isAudioPlaying  = true;
         mp1.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mp1) {
@@ -900,7 +900,7 @@ public abstract class GameActivity extends AppCompatActivity {
             repeatLocked = false;
             playCorrectFinalSound();
         } else {
-            mediaPlayerIsPlaying = false;
+            isAudioPlaying  = false;
             if (repeatLocked) {
                 setAllGameButtonsClickable();
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/GameActivity.java
@@ -38,6 +38,7 @@ import static org.alphatilesapps.alphatiles.Start.differentiatesTileTypes;
 import static org.alphatilesapps.alphatiles.Start.gameList;
 import static org.alphatilesapps.alphatiles.Start.stageCorrespondenceRatio;
 import static org.alphatilesapps.alphatiles.Start.tileAudioIDs;
+import static org.alphatilesapps.alphatiles.Start.tileDurations;
 import static org.alphatilesapps.alphatiles.Start.placeholderCharacter;
 import static org.alphatilesapps.alphatiles.Start.tileHashMap;
 import static org.alphatilesapps.alphatiles.Start.tileList;

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Testing.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Testing.java
@@ -1,6 +1,0 @@
-package org.alphatilesapps.alphatiles;
-
-public class Testing {
-    public static boolean tempSoundPoolSwitch = true;    // true for SoundPool, false for MediaPlayer
-
-}

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -16,7 +16,6 @@ import com.segment.analytics.Properties;
 
 import static android.graphics.Color.WHITE;
 import static org.alphatilesapps.alphatiles.Start.*;
-import static org.alphatilesapps.alphatiles.Testing.tempSoundPoolSwitch;
 
 public class Thailand extends GameActivity {
     ArrayList<Start.Word> fourWordChoices = new ArrayList<>();
@@ -754,15 +753,8 @@ public class Thailand extends GameActivity {
         }, correctSoundDuration);
     }
 
-    public void playCorrectSoundThenActiveTileClip(final boolean playFinalSound) {
-        if (tempSoundPoolSwitch) {
-            playCorrectSoundThenActiveTileClip1(playFinalSound); //SoundPool
-        } else {
-            playCorrectSoundThenActiveTileClip0(playFinalSound); //MediaPlayer
-        }
-    }
 
-    public void playCorrectSoundThenActiveTileClip1(final boolean playFinalSound) { //JP: Specifically for TILE audio. playCorrectSoundThenActiveWordClip is for WORDS
+    public void playCorrectSoundThenActiveTileClip(final boolean playFinalSound) { //JP: Specifically for TILE audio. playCorrectSoundThenActiveWordClip is for WORDS
         setAllGameButtonsUnclickable();
         setOptionsRowUnclickable();
 
@@ -787,19 +779,6 @@ public class Thailand extends GameActivity {
         }, correctSoundDuration);
     }
 
-    public void playCorrectSoundThenActiveTileClip0(final boolean playFinalSound) { // Media player
-        MediaPlayer mp2 = MediaPlayer.create(this, R.raw.zz_correct);
-        mediaPlayerIsPlaying = true;
-        mp2.start();
-        mp2.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-            @Override
-            public void onCompletion(MediaPlayer mp2) {
-                mp2.reset(); //JP: This fixes "mediaplayer went away with unhandled events" issue
-                mp2.release();
-                playActiveTileClip(playFinalSound);
-            }
-        });
-    }
 
     public void clickPicHearAudio(View view) {
         super.clickPicHearAudio(view);


### PR DESCRIPTION
**Editing Audio Player Boolean**

Issue: 
#282 

Summary of SoundPool vs MediaPlayer:
MediaPlayer better for long sounds (instructions)
SoundPool better for short sounds (everything else)

**The way it was:**
SoundPool vs MediaPlayer:
The app used a boolean to determine whether to use SoundPool or MediaPlayer for short sounds. 
To play a sound, the code used a sound method (e.g. playActiveWordClip) that’s sole purpose was to check the boolean and call one of two other methods, (e.g. playActiveWordClip1 or playActiveWordClip0) based on the boolean. 
In practice, the boolean was set to true, so the method associated with SoundPool was always used. 
Files affected: **GameActivity** (contains most of the sound logic), **Thailand** (has some of its own sound logic), and **Testing**.java (had the boolean).

**What I did:** 
Refactored the code so it directly calls each Sound method associated with SoundPool, and deleted the corresponding boolean checking method and the method associated with MediaPlayer, which were redundant. 
Deleted Testing.java, whose sole purpose was to store the SoundPool vs MediaPlayer boolean. 
Removed the Boolean from the code. Wherever there was a check before, now SoundPool is automatically played.

**How it is now:**
SoundPool is automatically used for short sounds. This is functionally the same as before, but without the unnecessary boolean logic. 
MediaPlayer is still hardcoded for instructions, just like before. 
