### PR TITLE
Fix Colombia (spell from memory) keyboard bug

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -134,6 +134,11 @@ public class Colombia extends GameActivity {
         ImageView wordImage = (ImageView) findViewById(R.id.wordImage);
         wordImage.setClickable(true);
 
+        if (totalScreens > 1) {
+            keyboardScreenNo = 1;
+            updateKeyboard();
+        }
+
     }
 
     private void setWord() {


### PR DESCRIPTION
After spelling one word and going to the next, the app remembers the page last used. E.g. if the final character typed for the round one word was on ‘page 2’, and then in the next round one starts to type the new word and the first character is on ‘page 1’, the app uses ‘page 2’ key values even though the player sees page 1 keys.