### PR TITLE
Loteria level 2 samuel

### DIFF
--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -137,6 +137,7 @@ public class Italy extends GameActivity {
         if(!Start.changeArrowColor) {
             playNextWordImage.setImageResource(R.drawable.zz_forward_green);
         }
+
         updatePointsAndTrackers(0);
         playAgain();
     }
@@ -246,6 +247,18 @@ public class Italy extends GameActivity {
         // Shuffle the gameCards again; they will be "called" in order from here on out
         Collections.shuffle(gameCards);
 
+        if (challengeLevel==1) {
+            for (int t = 0; t < 16; t++) {
+                ImageView wordImage = findViewById(WORD_IMAGES[t]);
+                wordImage.setVisibility(View.VISIBLE);
+            }
+        } else if (challengeLevel==2) {
+            for (int t = 0; t < 16; t++) {
+                ImageView wordImage = findViewById(WORD_IMAGES[t]);
+                wordImage.setVisibility(View.INVISIBLE);
+            }
+        }
+
         // Display the first word
         nextWordFromGameSet();
 
@@ -292,6 +305,7 @@ public class Italy extends GameActivity {
 
         ImageView imageJustSelected = findViewById(WORD_IMAGES[indexOfTileJustSelected - 1]);
         imageJustSelected.setImageResource(R.drawable.zz_bean);
+        imageJustSelected.setVisibility(View.VISIBLE);
 
         TextView thisCardText = findViewById(GAME_BUTTONS[indexOfTileJustSelected - 1]);
         thisCardText.setTextColor(Color.BLACK);
@@ -323,6 +337,7 @@ public class Italy extends GameActivity {
                 for (int i = 0; i < sequence.length; i++) {
                     ImageView bean = findViewById(WORD_IMAGES[sequence[i] - 1]);
                     bean.setImageResource(R.drawable.zz_bean_loteria);
+                    bean.setVisibility(View.VISIBLE);
                 }
                 return true;
             }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -259,6 +259,8 @@ public class Italy extends GameActivity {
             }
         }
 
+        setAllGameButtonsClickable();
+
         // Display the first word
         nextWordFromGameSet();
 
@@ -339,6 +341,7 @@ public class Italy extends GameActivity {
                     bean.setImageResource(R.drawable.zz_bean_loteria);
                     bean.setVisibility(View.VISIBLE);
                 }
+
                 return true;
             }
         }
@@ -347,6 +350,7 @@ public class Italy extends GameActivity {
     }
 
     public void respondToLoteria() {
+        setAllGameButtonsUnclickable();
         setAdvanceArrowToBlue();
         playCorrectSoundThenActiveWordClip(true);
         updatePointsAndTrackers(4);

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -108,6 +108,18 @@ public class Italy extends GameActivity {
             Collections.shuffle(sortableTilesArray);
         }
 
+        if (challengeLevel==1) {
+            for (int t = 0; t < 16; t++) {
+                ImageView wordImage = findViewById(WORD_IMAGES[t]);
+                wordImage.setVisibility(View.VISIBLE);
+            }
+        } else if (challengeLevel==2) {
+            for (int t = 0; t < 16; t++) {
+                ImageView wordImage = findViewById(WORD_IMAGES[t]);
+                wordImage.setVisibility(View.INVISIBLE);
+            }
+        }
+
         // override default deck size setting, if configured
         final String deckSizeSetting = Start.settingsList.find(ITALY_DECK_SIZE);
         if (! deckSizeSetting.isEmpty()) {
@@ -139,6 +151,7 @@ public class Italy extends GameActivity {
         nextWordArrow.setClickable(false);
 
         ImageView referenceItem = findViewById(R.id.referenceItem);
+
         referenceItem.setClickable(false);
 
         for (int t = 0; t < visibleGameButtons; t++) {

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -294,7 +294,9 @@ public class Italy extends GameActivity {
 
         TextView tileJustSelected = findViewById(GAME_BUTTONS[indexOfTileJustSelected - 1]);
 
-        if (tileJustSelected.getText().equals(wordList.stripInstructionCharacters(refWord.wordInLOP))) {
+        if (boardCardsFound[indexOfTileJustSelected - 1]) {
+            respondToIncorrectSelection();
+        } else if (tileJustSelected.getText().equals(wordList.stripInstructionCharacters(refWord.wordInLOP))) {
             respondToCorrectSelection(indexOfTileJustSelected);
         } else {
             respondToIncorrectSelection();
@@ -354,6 +356,11 @@ public class Italy extends GameActivity {
         setAdvanceArrowToBlue();
         playCorrectSoundThenActiveWordClip(true);
         updatePointsAndTrackers(4);
+
+        ImageView nextWordArrow = findViewById(R.id.playNextWord);
+        nextWordArrow.setImageResource(R.drawable.zz_forward_inactive);
+        nextWordArrow.setClickable(false);
+        nextWordArrow.setVisibility(View.INVISIBLE);
 
         // TODO: Draw a thin/transparent line across the loteria?
     }

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Italy.java
@@ -259,6 +259,11 @@ public class Italy extends GameActivity {
             }
         }
 
+        ImageView nextWordArrow = findViewById(R.id.playNextWord);
+        nextWordArrow.setImageResource(R.drawable.zz_forward_inactive);
+        nextWordArrow.setClickable(true);
+        nextWordArrow.setVisibility(View.VISIBLE);
+
         setAllGameButtonsClickable();
 
         // Display the first word


### PR DESCRIPTION
Italy (Loteria): Add Second Level and Fix Bugs
There is now a Challenge Level 2 where the text appears without the image. A bug has also been fixed where a player can repeatedly tap on the text/image that just completed the loteria and keep “winning” the round and gaining points.