### PR TITLE
Fix Colombia CL1/2 and Thailand Block 03 bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId = "org.alphatilesapps.alphatiles"
         minSdk = 23
         targetSdk = 36
-        versionCode = 320
-        versionName = "3.0.8"
+        versionCode = 321
+        versionName = "3.0.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Colombia.java
@@ -103,6 +103,7 @@ public class Colombia extends GameActivity {
             hideInstructionAudioImage();
         }
 
+        totalScreens = 1;
         keyboardScreenNo = 1;
         updatePointsAndTrackers(0);
         playAgain();

--- a/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
+++ b/app/src/main/java/org/alphatilesapps/alphatiles/Thailand.java
@@ -192,6 +192,7 @@ public class Thailand extends GameActivity {
                 int freshChecks = 0;
                 while (!freshTile) {
                     chooseWord();
+                    freshChecks++;
                     parsedRefWordTileArray = tileList.parseWordIntoTiles(refWord.wordInLOP, refWord);
                     refTile = firstAudibleTile(refWord);
                     refString = refTile.text;


### PR DESCRIPTION
Fix Colombia CL1/2 bug resulting from yesterday's CL3 fix and add mis…sing freshChecks++ to Block 03 of Thailand.

Yesterday's #308 Colombia fix rewrote some if/then statements in (intended to be) equivalent fashion, but the new variable (totalScreens) was never defined for CL1/CL2, leading to totalScreens=0 when total Screens=1 was expected.

Block 3 of Thailand (word to word matching) was missing a freshChecks++ line.